### PR TITLE
Check for None before accessing transaction settings

### DIFF
--- a/newrelic/api/cat_header_mixin.py
+++ b/newrelic/api/cat_header_mixin.py
@@ -76,7 +76,7 @@ class CatHeaderMixin(object):
 
         """
 
-        if transaction is None:
+        if transaction is None or transaction.enabled is False:
             return []
 
         settings = transaction.settings

--- a/newrelic/api/cat_header_mixin.py
+++ b/newrelic/api/cat_header_mixin.py
@@ -76,7 +76,7 @@ class CatHeaderMixin(object):
 
         """
 
-        if transaction is None or transaction.enabled is False:
+        if transaction is None or transaction.settings is None:
             return []
 
         settings = transaction.settings


### PR DESCRIPTION
# Overview
This issue happened with Tornado. Within async POST handler, if we finish the request with self.finish() before using AsyncHttp client for making a http request, the transaction is 'exited' with settings set to None. But we land up in generate_request_headers with 'transaction' not set to None but transaction.settings None, leading to exception:

```
Traceback (most recent call last):
  File "/home/ketan/repo/iot/newrelic/iot-data-manager/services/common/asynchttp.py", line 24, in fetch
    async_http_response = await http_client.fetch(url)
  File "/home/ketan/.local/lib/python3.6/site-packages/newrelic/hooks/framework_tornado.py", line 284, in wrap_httpclient_fetch
    outgoing_headers = trace.generate_request_headers(current_transaction())
  File "/home/ketan/.local/lib/python3.6/site-packages/newrelic/api/cat_header_mixin.py", line 92, in generate_request_headers
    if settings.distributed_tracing.enabled:
AttributeError: 'NoneType' object has no attribute 'distributed_tracing'
```

Added check for `transaction.settings`.

# Related Github Issue
https://github.com/newrelic/newrelic-python-agent/issues/19

# Testing
Tested this change with Tornado.
