### PR TITLE
Use is_alive in place of deprecated isAlive

### DIFF
--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -691,7 +691,7 @@ class Agent(object):
 
             # Skip this if background thread already running.
 
-            if self._harvest_thread.isAlive():
+            if self._harvest_thread.is_alive():
                 return
 
             _logger.debug('Activating agent instance.')


### PR DESCRIPTION
threading.Thread.isAlive() is removed in python3.9

> The isAlive() method of threading.Thread has been removed. It was deprecated since Python 3.8. Use is_alive() instead. (Contributed by Dong-hee Na in bpo-37804.)

https://docs.python.org/3.9/whatsnew/3.9.html#removed