### PR TITLE
Fix DeprecationWarning in import_hook

### DIFF
--- a/tests/agent_unittests/test_import_hook.py
+++ b/tests/agent_unittests/test_import_hook.py
@@ -1,0 +1,43 @@
+from pytest import raises
+
+
+def test_import_hook_finder():
+    """
+    This asserts the behavior of ImportHookFinder.find_module. It behaves
+    differently depending on whether or not the module it is looking for
+    exists, has been registered with an import hook, and across different
+    python versions.
+    """
+    from newrelic.api.import_hook import ImportHookFinder, register_import_hook
+    import sys
+
+    PY2 = sys.version_info[0] == 2
+
+    finder = ImportHookFinder()
+
+    # a dummy hook just to be able to register hooks for modules
+    def hook(*args, **kwargs):
+        pass
+
+    # Finding a module that does not exist and is not registered returns None.
+    module = finder.find_module('some_module_that_does_not_exist')
+    assert module is None
+
+    # Finding a module that does not exist and is registered behaves
+    # differently on python 2 vs python 3.
+    register_import_hook('some_module_that_does_not_exist', hook)
+    if PY2:
+        with raises(ImportError):
+            module = finder.find_module('some_module_that_does_not_exist')
+    else:
+        module = finder.find_module('some_module_that_does_not_exist')
+        assert module is None
+
+    # Finding a module that exists, but is not registered returns None.
+    module = finder.find_module('newrelic')
+    assert module is None
+
+    # Finding a module that exists, and is registered, finds that module.
+    register_import_hook('newrelic', hook)
+    module = finder.find_module('newrelic')
+    assert module is not None


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview

For Python >=3.4, using find_loader is deprecated, and importing it
generates a DeprecationWarning. Mirroring wrapt's implementation of a
similar construct in its importer.py (on which this code seems modeled),
we can try to use the new find_spec first,  then the old python 2.7
fallback, as before. Since the newrelic python agent only supports 2.7+
and 3.5+, there is no need to keep support for the deprecated
find_loader at all.

The immediate result of this change is that one less DeprecationWarning
is fired at runtime when using the newrelic python agent. There are
still other DeprecationWarnings originating in this file that are not
fixed by this commit.

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.