### PR TITLE
PYTHON-3826: Adding fastapi tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,12 @@ jobs:
 
     strategy:
       matrix:
-        test-directory: [agent_features, agent_streaming, agent_unittests, framework_starlette]
+        test-directory: 
+          - agent_features
+          - agent_streaming
+          - agent_unittests
+          - framework_fastapi
+          - framework_starlette
 
     runs-on: ubuntu-latest
 

--- a/tests/framework_fastapi/_target_application.py
+++ b/tests/framework_fastapi/_target_application.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+from testing_support.asgi_testing import AsgiTest
+from newrelic.api.transaction import current_transaction
+
+app = FastAPI()
+
+
+@app.get("/sync")
+def sync():
+    assert current_transaction() is not None
+    return {}
+
+
+@app.get("/async")
+async def non_sync():
+    assert current_transaction() is not None
+    return {}
+
+
+target_application = AsgiTest(app)

--- a/tests/framework_fastapi/conftest.py
+++ b/tests/framework_fastapi/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.hooks.framework_fastapi',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True,
+    'debug.log_autorum_middleware': True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (framework_fastapi)',
+        default_settings=_default_settings)
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass
+
+
+@pytest.fixture(scope="session")
+def app():
+    import _target_application
+
+    return _target_application.target_application

--- a/tests/framework_fastapi/test_application.py
+++ b/tests/framework_fastapi/test_application.py
@@ -1,0 +1,16 @@
+import pytest
+from testing_support.fixtures import validate_transaction_metrics
+
+
+@pytest.mark.parametrize("endpoint,transaction_name", (
+    ("/sync", "_target_application:sync"),
+    ("/async", "_target_application:non_sync"),
+))
+def test_application(app, endpoint, transaction_name):
+    @validate_transaction_metrics(transaction_name,
+        scoped_metrics=[("Function/" + transaction_name, 1)])
+    def _test():
+        response = app.get(endpoint)
+        assert response.status == 200
+
+    _test()

--- a/tests/framework_fastapi/tox.ini
+++ b/tests/framework_fastapi/tox.ini
@@ -13,6 +13,11 @@ setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
 
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
+
 commands = py.test -v []
 
 install_command=

--- a/tests/framework_fastapi/tox.ini
+++ b/tests/framework_fastapi/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist = py36,py37,py38
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    fastapi
+
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}


### PR DESCRIPTION
Sidekick: @umaannamalai 

# Overview
Describe the changes present in the pull request
* Import fastapi tests to public repo.
* Consolidates fastapi tests to run only with C extensions.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
