### PR TITLE
PYTHON-3777 Celery Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - agent_features
           - agent_streaming
           - agent_unittests
+          - application_celery
           - framework_fastapi
           - framework_starlette
 

--- a/tests/application_celery/conftest.py
+++ b/tests/application_celery/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.hooks.application_celery',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (application_celery)',
+        default_settings=_default_settings)
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/application_celery/tasks.py
+++ b/tests/application_celery/tasks.py
@@ -1,0 +1,12 @@
+from celery import Celery
+
+
+app = Celery('tasks')
+
+@app.task
+def add(x, y):
+    return x + y
+
+@app.task
+def tsum(nums):
+    return sum(nums)

--- a/tests/application_celery/test_celery.py
+++ b/tests/application_celery/test_celery.py
@@ -1,0 +1,86 @@
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import ignore_transaction, end_of_transaction
+
+from testing_support.fixtures import validate_transaction_metrics
+
+from tasks import add, tsum
+
+@validate_transaction_metrics(
+        name='test_celery:test_celery_task_as_function_trace',
+        scoped_metrics=[('Function/tasks:add.__call__', 1)],
+        background_task=True)
+@background_task()
+def test_celery_task_as_function_trace():
+    """
+    Calling add() inside a transaction means the agent will record
+    add() as a FunctionTrace.
+
+    """
+    result = add(3, 4)
+    assert result == 7
+
+
+@validate_transaction_metrics(
+        name='tasks.add',
+        group='Celery',
+        scoped_metrics=[],
+        background_task=True)
+def test_celery_task_as_background_task():
+    """
+    Calling add() outside of a transaction means the agent will create
+    a background transaction (with a group of 'Celery') and record add()
+    as a background task.
+
+    """
+    result = add(3, 4)
+    assert result == 7
+
+@validate_transaction_metrics(
+        name='test_celery:test_celery_tasks_multiple_function_traces',
+        scoped_metrics=[('Function/tasks:add.__call__', 1),
+                        ('Function/tasks:tsum.__call__', 1)],
+        background_task=True)
+@background_task()
+def test_celery_tasks_multiple_function_traces():
+    add_result = add(5, 6)
+    assert add_result == 11
+
+    tsum_result = tsum([1, 2, 3, 4])
+    assert tsum_result == 10
+
+
+@background_task()
+def test_celery_tasks_ignore_transaction():
+    """
+    No transaction is recorded, due to the call to ignore_transaction(),
+    so no validation fixture is used. The purpose of this test is to make
+    sure the agent doesn't throw an error.
+
+    """
+    add_result = add(1, 2)
+    assert add_result == 3
+
+    ignore_transaction()
+
+    tsum_result = tsum([1, 2, 3])
+    assert tsum_result == 6
+
+
+@validate_transaction_metrics(
+        name='test_celery:test_celery_tasks_end_transaction',
+        scoped_metrics=[('Function/tasks:add.__call__', 1)],
+        background_task=True)
+@background_task()
+def test_celery_tasks_end_transaction():
+    """
+    Only functions that run before the call to end_of_transaction() are
+    included in the transaction.
+
+    """
+    add_result = add(1, 2)
+    assert add_result == 3
+
+    end_of_transaction()
+
+    tsum_result = tsum([1, 2, 3])
+    assert tsum_result == 6

--- a/tests/application_celery/test_celery_max_tasks_per_child.py
+++ b/tests/application_celery/test_celery_max_tasks_per_child.py
@@ -1,0 +1,25 @@
+import pytest
+
+from billiard import get_context
+from billiard.pool import Worker
+
+from testing_support.validators.validate_function_called import (
+        validate_function_called)
+
+
+class OnExit(Exception):
+    pass
+
+
+@validate_function_called('newrelic.core.agent', 'Agent.shutdown_agent')
+def test_max_tasks_per_child():
+
+    def on_exit(*args, **kwargs):
+        raise OnExit()
+
+    ctx = get_context()
+    worker = Worker(ctx.SimpleQueue(), ctx.SimpleQueue(), None,
+            maxtasks=1, on_exit=on_exit)
+
+    with pytest.raises(OnExit):
+        worker._do_exit(None, 0)

--- a/tests/application_celery/tox.ini
+++ b/tests/application_celery/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39,pypy,pypy3},
+    py27,py35,py36,py37,py38,py39,pypy,pypy3
 
 [pytest]
 usefixtures = session_initialization requires_data_collector

--- a/tests/application_celery/tox.ini
+++ b/tests/application_celery/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
+    {pypy,pypy3}-without-extensions,
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    celery<5.0
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/application_celery/tox.ini
+++ b/tests/application_celery/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
-    {pypy,pypy3}-without-extensions,
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3},
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -13,11 +12,13 @@ deps =
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 
 install_command=
     pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
-

--- a/tests/application_celery/tox.ini
+++ b/tests/application_celery/tox.ini
@@ -8,7 +8,7 @@ usefixtures = session_initialization requires_data_collector
 
 [testenv]
 deps =
-    celery<5.0
+    celery<6.0
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}

--- a/tests/testing_support/validators/validate_function_called.py
+++ b/tests/testing_support/validators/validate_function_called.py
@@ -1,0 +1,22 @@
+from newrelic.common.object_wrapper import (transient_function_wrapper,
+        function_wrapper)
+
+
+def validate_function_called(module, name):
+    """Verify that a function is called."""
+
+    called = []
+
+    @transient_function_wrapper(module, name)
+    def _validate_function_called(wrapped, instance, args, kwargs):
+        called.append(True)
+        return wrapped(*args, **kwargs)
+
+    @function_wrapper
+    def wrapper(wrapped, instance, args, kwargs):
+        new_wrapper = _validate_function_called(wrapped)
+        result = new_wrapper(*args, **kwargs)
+        assert called
+        return result
+
+    return wrapper


### PR DESCRIPTION
Sidekick: @umaannamalai 

# Overview

* Ports internal test suite to public repo.
* Reduces testing matrix to remove C extension based testing.

# Related Github Issue

PYTHON-3777

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
