### PR TITLE
PYTHON-3832 Tornado Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,13 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-${{ hashFiles('tests/${{ matrix.test-directory }}/tox.ini', 'tests/base_requirements.txt') }}-
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
+    # Special case packages
+    - name: Install libcurl-dev
+      if: ${{ matrix.test-directory == 'framework_tornado' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
+
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
           - framework_flask
           - framework_sanic
           - framework_starlette
+          - framework_tornado
 
     runs-on: ubuntu-latest
 

--- a/tests/framework_tornado/_target_application.py
+++ b/tests/framework_tornado/_target_application.py
@@ -1,0 +1,265 @@
+import time
+import tornado.ioloop
+import tornado.web
+import tornado.gen
+import tornado.httpclient
+import tornado.websocket
+import tornado.httputil
+from tornado.routing import PathMatches
+
+
+def dummy(*args, **kwargs):
+    pass
+
+
+class BadGetStatusHandler(tornado.web.RequestHandler):
+    def get(self):
+        self.write("Hello, world")
+
+    def get_status(self, *args, **kwargs):
+        raise ValueError("OOPS")
+
+
+class ProcessCatHeadersHandler(tornado.web.RequestHandler):
+    def __init__(self, application, request, response_code=200, **kwargs):
+        super(ProcessCatHeadersHandler, self).__init__(application, request,
+                **kwargs)
+        self.response_code = response_code
+
+    def get(self, client_cross_process_id, txn_header, flush=None):
+        import newrelic.api.transaction as _transaction
+        txn = _transaction.current_transaction()
+        if txn:
+            txn._process_incoming_cat_headers(client_cross_process_id,
+                    txn_header)
+
+        if self.response_code != 200:
+            self.set_status(self.response_code)
+            return
+
+        self.write("Hello, world")
+
+        if flush == 'flush':
+            # Force a flush prior to calling finish
+            # This causes the headers to get written immediately. The tests
+            # which hit this endpoint will check that the response has been
+            # properly processed even though we send the headers here.
+            self.flush()
+
+            # change the headers to garbage
+            self.set_header('Content-Type', 'garbage')
+
+
+class EchoHeaderHandler(tornado.web.RequestHandler):
+    def get(self):
+        response = str(self.request.headers.__dict__).encode('utf-8')
+        self.write(response)
+
+
+class SimpleHandler(tornado.web.RequestHandler):
+    options = {'your_command': 'options'}
+
+    def get(self):
+        self.write("Hello, world")
+
+    def log_exception(self, *args, **kwargs):
+        pass
+
+    post = get
+    put = get
+    delete = get
+    patch = get
+
+
+class NativeSimpleHandler(tornado.web.RequestHandler):
+    async def get(self):
+        self.write("Hello, world")
+
+
+class SuperSimpleHandler(SimpleHandler):
+    def get(self):
+        super(SuperSimpleHandler, self).get()
+
+
+class CallSimpleHandler(tornado.web.RequestHandler):
+    def get(self):
+        SimpleHandler(self.application, self.request).get()
+
+
+class CoroThrowHandler(tornado.web.RequestHandler):
+    @tornado.gen.coroutine
+    def get(self):
+        try:
+            yield self.boom()
+        except ValueError:
+            pass
+        self.write("Hello, world")
+
+    @tornado.gen.coroutine
+    def boom(self):
+        raise ValueError('BOOM!')
+
+
+class CoroHandler(tornado.web.RequestHandler):
+    @tornado.gen.coroutine
+    def get(self):
+        yield tornado.gen.sleep(0)
+        self.write("Hello, world")
+
+
+class FakeCoroHandler(tornado.web.RequestHandler):
+    @tornado.gen.coroutine
+    def get(self):
+        self.write("Hello, world")
+
+
+class InitializeHandler(tornado.web.RequestHandler):
+    def initialize(self, *args, **kwargs):
+        pass
+
+    def get(self):
+        self.write("Hello, world")
+
+
+class HTMLInsertionHandler(tornado.web.RequestHandler):
+    HTML = """<html>
+    <head>
+        <meta charset="utf-8">
+        <title>My Website</title>
+    </head>
+    <body>
+        Hello World! There is no New Relic Browser here :(
+    </body>
+    </html>
+    """
+
+    def get(self):
+        self.finish(self.HTML)
+
+
+class CrashHandler(tornado.web.RequestHandler):
+    def get(self):
+        raise ValueError("whoopsie")
+
+
+class MultiTraceHandler(tornado.web.RequestHandler):
+    async def get(self):
+        coros = (self.trace() for _ in range(2))
+        await tornado.gen.multi(coros)
+        self.write("*")
+
+    def trace(self):
+        from newrelic.api.function_trace import FunctionTrace
+
+        with FunctionTrace(name='trace', terminal=True):
+            pass
+
+
+class WebSocketHandler(tornado.websocket.WebSocketHandler):
+    def on_message(self, message):
+        self.write_message("hello " + message)
+
+
+class EnsureFutureHandler(tornado.web.RequestHandler):
+    def get(self):
+        import asyncio
+
+        @asyncio.coroutine
+        def coro_trace():
+            from newrelic.api.function_trace import FunctionTrace
+
+            with FunctionTrace(name='trace', terminal=True):
+                yield from tornado.gen.sleep(0)
+
+        asyncio.ensure_future(coro_trace())
+
+
+class WebNestedHandler(WebSocketHandler):
+    def on_message(self, message):
+        super(WebNestedHandler, self).on_message(message)
+
+
+class CustomApplication(
+        tornado.httputil.HTTPServerConnectionDelegate,
+        tornado.httputil.HTTPMessageDelegate):
+
+    def start_request(self, server_conn, http_conn):
+        self.server_conn = server_conn
+        self.http_conn = http_conn
+        return self
+
+    def finish(self):
+        response_line = tornado.httputil.ResponseStartLine(
+                "HTTP/1.1", 200, "OK")
+        headers = tornado.httputil.HTTPHeaders()
+        headers["Content-Type"] = "text/plain"
+        self.http_conn.write_headers(response_line, headers)
+        self.http_conn.write(b"*")
+        self.http_conn.finish()
+
+
+class BlockingHandler(tornado.web.RequestHandler):
+    total = 0
+    future = None
+
+    def initialize(self, yield_before_finish=False):
+        self.yield_before_finish = yield_before_finish
+
+    async def get(self, total=1):
+        import asyncio
+        total = int(total)
+
+        cls = type(self)
+        if cls.total == 0:
+            cls.future = asyncio.Future()
+
+        cls.total += 1
+        if cls.total == total:
+            cls.total = 0
+            cls.future.set_result(True)
+            cls.future = None
+            time.sleep(0.1)
+        else:
+            await cls.future
+
+        if self.yield_before_finish:
+            await asyncio.sleep(0)
+
+        self.write('*')
+
+
+def make_app(custom=False):
+    handlers = [
+        (PathMatches(r'/simple'), SimpleHandler),
+        (r'/crash', CrashHandler),
+        (r'/call-simple', CallSimpleHandler),
+        (r'/super-simple', SuperSimpleHandler),
+        (r'/coro', CoroHandler),
+        (r'/coro-throw', CoroThrowHandler),
+        (r'/fake-coro', FakeCoroHandler),
+        (r'/init', InitializeHandler),
+        (r'/html-insertion', HTMLInsertionHandler),
+        (r'/bad-get-status', BadGetStatusHandler),
+        (r'/force-cat-response/(\S+)/(\S+)/(\S+)', ProcessCatHeadersHandler),
+        (r'/304-cat-response/(\S+)/(\S+)', ProcessCatHeadersHandler,
+                {'response_code': 304}),
+        (r'/echo-headers', EchoHeaderHandler),
+        (r'/native-simple', NativeSimpleHandler),
+        (r'/multi-trace', MultiTraceHandler),
+        (r'/web-socket', WebSocketHandler),
+        (r'/ensure-future', EnsureFutureHandler),
+        (r'/call-web-socket', WebNestedHandler),
+        (r'/block/(\d+)', BlockingHandler),
+        (r'/block-with-yield/(\d+)', BlockingHandler,
+                {'yield_before_finish': True}),
+    ]
+    if custom:
+        return CustomApplication()
+    else:
+        return tornado.web.Application(handlers, log_function=dummy)
+
+
+if __name__ == "__main__":
+    app = make_app()
+    app.listen(8888, address='127.0.0.1')
+    tornado.ioloop.IOLoop.current().start()

--- a/tests/framework_tornado/_target_application.py
+++ b/tests/framework_tornado/_target_application.py
@@ -17,7 +17,7 @@ class BadGetStatusHandler(tornado.web.RequestHandler):
         self.write("Hello, world")
 
     def get_status(self, *args, **kwargs):
-        raise ValueError("OOPS")
+        raise ValueError("Bad Status")
 
 
 class ProcessCatHeadersHandler(tornado.web.RequestHandler):
@@ -90,14 +90,14 @@ class CoroThrowHandler(tornado.web.RequestHandler):
     @tornado.gen.coroutine
     def get(self):
         try:
-            yield self.boom()
+            yield self.throw_exception()
         except ValueError:
             pass
         self.write("Hello, world")
 
     @tornado.gen.coroutine
-    def boom(self):
-        raise ValueError('BOOM!')
+    def throw_exception(self):
+        raise ValueError('Throwing exception.')
 
 
 class CoroHandler(tornado.web.RequestHandler):

--- a/tests/framework_tornado/_target_application.py
+++ b/tests/framework_tornado/_target_application.py
@@ -139,7 +139,7 @@ class HTMLInsertionHandler(tornado.web.RequestHandler):
 
 class CrashHandler(tornado.web.RequestHandler):
     def get(self):
-        raise ValueError("whoopsie")
+        raise ValueError("CrashHandler")
 
 
 class MultiTraceHandler(tornado.web.RequestHandler):

--- a/tests/framework_tornado/conftest.py
+++ b/tests/framework_tornado/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,  # noqa
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (framework_tornado)',
+        default_settings=_default_settings)
+
+_coverage_source = [
+    'newrelic.hooks.framework_tornado',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+
+@pytest.fixture(scope='module')
+def app(request):
+    import tornado
+    from tornado.testing import AsyncHTTPTestCase
+    from _target_application import make_app
+
+    class App(AsyncHTTPTestCase):
+        def get_app(self):
+            custom = request.node.get_closest_marker("custom_app")
+            return make_app(custom)
+
+        def runTest(self, *args, **kwargs):
+            pass
+
+        @property
+        def tornado_version(self):
+            return '.'.join(map(str, tornado.version_info))
+
+    case = App()
+    case.setUp()
+    yield case
+    case.tearDown()

--- a/tests/framework_tornado/test_custom_handler.py
+++ b/tests/framework_tornado/test_custom_handler.py
@@ -1,0 +1,19 @@
+import pytest
+from testing_support.fixtures import validate_transaction_metrics
+
+pytestmark = pytest.mark.custom_app
+
+
+def test_custom_handler(app):
+    FRAMEWORK_METRIC = 'Python/Framework/Tornado/%s' % app.tornado_version
+
+    @validate_transaction_metrics(
+        name='_target_application:CustomApplication',
+        rollup_metrics=((FRAMEWORK_METRIC, 1),),
+    )
+    def _test():
+        response = app.fetch('/')
+        assert response.code == 200
+        assert response.body == b'*'
+
+    _test()

--- a/tests/framework_tornado/test_externals.py
+++ b/tests/framework_tornado/test_externals.py
@@ -1,0 +1,355 @@
+import io
+import pytest
+import socket
+import sys
+
+from newrelic.api.transaction import current_transaction
+from newrelic.api.background_task import background_task
+from newrelic.api.function_trace import FunctionTrace
+
+from testing_support.external_fixtures import (
+        validate_distributed_tracing_header,
+        validate_outbound_headers)
+from testing_support.fixtures import (validate_transaction_metrics,
+        override_application_settings)
+from testing_support.mock_external_http_server import (
+        MockExternalHTTPHResponseHeadersServer,
+        MockExternalHTTPServer)
+
+ENCODING_KEY = '1234567890123456789012345678901234567890'
+
+is_pypy = hasattr(sys, 'pypy_version_info')
+
+
+@pytest.fixture(scope='module')
+def external():
+    external = MockExternalHTTPHResponseHeadersServer()
+    with external:
+        yield external
+
+
+def _get_open_port():
+    # https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
+    s = socket.socket()
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@background_task(name='make_request')
+def make_request(port, req_type, client_cls, count=1, raise_error=True,
+        as_kwargs=True, **kwargs):
+    import tornado.gen
+    import tornado.concurrent
+    import tornado.httpclient
+    import tornado.ioloop
+
+    class CustomAsyncHTTPClient(tornado.httpclient.AsyncHTTPClient):
+        def fetch_impl(self, request, callback):
+            out = []
+            for k, v in request.headers.items():
+                out.append('%s: %s' % (k, v))
+            body = '\n'.join(out).encode('utf-8')
+            response = tornado.httpclient.HTTPResponse(request=request,
+                    code=200, buffer=io.BytesIO(body))
+            callback(response)
+
+    cls = tornado.httpclient.AsyncHTTPClient
+    if client_cls == 'AsyncHTTPClient':
+        cls.configure(None)
+    elif client_cls == 'CurlAsyncHTTPClient':
+        if is_pypy:
+            pytest.skip("Pypy not supported by Pycurl")
+        import tornado.curl_httpclient
+        cls.configure(tornado.curl_httpclient.CurlAsyncHTTPClient)
+    elif client_cls == 'HTTPClient':
+        cls = tornado.httpclient.HTTPClient
+    elif client_cls == 'CustomAsyncHTTPClient':
+        cls.configure(CustomAsyncHTTPClient)
+    else:
+        raise ValueError("Received unknown client type: %s" % client_cls)
+
+    client = cls(force_instance=True)
+    callback = None
+
+    uri = 'http://localhost:%s' % port
+    if req_type == 'class':
+        req = tornado.httpclient.HTTPRequest(uri, **kwargs)
+        kwargs = {}
+    elif req_type == 'uri':
+        req = uri
+    else:
+        raise ValueError("Received unknown request type: %s" % req_type)
+
+    @tornado.gen.coroutine
+    def _make_request():
+
+        if as_kwargs:
+            futures = [client.fetch(req, raise_error=raise_error, **kwargs)
+                    for _ in range(count)]
+        elif tornado.version_info < (6, 0):
+            futures = [client.fetch(req, callback, raise_error, **kwargs)
+                    for _ in range(count)]
+        else:
+            futures = [client.fetch(req, raise_error, **kwargs)
+                    for _ in range(count)]
+
+        assert all(isinstance(f, tornado.concurrent.Future) for f in futures)
+
+        if count > 1:
+            responses = yield tornado.gen.multi_future(futures)
+            response = responses[0]
+        else:
+            response = yield futures[0]
+
+        raise tornado.gen.Return(response)
+
+    if client_cls == 'HTTPClient':
+        for _ in range(count):
+            response = client.fetch(req, raise_error=raise_error, **kwargs)
+        return response
+    else:
+        response = tornado.ioloop.IOLoop.current().run_sync(_make_request)
+        return response
+
+
+@pytest.mark.parametrize('client_class,as_kwargs', [
+    ('AsyncHTTPClient', True),
+    ('AsyncHTTPClient', False),
+    ('CurlAsyncHTTPClient', True),
+    ('CurlAsyncHTTPClient', False),
+    ('CustomAsyncHTTPClient', True),
+    ('CustomAsyncHTTPClient', False),
+    ('HTTPClient', True),
+])
+@pytest.mark.parametrize('cat_enabled,user_header', [
+    (True, None),
+    (True, 'X-NewRelic-ID'),
+    (True, 'X-NewRelic-Transaction'),
+    (False, None),
+])
+@pytest.mark.parametrize('request_type', ['uri', 'class'])
+@pytest.mark.parametrize('num_requests', [1, 2])
+@pytest.mark.parametrize('distributed_tracing,span_events', (
+    (True, True),
+    (True, False),
+    (False, False),
+))
+def test_httpclient(cat_enabled, request_type, client_class, user_header,
+        num_requests, distributed_tracing, span_events, external, as_kwargs):
+
+    port = external.port
+
+    expected_metrics = [
+        ('External/localhost:%s/tornado/GET' % port, num_requests)
+    ]
+
+    @override_application_settings({
+        'distributed_tracing.enabled': distributed_tracing,
+        'span_events.enabled': span_events,
+    })
+    @validate_transaction_metrics(
+        'test_externals:test_httpclient',
+        background_task=True,
+        rollup_metrics=expected_metrics,
+        scoped_metrics=expected_metrics
+    )
+    @background_task(name='test_externals:test_httpclient')
+    def _test():
+        headers = {}
+        if user_header:
+            headers = {user_header: 'USER'}
+
+        response = make_request(port, request_type, client_class,
+                headers=headers, count=num_requests, as_kwargs=as_kwargs)
+        assert response.code == 200
+
+        body = response.body
+        if hasattr(body, 'decode'):
+            body = body.decode('utf-8')
+
+        headers = {}
+        for header_line in body.split('\n'):
+            if ':' not in header_line:
+                continue
+            header_key, header_val = header_line.split(':', 1)
+            header_key = header_key.strip()
+            header_val = header_val.strip()
+            headers[header_key] = header_val
+
+        # User headers override all inserted NR headers
+        if user_header:
+            assert headers[user_header] == 'USER'
+        elif cat_enabled:
+            t = current_transaction()
+            assert t
+            t._test_request_headers = headers
+
+            if distributed_tracing:
+                validate_distributed_tracing_header(header='Newrelic')
+            else:
+                validate_outbound_headers()
+        else:
+            # new relic shouldn't add anything to the outgoing
+            assert 'x-newrelic' not in body, body
+
+        assert 'X-NewRelic-App-Data' not in headers
+
+    _test()
+
+
+CAT_RESPONSE_CODE = None
+
+
+def cat_response_handler(self):
+    global CAT_RESPONSE_CODE
+    # payload
+    # (
+    #     u'1#1', u'WebTransaction/Function/app:beep',
+    #     0, 1.23, -1,
+    #     'dd4a810b7cb7f937',
+    #     False,
+    # )
+    cat_response_header = ('X-NewRelic-App-Data',
+            'ahACFwQUGxpuVVNmQVVbRVZbTVleXBxyQFhUTFBfXx1SREUMV'
+            'V1cQBMeAxgEGAULFR0AHhFQUQJWAAgAUwVQVgJQDgsOEh1UUlhGU2o=')
+    self.send_response(CAT_RESPONSE_CODE)
+    self.send_header(*cat_response_header)
+    self.end_headers()
+    self.wfile.write(b'BEEEEEP')
+
+
+@pytest.fixture(scope='module')
+def cat_response_server():
+    port = _get_open_port()
+    external = MockExternalHTTPServer(handler=cat_response_handler, port=port)
+    with external:
+        yield external
+
+
+@pytest.mark.parametrize('client_class',
+        ['AsyncHTTPClient', 'CurlAsyncHTTPClient', 'HTTPClient'])
+@pytest.mark.parametrize('cat_enabled', [True, False])
+@pytest.mark.parametrize('request_type', ['uri', 'class'])
+@pytest.mark.parametrize('response_code,raise_error', [
+    (500, True),
+    (500, False),
+    (200, False),
+])
+def test_client_cat_response_processing(cat_enabled, request_type,
+        client_class, raise_error, response_code, cat_response_server):
+    global CAT_RESPONSE_CODE
+    CAT_RESPONSE_CODE = response_code
+
+    _custom_settings = {
+        'cross_process_id': '1#1',
+        'encoding_key': ENCODING_KEY,
+        'trusted_account_ids': [1],
+        'cross_application_tracer.enabled': cat_enabled,
+        'distributed_tracing.enabled': False,
+        'transaction_tracer.transaction_threshold': 0.0,
+    }
+
+    port = cat_response_server.port
+    expected_metrics = [
+        ('ExternalTransaction/localhost:%s/1#1/WebTransaction/'
+                'Function/app:beep' % port, 1 if cat_enabled else None),
+    ]
+
+    @validate_transaction_metrics(
+        'make_request',
+        background_task=True,
+        rollup_metrics=expected_metrics,
+        scoped_metrics=expected_metrics
+    )
+    @override_application_settings(_custom_settings)
+    def _test():
+        import tornado
+        import tornado.httpclient
+        try:
+            response = make_request(port, request_type, client_class,
+                    raise_error=raise_error)
+        except tornado.httpclient.HTTPError as e:
+            assert raise_error
+            response = e.response
+        else:
+            assert not raise_error
+
+        assert response.code == response_code
+
+    _test()
+
+
+@pytest.mark.parametrize('client_class', ['AsyncHTTPClient',
+    'CurlAsyncHTTPClient', 'HTTPClient'])
+@validate_transaction_metrics('make_request',
+        background_task=True)
+def test_httpclient_invalid_method(client_class, external):
+    with pytest.raises(KeyError):
+        make_request(external.port, 'uri', client_class,
+                method='COOKIES')
+
+
+@pytest.mark.parametrize('client_class',
+        ['AsyncHTTPClient', 'CurlAsyncHTTPClient', 'HTTPClient'])
+@validate_transaction_metrics('make_request',
+        background_task=True)
+def test_httpclient_invalid_kwarg(client_class, external):
+    with pytest.raises(TypeError):
+        make_request(external.port, 'uri', client_class, boop='1234')
+
+
+def test_httpclient_fetch_crashes(external):
+    @validate_transaction_metrics('test_httpclient_fetch_crashes',
+        background_task=True,
+        rollup_metrics=[('External/localhost:%d/tornado/GET' % external.port, 1)],
+        scoped_metrics=[('External/localhost:%d/tornado/GET' % external.port, 1)]
+    )
+    @background_task(name='test_httpclient_fetch_crashes')
+    def _test():
+        import tornado.httpclient
+
+        class CrashClient(tornado.httpclient.AsyncHTTPClient):
+            def fetch_impl(self, *args, **kwargs):
+                raise ValueError("BOOM")
+
+        client = CrashClient(force_instance=True)
+
+        port = external.port
+        with pytest.raises(ValueError):
+            tornado.ioloop.IOLoop.current().run_sync(
+                    lambda: client.fetch('http://localhost:%s' % port))
+
+    _test()
+
+
+def test_httpclient_fetch_inside_terminal_node(external):
+    @validate_transaction_metrics('test_httpclient_fetch_inside_terminal_node',
+        background_task=True,
+        rollup_metrics=[('External/localhost:%d/tornado/GET' % external.port, None)],
+        scoped_metrics=[('External/localhost:%d/tornado/GET' % external.port, None)]
+    )
+    @background_task(name='test_httpclient_fetch_inside_terminal_node')
+    def _test():
+        # Test that our instrumentation correctly handles the case when the parent
+        # is a terminal node
+        import tornado.httpclient
+        import tornado.gen
+        import tornado.ioloop
+        client = tornado.httpclient.AsyncHTTPClient(force_instance=True)
+
+        # This is protecting against a "pop_current" when the external trace never
+        # actually gets pushed
+        port = external.port
+
+        @tornado.gen.coroutine
+        def _make_request():
+            with FunctionTrace(name='parent', terminal=True):
+                response = yield client.fetch('http://localhost:%s' % port)
+            return response
+
+        response = tornado.ioloop.IOLoop.current().run_sync(_make_request)
+        assert response.code == 200
+
+    _test()

--- a/tests/framework_tornado/test_externals.py
+++ b/tests/framework_tornado/test_externals.py
@@ -217,7 +217,7 @@ def cat_response_handler(self):
     self.send_response(CAT_RESPONSE_CODE)
     self.send_header(*cat_response_header)
     self.end_headers()
-    self.wfile.write(b'BEEEEEP')
+    self.wfile.write(b'Example Data')
 
 
 @pytest.fixture(scope='module')

--- a/tests/framework_tornado/test_inbound_cat.py
+++ b/tests/framework_tornado/test_inbound_cat.py
@@ -1,0 +1,133 @@
+import json
+import pytest
+from testing_support.fixtures import (make_cross_agent_headers,
+        override_application_settings, validate_transaction_event_attributes,
+        validate_transaction_metrics)
+
+ENCODING_KEY = '1234567890123456789012345678901234567890'
+
+
+_custom_settings = {
+        'cross_process_id': '1#1',
+        'encoding_key': ENCODING_KEY,
+        'trusted_account_ids': [1],
+        'cross_application_tracer.enabled': True,
+        'distributed_tracing.enabled': False,
+        'transaction_tracer.transaction_threshold': 0.0,
+}
+
+
+@override_application_settings(_custom_settings)
+@validate_transaction_event_attributes(
+    required_params={
+        'agent': (), 'user': (), 'intrinsic': (),
+    },
+    forgone_params={
+        'agent': (), 'user': (), 'intrinsic': (),
+    },
+    exact_attrs={
+        'agent': {
+            'response.status': '200',
+            'response.headers.contentType': 'text/html; charset=UTF-8',
+        },
+        'user': {}, 'intrinsic': {},
+    },
+)
+@pytest.mark.parametrize('manual_flush', ['flush', 'no-flush'])
+def test_response_to_inbound_cat(app, manual_flush):
+    payload = (
+        u'1#1', u'WebTransaction/Function/app:beep',
+        0, 1.23, -1,
+        'dd4a810b7cb7f937', False
+    )
+    headers = make_cross_agent_headers(payload, ENCODING_KEY, '1#1')
+
+    client_cross_process_id = headers['X-NewRelic-ID']
+    txn_header = headers['X-NewRelic-Transaction']
+
+    response = app.fetch('/force-cat-response/%s/%s/%s' %
+            (client_cross_process_id, txn_header, manual_flush))
+    assert response.code == 200
+    assert 'X-NewRelic-App-Data' in list(response.headers.keys())
+
+
+@validate_transaction_event_attributes(
+    required_params={'agent': (), 'user': (), 'intrinsic': ()},
+    forgone_params={
+        'agent': ('response.headers',),
+        'user': (),
+        'intrinsic': (),
+    },
+    exact_attrs={
+        'agent': {
+            'request.method': 'GET',
+            'response.status': '304'},
+        'user': {},
+        'intrinsic': {},
+    },
+)
+@override_application_settings(_custom_settings)
+def test_cat_headers_not_inserted(app):
+    payload = (
+        u'1#1', u'WebTransaction/Function/app:beep',
+        0, 1.23, -1,
+        'dd4a810b7cb7f937', False
+    )
+    headers = make_cross_agent_headers(payload, ENCODING_KEY, '1#1')
+
+    client_cross_process_id = headers['X-NewRelic-ID']
+    txn_header = headers['X-NewRelic-Transaction']
+
+    response = app.fetch('/304-cat-response/%s/%s' %
+            (client_cross_process_id, txn_header))
+    assert response.code == 304
+    assert 'X-NewRelic-App-Data' not in list(response.headers.keys())
+
+
+@override_application_settings(_custom_settings)
+@validate_transaction_metrics('_target_application:SimpleHandler.get',
+        rollup_metrics=[('ClientApplication/1#1/all', 1)])
+@validate_transaction_event_attributes(
+    required_params={'agent': [], 'user': [], 'intrinsic': []},
+    forgone_params={'agent': [], 'user': [], 'intrinsic': []},
+    exact_attrs={'agent': {}, 'user': {},
+        'intrinsic': {'nr.referringTransactionGuid': 'b854df4feb2b1f06'}},
+)
+def test_inbound_cat_metrics_and_intrinsics(app):
+    payload = ['b854df4feb2b1f06', False, '7e249074f277923d', '5d2957be']
+    headers = make_cross_agent_headers(payload, ENCODING_KEY, '1#1')
+
+    response = app.fetch('/simple', headers=headers)
+    assert response.code == 200
+
+
+@override_application_settings({
+    'account_id': 1,
+    'trusted_account_key': 1,
+    'primary_application_id': 1,
+    'distributed_tracing.enabled': True,
+})
+@validate_transaction_metrics(
+    '_target_application:SimpleHandler.get',
+    rollup_metrics=(
+        ('Supportability/DistributedTrace/AcceptPayload/Success', 1),
+    )
+)
+def test_inbound_dt(app):
+    PAYLOAD = {
+        "v": [0, 1],
+        "d": {
+            "ac": 1,
+            "ap": 1,
+            "id": "7d3efb1b173fecfa",
+            "tx": "e8b91a159289ff74",
+            "pr": 1.234567,
+            "sa": True,
+            "ti": 1518469636035,
+            "tr": "d6b4ba0c3a712ca",
+            "ty": "App"
+        }
+    }
+    headers = {'newrelic': json.dumps(PAYLOAD)}
+    response = app.fetch('/simple', headers=headers)
+    assert response.code == 200

--- a/tests/framework_tornado/test_server.py
+++ b/tests/framework_tornado/test_server.py
@@ -1,0 +1,232 @@
+import pytest
+from newrelic.core.config import global_settings
+from testing_support.fixtures import (validate_transaction_metrics,
+        override_generic_settings, function_not_called,
+        validate_transaction_event_attributes,
+        validate_transaction_errors, override_ignore_status_codes,
+        override_application_settings)
+from testing_support.validators.validate_transaction_count import (
+        validate_transaction_count)
+
+
+@pytest.mark.parametrize('uri,name,metrics, method_metric', (
+    ('/native-simple', '_target_application:NativeSimpleHandler.get', None,
+            True),
+    ('/simple', '_target_application:SimpleHandler.get', None, True),
+    ('/call-simple', '_target_application:CallSimpleHandler.get', None, True),
+    ('/super-simple', '_target_application:SuperSimpleHandler.get', None,
+            True),
+    ('/coro', '_target_application:CoroHandler.get', None, False),
+    ('/fake-coro', '_target_application:FakeCoroHandler.get', None, False),
+    ('/coro-throw', '_target_application:CoroThrowHandler.get', None, False),
+    ('/init', '_target_application:InitializeHandler.get', None, True),
+    ('/multi-trace', '_target_application:MultiTraceHandler.get',
+        [('Function/trace', 2)], True),
+))
+@override_application_settings({'attributes.include': ['request.*']})
+def test_server(app, uri, name, metrics, method_metric):
+    FRAMEWORK_METRIC = 'Python/Framework/Tornado/%s' % app.tornado_version
+    METHOD_METRIC = 'Function/%s' % name
+
+    metrics = metrics or []
+    metrics.append((FRAMEWORK_METRIC, 1))
+    metrics.append((METHOD_METRIC, 1 if method_metric else None))
+
+    host = '127.0.0.1:' + str(app.get_http_port())
+
+    @validate_transaction_metrics(
+        name,
+        rollup_metrics=metrics,
+    )
+    @validate_transaction_event_attributes(
+        required_params={
+            'agent': ('response.headers.contentType',),
+            'user': (), 'intrinsic': ()},
+        exact_attrs={
+            'agent': {'request.headers.contentType': '1234',
+                'request.headers.host': host,
+                'request.method': 'GET',
+                'request.uri': uri,
+                'response.status': '200'},
+            'user': {},
+            'intrinsic': {'port': app.get_http_port()},
+        },
+    )
+    def _test():
+        response = app.fetch(uri, headers=(('Content-Type', '1234'),))
+        assert response.code == 200
+
+    _test()
+
+
+@pytest.mark.parametrize('uri,name,metrics,method_metric', (
+    ('/native-simple', '_target_application:NativeSimpleHandler.get', None,
+            True),
+    ('/simple', '_target_application:SimpleHandler.get', None, True),
+    ('/call-simple', '_target_application:CallSimpleHandler.get', None, True),
+    ('/super-simple', '_target_application:SuperSimpleHandler.get', None,
+            True),
+    ('/coro', '_target_application:CoroHandler.get', None, False),
+    ('/fake-coro', '_target_application:FakeCoroHandler.get', None, False),
+    ('/coro-throw', '_target_application:CoroThrowHandler.get', None, False),
+    ('/init', '_target_application:InitializeHandler.get', None, True),
+    ('/ensure-future',
+            '_target_application:EnsureFutureHandler.get',
+        [('Function/trace', None)], True),
+    ('/multi-trace', '_target_application:MultiTraceHandler.get',
+        [('Function/trace', 2)], True),
+))
+def test_concurrent_inbound_requests(app, uri, name, metrics, method_metric):
+    from tornado import gen
+
+    FRAMEWORK_METRIC = 'Python/Framework/Tornado/%s' % app.tornado_version
+    METHOD_METRIC = 'Function/%s' % name
+
+    metrics = metrics or []
+    metrics.append((FRAMEWORK_METRIC, 1))
+    metrics.append((METHOD_METRIC, 1 if method_metric else None))
+
+    @validate_transaction_count(2)
+    @validate_transaction_metrics(
+        name,
+        rollup_metrics=metrics,
+    )
+    def _test():
+        url = app.get_url(uri)
+        coros = (app.http_client.fetch(url) for _ in range(2))
+        responses = app.io_loop.run_sync(lambda: gen.multi(coros))
+
+        for response in responses:
+            assert response.code == 200
+
+    _test()
+
+
+@validate_transaction_metrics('_target_application:CrashHandler.get')
+@validate_transaction_errors(['builtins:ValueError'])
+def test_exceptions_are_recorded(app):
+    response = app.fetch('/crash')
+    assert response.code == 500
+
+
+@pytest.mark.parametrize('nr_enabled,ignore_status_codes', [
+    (True, [405]),
+    (True, []),
+    (False, None),
+])
+def test_unsupported_method(app, nr_enabled, ignore_status_codes):
+
+    def _test():
+        response = app.fetch('/simple',
+                method='TEAPOT', body=b'', allow_nonstandard_methods=True)
+        assert response.code == 405
+
+    if nr_enabled:
+        _test = override_ignore_status_codes(ignore_status_codes)(_test)
+        _test = validate_transaction_metrics(
+                '_target_application:SimpleHandler')(_test)
+
+        if ignore_status_codes:
+            _test = validate_transaction_errors(errors=[])(_test)
+        else:
+            _test = validate_transaction_errors(
+                    errors=['tornado.web:HTTPError'])(_test)
+    else:
+        settings = global_settings()
+        _test = override_generic_settings(settings, {'enabled': False})(_test)
+
+    _test()
+
+
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics('tornado.web:ErrorHandler')
+@validate_transaction_event_attributes(
+    required_params={'agent': (), 'user': (), 'intrinsic': ()},
+    exact_attrs={
+        'agent': {'request.uri': '/does-not-exist'},
+        'user': {},
+        'intrinsic': {},
+    },
+)
+def test_not_found(app):
+    response = app.fetch('/does-not-exist')
+    assert response.code == 404
+
+
+@override_generic_settings(global_settings(), {
+    'enabled': False,
+})
+@function_not_called('newrelic.core.stats_engine',
+        'StatsEngine.record_transaction')
+def test_nr_disabled(app):
+    response = app.fetch('/simple')
+    assert response.code == 200
+
+
+@pytest.mark.parametrize('uri,name', (
+    ('/web-socket', '_target_application:WebSocketHandler'),
+    ('/call-web-socket', '_target_application:WebNestedHandler'),
+))
+def test_web_socket(uri, name, app):
+    import asyncio
+    from tornado.websocket import websocket_connect
+
+    @validate_transaction_metrics(
+        name,
+        rollup_metrics=[('Function/%s' % name, None)],
+    )
+    def _test():
+        url = app.get_url(uri).replace('http', 'ws')
+
+        @asyncio.coroutine
+        def _connect():
+            conn = yield from websocket_connect(url)
+            return conn
+
+        @validate_transaction_metrics(
+            name,
+        )
+        def connect():
+            return app.io_loop.run_sync(_connect)
+
+        @function_not_called('newrelic.core.stats_engine',
+                'StatsEngine.record_transaction')
+        def call(call):
+            @asyncio.coroutine
+            def _call():
+                yield from conn.write_message("test")
+                resp = yield from conn.read_message()
+                assert resp == "hello test"
+            app.io_loop.run_sync(_call)
+
+        conn = connect()
+        call(conn)
+        conn.close()
+
+    _test()
+
+
+LOOP_TIME_METRICS = (
+    ('EventLoop/Wait/'
+        'WebTransaction/Function/_target_application:BlockingHandler.get', 1),
+)
+
+
+@pytest.mark.parametrize('yield_before_finish', (True, False))
+@validate_transaction_metrics(
+    "_target_application:BlockingHandler.get",
+    scoped_metrics=LOOP_TIME_METRICS,
+)
+def test_io_loop_blocking_time(app, yield_before_finish):
+    from tornado import gen
+
+    if yield_before_finish:
+        url = app.get_url('/block-with-yield/2')
+    else:
+        url = app.get_url('/block/2')
+
+    coros = (app.http_client.fetch(url) for _ in range(2))
+    responses = app.io_loop.run_sync(lambda: gen.multi(coros))
+
+    for response in responses:
+        assert response.code == 200

--- a/tests/framework_tornado/tox.ini
+++ b/tests/framework_tornado/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py35,py36,py37,py38,py39,pypy3}-tornado{0600,master}
+    {py35,py36,py37,py38,py39,pypy3}-tornado0600
+    {py36,py37,py38,py39,pypy3}-tornadomaster
 
 [pytest]
 usefixtures = collector_available_fixture code_coverage collector_agent_registration

--- a/tests/framework_tornado/tox.ini
+++ b/tests/framework_tornado/tox.ini
@@ -1,0 +1,28 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py35,py36,py37,py38,py39}-tornado{0600,master}-{with,without}-extensions,
+    pypy3-tornado{0600,master}-without-extensions,
+
+[jenkins]
+mostrecent = tornado0600
+
+[pytest]
+usefixtures = collector_available_fixture code_coverage collector_agent_registration
+
+[testenv]
+deps =
+    pycurl
+    tornado0600: tornado<6.1
+    tornadomaster: https://github.com/tornadoweb/tornado/archive/master.zip
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/framework_tornado/tox.ini
+++ b/tests/framework_tornado/tox.ini
@@ -1,11 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py35,py36,py37,py38,py39}-tornado{0600,master}-{with,without}-extensions,
-    pypy3-tornado{0600,master}-without-extensions,
-
-[jenkins]
-mostrecent = tornado0600
+    {py35,py36,py37,py38,py39,pypy3}-tornado{0600,master}
 
 [pytest]
 usefixtures = collector_available_fixture code_coverage collector_agent_registration
@@ -18,11 +14,13 @@ deps =
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 
 install_command=
     pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
-

--- a/tests/testing_support/external_fixtures.py
+++ b/tests/testing_support/external_fixtures.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import current_transaction
+from newrelic.common.encoding_utils import (json_decode,
+    obfuscate, deobfuscate, DistributedTracePayload)
 from newrelic.common.object_wrapper import transient_function_wrapper
 
+OUTBOUND_TRACE_KEYS_REQUIRED = (
+        'ty', 'ac', 'ap', 'tr', 'pr', 'sa', 'ti')
 
 def validate_synthetics_external_trace_header(required_header=(),
         should_exist=True):
@@ -64,3 +69,102 @@ def validate_synthetics_external_trace_header(required_header=(),
         return result
 
     return _validate_synthetics_external_trace_header
+
+def validate_outbound_headers(header_id='X-NewRelic-ID',
+        header_transaction='X-NewRelic-Transaction'):
+    transaction = current_transaction()
+    headers = transaction._test_request_headers
+    settings = transaction.settings
+    encoding_key = settings.encoding_key
+
+    assert header_id in headers
+
+    values = headers[header_id]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    cross_process_id = deobfuscate(value, encoding_key)
+    assert cross_process_id == settings.cross_process_id
+
+    assert header_transaction in headers
+
+    values = headers[header_transaction]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    (guid, record_tt, trip_id, path_hash) = \
+            json_decode(deobfuscate(value, encoding_key))
+
+    assert guid == transaction.guid
+    assert record_tt == transaction.record_tt
+    assert trip_id == transaction.trip_id
+    assert path_hash == transaction.path_hash
+
+
+def validate_distributed_tracing_header(header='newrelic'):
+    transaction = current_transaction()
+    headers = transaction._test_request_headers
+    account_id = transaction.settings.account_id
+    application_id = transaction.settings.primary_application_id
+
+    assert header in headers, headers
+
+    values = headers[header]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    # Parse payload
+    payload = DistributedTracePayload.from_http_safe(value)
+
+    # Distributed Tracing v0.1 is currently implemented
+    assert payload['v'] == [0, 1], payload['v']
+
+    data = payload['d']
+
+    # Verify all required keys are present
+    assert all(k in data for k in OUTBOUND_TRACE_KEYS_REQUIRED)
+
+    # Type will always be App (not mobile / browser)
+    assert data['ty'] == 'App'
+
+    # Verify account/app id
+    assert data['ac'] == account_id
+    assert data['ap'] == application_id
+
+    # Verify data belonging to this transaction
+    assert data['tx'] == transaction.guid
+
+    # If span events are enabled, id should be sent
+    # otherwise, id should be omitted
+    if transaction.settings.span_events.enabled:
+        assert 'id' in data
+    else:
+        assert 'id' not in data
+
+    # Verify referring transaction information
+    assert len(data['tr']) == 32
+    if transaction.referring_transaction_guid is not None:
+        assert data['tr'] == transaction._trace_id
+    else:
+        assert data['tr'].startswith(transaction.guid)
+
+    assert 'pa' not in data
+
+    # Verify timestamp is an integer
+    assert isinstance(data['ti'], int)
+
+    # Verify that priority is a float
+    assert isinstance(data['pr'], float)
+

--- a/tests/testing_support/validators/validate_transaction_count.py
+++ b/tests/testing_support/validators/validate_transaction_count.py
@@ -1,0 +1,22 @@
+from newrelic.common.object_wrapper import (transient_function_wrapper,
+        function_wrapper)
+
+
+def validate_transaction_count(count):
+    _count = []
+
+    @transient_function_wrapper('newrelic.core.stats_engine',
+            'StatsEngine.record_transaction')
+    def _increment_count(wrapped, instance, args, kwargs):
+        _count.append(True)
+        return wrapped(*args, **kwargs)
+
+    @function_wrapper
+    def _validate_transaction_count(wrapped, instance, args, kwargs):
+        _new_wrapped = _increment_count(wrapped)
+        result = _new_wrapped(*args, **kwargs)
+        assert len(_count) == count
+
+        return result
+
+    return _validate_transaction_count


### PR DESCRIPTION
Sidekick: @carrieedwards 

# Overview

* Ports tornado tests to public repo
* Cleans up some logic and language
* Removes unsupported py35 from tornado master.

# Related Github Issue

PYTHON-3832

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
