### PR TITLE
PYTHON-3821 aiohttp Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
           - agent_unittests
           - application_celery
           - component_flask_rest
+          - framework_aiohttp
           - framework_bottle
           - framework_falcon
           - framework_fastapi

--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -1,0 +1,184 @@
+import asyncio
+import sys
+from aiohttp import web, WSMsgType, ClientSession
+from newrelic.api.function_trace import function_trace
+
+
+@asyncio.coroutine
+def index(request):
+    yield
+    resp = web.Response(text='Hello Aiohttp!')
+    resp.set_cookie('ExampleCookie', 'ExampleValue')
+    return resp
+
+
+@asyncio.coroutine
+def hang(request):
+    while True:
+        yield
+
+
+@asyncio.coroutine
+def error(request):
+    raise ValueError("Value Error")
+
+
+@asyncio.coroutine
+def non_500_error(request):
+    raise web.HTTPGone()
+
+
+@asyncio.coroutine
+def raise_404(request):
+    raise web.HTTPNotFound()
+
+
+@asyncio.coroutine
+@function_trace()
+def wait():
+    yield from asyncio.sleep(0.1)
+
+
+@asyncio.coroutine
+def run_task(loop):
+    yield from wait()
+    loop.stop()
+
+
+@asyncio.coroutine
+def background(request):
+    try:
+        loop = request.loop
+    except AttributeError:
+        loop = request.task._loop
+
+    asyncio.set_event_loop(loop)
+    asyncio.tasks.ensure_future(run_task(loop))
+    return web.Response(text='Background Task Scheduled')
+
+
+class HelloWorldView(web.View):
+
+    @asyncio.coroutine
+    def _respond(self):
+        yield
+        resp = web.Response(text='Hello Aiohttp!')
+        resp.set_cookie('ExampleCookie', 'ExampleValue')
+        return resp
+
+    get = _respond
+    post = _respond
+    put = _respond
+    patch = _respond
+    delete = _respond
+
+
+class KnownException(Exception):
+    pass
+
+
+class KnownErrorView(web.View):
+
+    @asyncio.coroutine
+    def _respond(self):
+        try:
+            yield
+        except KnownException:
+            pass
+        finally:
+            return web.Response(text='Hello Aiohttp!')
+
+    get = _respond
+    post = _respond
+    put = _respond
+    patch = _respond
+    delete = _respond
+
+
+@asyncio.coroutine
+def websocket_handler(request):
+
+    ws = web.WebSocketResponse()
+    yield from ws.prepare(request)
+
+    # receive messages for all eternity!
+    # (or until the client closes the socket)
+    while not ws.closed:
+        msg = yield from ws.receive()
+        if msg.type == WSMsgType.TEXT:
+            result = ws.send_str('/' + msg.data)
+            if hasattr(result, '__await__'):
+                yield from result.__await__()
+
+    return ws
+
+
+@asyncio.coroutine
+def fetch(method, url, loop):
+    session = ClientSession(loop=loop)
+
+    if hasattr(session, '__aenter__'):
+        yield from session.__aenter__()
+    else:
+        session.__enter__()
+
+    try:
+        _method = getattr(session, method)
+        response = yield from asyncio.wait_for(
+                _method(url), timeout=None, loop=loop)
+        text = yield from response.text()
+
+    finally:
+        if hasattr(session, '__aexit__'):
+            yield from session.__aexit__(*sys.exc_info())
+        else:
+            session.__exit__(*sys.exc_info())
+
+    return text
+
+
+@asyncio.coroutine
+def fetch_multiple(method, loop, url):
+    coros = [fetch(method, url, loop) for _ in range(2)]
+    responses = yield from asyncio.gather(*coros, loop=loop)
+    return '\n'.join(responses)
+
+
+@asyncio.coroutine
+def multi_fetch_handler(request):
+    try:
+        loop = request.loop
+    except AttributeError:
+        loop = request.task._loop
+
+    responses = yield from fetch_multiple('get', loop, request.query['url'])
+    return web.Response(text=responses, content_type='text/html')
+
+
+def make_app(middlewares=None, loop=None):
+    app = web.Application(middlewares=middlewares, loop=loop)
+    app.router.add_route('*', '/coro', index)
+    app.router.add_route('*', '/class', HelloWorldView)
+    app.router.add_route('*', '/error', error)
+    app.router.add_route('*', '/known_error', KnownErrorView)
+    app.router.add_route('*', '/non_500_error', non_500_error)
+    app.router.add_route('*', '/raise_404', raise_404)
+    app.router.add_route('*', '/hang', hang)
+    app.router.add_route('*', '/background', background)
+    app.router.add_route('*', '/ws', websocket_handler)
+    app.router.add_route('*', '/multi_fetch', multi_fetch_handler)
+
+    for route in app.router.routes():
+        handler = route.handler
+
+        # https://github.com/aio-libs/aiohttp-cors/blob/73510a3a9212afd1d3740fd8b2feba63a1dcfe13/aiohttp_cors/urldispatcher_router_adapter.py#L95
+        # Check that this statement passes for all routes
+        # This statement was causing a crash since issubclass would error on
+        # function wrappers
+        isinstance(handler, type) and issubclass(handler, web.View)
+
+    return app
+
+
+if __name__ == '__main__':
+    web.run_app(make_app(), host='127.0.0.1')

--- a/tests/framework_aiohttp/conftest.py
+++ b/tests/framework_aiohttp/conftest.py
@@ -98,12 +98,12 @@ def aiohttp_app(request):
     case.tearDown()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def mock_header_server():
     with MockExternalHTTPHResponseHeadersServer() as _server:
         yield _server
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def mock_external_http_server():    
     response_values = []
 
@@ -119,7 +119,7 @@ def mock_external_http_server():
         yield (server, response_values)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def local_server_info(mock_header_server):
     host_port = '127.0.0.1:%d' % mock_header_server.port
     metric = 'External/%s/aiohttp/' % host_port

--- a/tests/framework_aiohttp/conftest.py
+++ b/tests/framework_aiohttp/conftest.py
@@ -1,0 +1,113 @@
+import sys
+import asyncio
+from collections import namedtuple
+from aiohttp.test_utils import (AioHTTPTestCase,
+        TestClient as _TestClient)
+
+from _target_application import make_app
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+from testing_support.mock_external_http_server import (
+        MockExternalHTTPHResponseHeadersServer)
+
+_coverage_source = [
+    'newrelic.hooks.framework_aiohttp',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (framework_aiohttp)',
+        default_settings=_default_settings)
+
+
+ServerInfo = namedtuple('ServerInfo', ('base_metric', 'url'))
+
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass
+
+
+class SimpleAiohttpApp(AioHTTPTestCase):
+
+    def __init__(self, server_cls, middleware, *args, **kwargs):
+        super(SimpleAiohttpApp, self).__init__(*args, **kwargs)
+        self.server_cls = server_cls
+        self.middleware = None
+        if middleware:
+            self.middleware = [middleware]
+
+    def setUp(self):
+        super(SimpleAiohttpApp, self).setUp()
+        asyncio.set_event_loop(self.loop)
+
+    def get_app(self, *args, **kwargs):
+        return make_app(self.middleware, loop=self.loop)
+
+    @asyncio.coroutine
+    def _get_client(self, app_or_server):
+        """Return a TestClient instance."""
+        client_constructor_arg = app_or_server
+
+        scheme = 'http'
+        host = '127.0.0.1'
+        server_kwargs = {}
+        if self.server_cls:
+            test_server = self.server_cls(app_or_server, scheme=scheme,
+                    host=host, **server_kwargs)
+            client_constructor_arg = test_server
+
+        try:
+            return _TestClient(client_constructor_arg,
+                    loop=self.loop)
+        except TypeError:
+            return _TestClient(client_constructor_arg)
+
+    get_client = _get_client
+
+
+@pytest.fixture()
+def aiohttp_app(request):
+    try:
+        middleware = request.getfixturevalue('middleware')
+    except:
+        middleware = None
+    try:
+        server_cls = request.getfixturevalue('server_cls')
+    except:
+        server_cls = None
+    case = SimpleAiohttpApp(server_cls=server_cls, middleware=middleware)
+    case.setUp()
+    yield case
+    case.tearDown()
+
+
+@pytest.fixture(scope='module')
+def external():
+    external = MockExternalHTTPHResponseHeadersServer()
+    with external:
+        yield external
+
+
+@pytest.fixture(scope='module')
+def local_server_info(external):
+    host_port = '127.0.0.1:%d' % external.port
+    metric = 'External/%s/aiohttp/' % host_port
+    url = 'http://' + host_port
+    return ServerInfo(metric, url)

--- a/tests/framework_aiohttp/test_client.py
+++ b/tests/framework_aiohttp/test_client.py
@@ -1,0 +1,270 @@
+import aiohttp
+import asyncio
+import pytest
+from yarl import URL
+
+from newrelic.api.background_task import background_task
+from newrelic.api.function_trace import function_trace
+from testing_support.fixtures import validate_transaction_metrics
+
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+skipif_aiohttp3 = pytest.mark.skipif(version_info >= (3, 0),
+        reason='This version of aiohttp does not support yield from syntax')
+
+
+@asyncio.coroutine
+def fetch(method, url):
+    with aiohttp.ClientSession() as session:
+        _method = getattr(session, method)
+        response = yield from asyncio.wait_for(_method(url), timeout=None)
+        response.raise_for_status()
+        yield from response.text()
+
+
+@background_task(name='fetch_multiple')
+@asyncio.coroutine
+def fetch_multiple(method, url):
+    coros = [fetch(method, url) for _ in range(2)]
+    return asyncio.gather(*coros, return_exceptions=True)
+
+
+if version_info < (2, 0):
+    _expected_error_class = aiohttp.errors.HttpProcessingError
+else:
+    _expected_error_class = aiohttp.client_exceptions.ClientResponseError
+
+
+def task(loop, method, exc_expected, url):
+    future = asyncio.ensure_future(fetch_multiple(method, url))
+    text_list = loop.run_until_complete(future)
+    if exc_expected:
+        assert isinstance(text_list[0], _expected_error_class)
+        assert isinstance(text_list[1], _expected_error_class)
+    else:
+        assert text_list[0] == text_list[1]
+
+
+test_matrix = (
+    ('get', False),
+    ('post', True),
+    ('options', True),
+    ('head', True),
+    ('put', True),
+    ('patch', True),
+    ('delete', True),
+)
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_yield_from(local_server_info, method, exc_expected):
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+@skipif_aiohttp3
+def test_client_yarl_yield_from(local_server_info):
+    method = 'get'
+
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, False, URL(local_server_info.url))
+
+    task_test()
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_no_txn_yield_from(local_server_info, method, exc_expected):
+
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_throw_yield_from(local_server_info, method, exc_expected):
+
+    class ThrowerException(ValueError):
+        pass
+
+    @background_task(name='test_client_throw_yield_from')
+    @asyncio.coroutine
+    def self_driving_thrower():
+        with aiohttp.ClientSession() as session:
+            coro = session._request(method.upper(), local_server_info.url)
+
+            # activate the coroutine
+            coro.send(None)
+
+            # inject error
+            coro.throw(ThrowerException())
+
+    @validate_transaction_metrics(
+        'test_client_throw_yield_from',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+
+        with pytest.raises(ThrowerException):
+            loop.run_until_complete(self_driving_thrower())
+
+    task_test()
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_close_yield_from(local_server_info, method, exc_expected):
+
+    @background_task(name='test_client_close_yield_from')
+    @asyncio.coroutine
+    def self_driving_closer():
+        with aiohttp.ClientSession() as session:
+            coro = session._request(method.upper(), local_server_info.url)
+
+            # activate the coroutine
+            coro.send(None)
+
+            # force close
+            coro.close()
+
+    @validate_transaction_metrics(
+        'test_client_close_yield_from',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self_driving_closer())
+
+    task_test()
+
+
+test_ws_matrix = (
+    # the 127.0.0.1 server does not accept websocket requests, hence an
+    # exception is expected but a metric will still be created
+    ('ws_connect', True),
+)
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_ws_matrix)
+def test_ws_connect_yield_from(local_server_info, method, exc_expected):
+
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + 'GET', 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + 'GET', 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_create_task_yield_from(local_server_info, method, exc_expected):
+
+    # `loop.create_task` returns a Task object which uses the coroutine's
+    # `send` method, not `__next__`
+
+    @asyncio.coroutine
+    def fetch_task(loop):
+        with aiohttp.ClientSession() as session:
+            coro = getattr(session, method)
+            resp = yield from loop.create_task(coro(local_server_info.url))
+            resp.raise_for_status()
+            yield from resp.text()
+
+    @background_task(name='test_create_task_yield_from')
+    @asyncio.coroutine
+    def fetch_multiple(loop):
+        coros = [fetch_task(loop) for _ in range(2)]
+        return asyncio.gather(*coros, return_exceptions=True)
+
+    @validate_transaction_metrics(
+        'test_create_task_yield_from',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        result = loop.run_until_complete(fetch_multiple(loop))
+        if exc_expected:
+            assert isinstance(result[0], _expected_error_class)
+            assert isinstance(result[1], _expected_error_class)
+        else:
+            assert result[0] == result[1]
+
+    task_test()
+
+
+@skipif_aiohttp3
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_terminal_node_yield_from(local_server_info, method, exc_expected):
+    """
+    This test injects a terminal node into a simple background task workflow.
+    It was added to validate a bug where our coro.send() wrapper would fail
+    when transaction's current node was terminal.
+    """
+
+    def task_test():
+        loop = asyncio.get_event_loop()
+
+        @function_trace(terminal=True)
+        def execute_task():
+            task(loop, method, exc_expected, local_server_info.url)
+
+        execute_task()
+
+    task_test()

--- a/tests/framework_aiohttp/test_client_async_await.py
+++ b/tests/framework_aiohttp/test_client_async_await.py
@@ -1,0 +1,297 @@
+import asyncio
+import aiohttp
+import pytest
+from yarl import URL
+
+from newrelic.api.background_task import background_task
+from newrelic.api.function_trace import function_trace
+from testing_support.fixtures import validate_transaction_metrics
+
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+
+
+async def fetch(method, url):
+    async with aiohttp.ClientSession() as session:
+        _method = getattr(session, method)
+        async with _method(url) as response:
+            response.raise_for_status()
+            return await response.text()
+
+
+@background_task(name='fetch_multiple')
+async def fetch_multiple(method, url):
+    coros = [fetch(method, url) for _ in range(2)]
+    return await asyncio.gather(*coros, return_exceptions=True)
+
+
+if version_info < (2, 0):
+    _expected_error_class = aiohttp.errors.HttpProcessingError
+else:
+    _expected_error_class = aiohttp.client_exceptions.ClientResponseError
+
+
+def task(loop, method, exc_expected, url):
+    text_list = loop.run_until_complete(fetch_multiple(method, url))
+    if exc_expected:
+        assert isinstance(text_list[0],
+                _expected_error_class), text_list[0].__class__
+        assert isinstance(text_list[1],
+                _expected_error_class), text_list[1].__class__
+    else:
+        assert text_list[0] == text_list[1], text_list
+
+
+test_matrix = (
+    ('get', False),
+    ('post', True),
+    ('options', True),
+    ('head', True),
+    ('put', True),
+    ('patch', True),
+    ('delete', True),
+)
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_async_await(local_server_info, method, exc_expected):
+
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+def test_client_yarl_async_await(local_server_info):
+    method = 'get'
+
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, False, URL(local_server_info.url))
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_no_txn_async_await(local_server_info, method, exc_expected):
+
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_throw_async_await(local_server_info, method, exc_expected):
+
+    class ThrowerException(ValueError):
+        pass
+
+    @background_task(name='test_client_throw_async_await')
+    async def self_driving_thrower():
+        async with aiohttp.ClientSession() as session:
+            coro = session._request(method.upper(), local_server_info.url)
+
+            # activate the coroutine
+            coro.send(None)
+
+            # inject error
+            coro.throw(ThrowerException())
+
+    @validate_transaction_metrics(
+        'test_client_throw_async_await',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+
+        with pytest.raises(ThrowerException):
+            loop.run_until_complete(self_driving_thrower())
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_client_close_async_await(local_server_info, method, exc_expected):
+
+    @background_task(name='test_client_close_async_await')
+    async def self_driving_closer():
+        async with aiohttp.ClientSession() as session:
+            coro = session._request(method.upper(), local_server_info.url)
+
+            # activate the coroutine
+            coro.send(None)
+
+            # force close
+            coro.close()
+
+    @validate_transaction_metrics(
+        'test_client_close_async_await',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 1),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self_driving_closer())
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_await_request_async_await(local_server_info, method, exc_expected):
+
+    async def request_with_await():
+        async with aiohttp.ClientSession() as session:
+            coro = session._request(method.upper(), local_server_info.url)
+
+            # force await
+            result = await coro
+            result.raise_for_status()
+            return await result.text()
+
+    @validate_transaction_metrics(
+        'test_await_request_async_await',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    @background_task(name='test_await_request_async_await')
+    def task_test():
+        loop = asyncio.get_event_loop()
+        coros = [request_with_await() for _ in range(2)]
+        future = asyncio.gather(*coros, return_exceptions=True)
+        text_list = loop.run_until_complete(future)
+        if exc_expected:
+            assert isinstance(text_list[0],
+                    _expected_error_class), text_list[0].__class__
+            assert isinstance(text_list[1],
+                    _expected_error_class), text_list[1].__class__
+        else:
+            assert text_list[0] == text_list[1], text_list
+
+    task_test()
+
+
+test_ws_matrix = (
+    # the 127.0.0.1 server does not accept websocket requests, hence an
+    # exception is expected but a metric will still be created
+    ('ws_connect', True),
+)
+
+
+@pytest.mark.parametrize('method,exc_expected', test_ws_matrix)
+def test_ws_connect_async_await(local_server_info, method, exc_expected):
+
+    @validate_transaction_metrics(
+        'fetch_multiple',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + 'GET', 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + 'GET', 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        task(loop, method, exc_expected, local_server_info.url)
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_create_task_async_await(local_server_info, method, exc_expected):
+
+    # `loop.create_task` returns a Task object which uses the coroutine's
+    # `send` method, not `__next__`
+
+    async def fetch_task(loop):
+        async with aiohttp.ClientSession() as session:
+            coro = getattr(session, method)
+            resp = await loop.create_task(coro(local_server_info.url))
+            resp.raise_for_status()
+            return await resp.text()
+
+    @background_task(name='test_create_task_async_await')
+    async def fetch_multiple(loop):
+        coros = [fetch_task(loop) for _ in range(2)]
+        return await asyncio.gather(*coros, return_exceptions=True)
+
+    @validate_transaction_metrics(
+        'test_create_task_async_await',
+        background_task=True,
+        scoped_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+        rollup_metrics=[
+            (local_server_info.base_metric + method.upper(), 2),
+        ],
+    )
+    def task_test():
+        loop = asyncio.get_event_loop()
+        result = loop.run_until_complete(fetch_multiple(loop))
+        if exc_expected:
+            assert isinstance(result[0],
+                    _expected_error_class), result[0].__class__
+            assert isinstance(result[1],
+                    _expected_error_class), result[1].__class__
+        else:
+            assert result[0] == result[1]
+
+    task_test()
+
+
+@pytest.mark.parametrize('method,exc_expected', test_matrix)
+def test_terminal_parent_async_await(local_server_info, method, exc_expected):
+    """
+    This test injects a terminal node into a simple background task workflow.
+    It was added to validate a bug where our coro.send() wrapper would fail
+    when transaction's current node was terminal.
+    """
+
+    def task_test():
+        loop = asyncio.get_event_loop()
+
+        @function_trace(terminal=True)
+        def execute_task():
+            task(loop, method, exc_expected, local_server_info.url)
+
+        execute_task()
+
+    task_test()

--- a/tests/framework_aiohttp/test_client_cat.py
+++ b/tests/framework_aiohttp/test_client_cat.py
@@ -99,7 +99,7 @@ def test_outbound_cross_process_headers(cat_enabled, distributed_tracing,
 
 _nr_key = ExternalTrace.cat_id_key
 _customer_headers_tests = [
-        {'TestHeader': 'Test Data 1'},
+        {'Test-Header': 'Test Data 1'},
         {_nr_key.title(): 'Test Data 2'},
 ]
 

--- a/tests/framework_aiohttp/test_client_cat.py
+++ b/tests/framework_aiohttp/test_client_cat.py
@@ -1,0 +1,249 @@
+import pytest
+import asyncio
+import aiohttp
+
+from newrelic.api.background_task import background_task
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import current_transaction
+
+from testing_support.external_fixtures import (create_incoming_headers,
+        validate_external_node_params, validate_cross_process_headers)
+from testing_support.fixtures import (override_application_settings,
+        validate_transaction_metrics)
+from testing_support.mock_external_http_server import (
+        MockExternalHTTPHResponseHeadersServer, MockExternalHTTPServer)
+
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+
+if version_info < (2, 0):
+    _expected_error_class = aiohttp.errors.HttpProcessingError
+else:
+    _expected_error_class = aiohttp.client_exceptions.ClientResponseError
+
+
+@asyncio.coroutine
+def fetch(url, headers=None, raise_for_status=False, connector=None):
+
+    kwargs = {}
+    if version_info >= (2, 0):
+        kwargs = {'raise_for_status': raise_for_status}
+
+    session = aiohttp.ClientSession(connector=connector, **kwargs)
+    request = session._request('GET', url, headers=headers)
+    headers = {}
+
+    try:
+        response = yield from request
+        if raise_for_status and version_info < (2, 0):
+            response.raise_for_status()
+    except _expected_error_class:
+        return headers
+
+    response_text = yield from response.text()
+    for header in response_text.split('\n'):
+        if not header:
+            continue
+        try:
+            h, v = header.split(':', 1)
+        except ValueError:
+            continue
+        headers[h.strip()] = v.strip()
+    f = session.close()
+    yield from asyncio.ensure_future(f)
+    return headers
+
+
+@pytest.fixture(scope='module')
+def mock_header_server():
+    with MockExternalHTTPHResponseHeadersServer() as _server:
+        yield _server
+
+
+@pytest.mark.parametrize('cat_enabled', (True, False))
+@pytest.mark.parametrize('distributed_tracing', (True, False))
+@pytest.mark.parametrize('span_events', (True, False))
+def test_outbound_cross_process_headers(cat_enabled, distributed_tracing,
+        span_events, mock_header_server):
+
+    @background_task(name='test_outbound_cross_process_headers')
+    @asyncio.coroutine
+    def _test():
+        headers = yield from fetch(
+                'http://127.0.0.1:%d' % mock_header_server.port)
+
+        transaction = current_transaction()
+        transaction._test_request_headers = headers
+
+        if distributed_tracing:
+            assert 'newrelic' in headers
+        elif cat_enabled:
+            assert ExternalTrace.cat_id_key in headers
+            assert ExternalTrace.cat_transaction_key in headers
+        else:
+            assert 'newrelic' not in headers
+            assert ExternalTrace.cat_id_key not in headers
+            assert ExternalTrace.cat_transaction_key not in headers
+
+        def _validate():
+            pass
+
+        if cat_enabled or distributed_tracing:
+            _validate = validate_cross_process_headers(_validate)
+
+        _validate()
+
+    @override_application_settings({
+        'cross_application_tracer.enabled': cat_enabled,
+        'distributed_tracing.enabled': distributed_tracing,
+        'span_events.enabled': span_events,
+    })
+    def test():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_test())
+
+    test()
+
+
+_nr_key = ExternalTrace.cat_id_key
+_customer_headers_tests = [
+        {'TestHeader': 'Test Data 1'},
+        {_nr_key.title(): 'Test Data 2'},
+]
+
+
+@pytest.mark.parametrize('customer_headers', _customer_headers_tests)
+def test_outbound_cross_process_headers_custom_headers(customer_headers,
+        mock_header_server):
+
+    loop = asyncio.get_event_loop()
+    headers = loop.run_until_complete(
+            background_task()(fetch)(
+            'http://127.0.0.1:%d' % mock_header_server.port,
+            customer_headers.copy()))
+
+    # always honor customer headers
+    for expected_header, expected_value in customer_headers.items():
+        assert headers.get(expected_header) == expected_value
+
+
+def test_outbound_cross_process_headers_no_txn(mock_header_server):
+
+    loop = asyncio.get_event_loop()
+    headers = loop.run_until_complete(fetch(
+            'http://127.0.0.1:%d' % mock_header_server.port))
+
+    assert not headers.get(ExternalTrace.cat_id_key)
+    assert not headers.get(ExternalTrace.cat_transaction_key)
+
+
+def test_outbound_cross_process_headers_exception(mock_header_server):
+
+    @background_task(name='test_outbound_cross_process_headers_exception')
+    @asyncio.coroutine
+    def test():
+        # corrupt the transaction object to force an error
+        transaction = current_transaction()
+        guid = transaction.guid
+        delattr(transaction, 'guid')
+
+        try:
+            headers = yield from fetch('http://127.0.0.1:%d' % mock_header_server.port)
+
+            assert not headers.get(ExternalTrace.cat_id_key)
+            assert not headers.get(ExternalTrace.cat_transaction_key)
+        finally:
+            transaction.guid = guid
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(test())
+
+
+class PoorResolvingConnector(aiohttp.TCPConnector):
+    @asyncio.coroutine
+    def _resolve_host(self, host, port, *args, **kwargs):
+        res = [{'hostname': host, 'host': host, 'port': 1234,
+                 'family': self._family, 'proto': 0, 'flags': 0}]
+        hosts = yield from super(PoorResolvingConnector,
+                self)._resolve_host(host, port, *args, **kwargs)
+        for hinfo in hosts:
+            res.append(hinfo)
+        return res
+
+
+@pytest.mark.parametrize('cat_enabled', [True, False])
+@pytest.mark.parametrize('response_code', [200, 404])
+@pytest.mark.parametrize('raise_for_status', [True, False])
+@pytest.mark.parametrize('connector_class',
+        [None, PoorResolvingConnector])  # None will use default
+def test_process_incoming_headers(cat_enabled, response_code,
+        raise_for_status, connector_class):
+
+    # It was discovered via packnsend that the `throw` method of the `_request`
+    # coroutine is used in the case of poorly resolved hosts. An older version
+    # of the instrumentation ended the ExternalTrace anytime `throw` was called
+    # which meant that incoming CAT headers were never processed. The
+    # `PoorResolvingConnector` connector in this test ensures that `throw` is
+    # always called and thus makes sure the trace is not ended before
+    # StopIteration is called.
+
+    _test_cross_process_response_scoped_metrics = [
+            ('ExternalTransaction/127.0.0.1:8990/1#2/test', 1 if cat_enabled
+                else None)]
+
+    _test_cross_process_response_rollup_metrics = [
+            ('External/all', 1),
+            ('External/allOther', 1),
+            ('External/127.0.0.1:8990/all', 1),
+            ('ExternalApp/127.0.0.1:8990/1#2/all', 1 if cat_enabled else None),
+            ('ExternalTransaction/127.0.0.1:8990/1#2/test', 1 if cat_enabled
+                else None)]
+
+    _test_cross_process_response_external_node_params = [
+            ('cross_process_id', '1#2'),
+            ('external_txn_name', 'test'),
+            ('transaction_guid', '0123456789012345')]
+
+    _test_cross_process_response_external_node_forgone_params = [
+            k for k, v in _test_cross_process_response_external_node_params]
+
+    connector = connector_class() if connector_class else None
+
+    @background_task(name='test_process_incoming_headers')
+    @asyncio.coroutine
+    def _test():
+        transaction = current_transaction()
+        headers = create_incoming_headers(transaction)
+
+        def respond_with_cat_header(self):
+            self.send_response(response_code)
+            for header, value in headers:
+                self.send_header(header, value)
+            self.end_headers()
+            self.wfile.write(b'')
+
+        with MockExternalHTTPServer(handler=respond_with_cat_header,
+                port=8990):
+            yield from fetch(
+                    'http://127.0.0.1:8990',
+                    raise_for_status=raise_for_status,
+                    connector=connector)
+
+    @override_application_settings({
+        'cross_application_tracer.enabled': cat_enabled,
+        'distributed_tracing.enabled': False
+    })
+    @validate_transaction_metrics(
+            'test_process_incoming_headers',
+            scoped_metrics=_test_cross_process_response_scoped_metrics,
+            rollup_metrics=_test_cross_process_response_rollup_metrics,
+            background_task=True)
+    @validate_external_node_params(
+            params=(_test_cross_process_response_external_node_params if
+                cat_enabled else []),
+            forgone_params=([] if cat_enabled else
+                _test_cross_process_response_external_node_forgone_params))
+    def test():
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_test())
+
+    test()

--- a/tests/framework_aiohttp/test_externals.py
+++ b/tests/framework_aiohttp/test_externals.py
@@ -1,0 +1,26 @@
+import pytest
+import asyncio
+
+from testing_support.fixtures import (validate_transaction_metrics,
+        validate_tt_parenting)
+
+expected_parenting = (
+    'TransactionNode', [
+        ('FunctionNode', [
+            ('ExternalTrace', []),
+            ('ExternalTrace', []),
+        ]),
+])
+
+
+@validate_tt_parenting(expected_parenting)
+@validate_transaction_metrics('_target_application:multi_fetch_handler',
+        rollup_metrics=[('External/all', 2)])
+def test_multiple_requests_within_transaction(local_server_info, aiohttp_app):
+    @asyncio.coroutine
+    def fetch():
+        resp = yield from aiohttp_app.client.request('GET', '/multi_fetch',
+                params={'url': local_server_info.url})
+        assert resp.status == 200
+
+    aiohttp_app.loop.run_until_complete(fetch())

--- a/tests/framework_aiohttp/test_middleware.py
+++ b/tests/framework_aiohttp/test_middleware.py
@@ -1,0 +1,77 @@
+import pytest
+import asyncio
+import aiohttp
+
+from newrelic.core.config import global_settings
+from testing_support.fixtures import (validate_transaction_metrics,
+        override_generic_settings)
+
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+
+
+@asyncio.coroutine
+def middleware_factory(app, handler):
+
+    @asyncio.coroutine
+    def middleware_handler(request):
+        response = yield from handler(request)
+        return response
+
+    return middleware_handler
+
+
+middleware_tests = [
+    (middleware_factory, 'Function/test_middleware:'
+            'middleware_factory.<locals>.middleware_handler'),
+]
+
+
+if version_info >= (3, 0):
+    @aiohttp.web.middleware
+    @asyncio.coroutine
+    def new_style_middleware(request, handler):
+        response = yield from handler(request)
+        return response
+
+    middleware_tests.append(
+        (new_style_middleware,
+         'Function/test_middleware:new_style_middleware'),
+    )
+
+
+@pytest.mark.parametrize('nr_enabled', [True, False])
+@pytest.mark.parametrize('middleware,metric', middleware_tests)
+def test_middleware(nr_enabled, aiohttp_app, middleware, metric):
+
+    @asyncio.coroutine
+    def fetch():
+        resp = yield from aiohttp_app.client.request('GET', '/coro')
+        assert resp.status == 200
+        text = yield from resp.text()
+        assert "Hello Aiohttp!" in text
+        return resp
+
+    def _test():
+        aiohttp_app.loop.run_until_complete(fetch())
+
+    if nr_enabled:
+        scoped_metrics = [
+            ('Function/_target_application:index', 1),
+            (metric, 1),
+        ]
+
+        rollup_metrics = [
+            ('Function/_target_application:index', 1),
+            (metric, 1),
+            ('Python/Framework/aiohttp/%s' % aiohttp.__version__, 1),
+        ]
+
+        _test = validate_transaction_metrics('_target_application:index',
+                scoped_metrics=scoped_metrics,
+                rollup_metrics=rollup_metrics)(_test)
+    else:
+        settings = global_settings()
+
+        _test = override_generic_settings(settings, {'enabled': False})(_test)
+
+    _test()

--- a/tests/framework_aiohttp/test_server.py
+++ b/tests/framework_aiohttp/test_server.py
@@ -1,0 +1,257 @@
+import pytest
+import asyncio
+import aiohttp
+from newrelic.core.config import global_settings
+
+from testing_support.fixtures import (validate_transaction_metrics,
+        validate_transaction_errors, validate_transaction_event_attributes,
+        count_transactions, override_generic_settings,
+        override_application_settings, override_ignore_status_codes)
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+
+
+BASE_REQUIRED_ATTRS = ['request.headers.contentType',
+            'request.method']
+
+# The agent should not record these attributes in events unless the settings
+# explicitly say to do so
+BASE_FORGONE_ATTRS = ['request.parameters.hello']
+
+
+@pytest.mark.parametrize('nr_enabled', [True, False])
+@pytest.mark.parametrize('method', [
+    'GET',
+    'POST',
+    'PUT',
+    'PATCH',
+    'DELETE',
+])
+@pytest.mark.parametrize('uri,metric_name,error,status', [
+    (
+        '/error?hello=world',
+        '_target_application:error',
+        'builtins:ValueError',
+        500
+    ),
+
+    (
+        '/non_500_error?hello=world',
+        '_target_application:non_500_error',
+        'aiohttp.web_exceptions:HTTPGone',
+        410
+    ),
+
+    (
+        '/raise_404?hello=world',
+        '_target_application:raise_404',
+        None,
+        404
+    ),
+])
+def test_error_exception(method, uri, metric_name, error, status, nr_enabled,
+        aiohttp_app):
+    @asyncio.coroutine
+    def fetch():
+        resp = yield from aiohttp_app.client.request(method,
+                uri, headers={'content-type': 'text/plain'})
+        assert resp.status == status
+
+    required_attrs = list(BASE_REQUIRED_ATTRS)
+    forgone_attrs = list(BASE_FORGONE_ATTRS)
+
+    if nr_enabled:
+        errors = []
+        if error:
+            errors.append(error)
+
+        @validate_transaction_errors(errors=errors)
+        @validate_transaction_metrics(metric_name,
+            scoped_metrics=[
+                ('Function/%s' % metric_name, 1),
+            ],
+            rollup_metrics=[
+                ('Function/%s' % metric_name, 1),
+                ('Python/Framework/aiohttp/%s' % aiohttp.__version__, 1),
+            ],
+        )
+        @validate_transaction_event_attributes(
+            required_params={
+                'agent': required_attrs,
+                'user': [],
+                'intrinsic': [],
+            },
+            forgone_params={
+                'agent': forgone_attrs,
+                'user': [],
+                'intrinsic': [],
+            },
+            exact_attrs={
+                'agent': {
+                    'response.status': str(status),
+                },
+                'user': {},
+                'intrinsic': {},
+            },
+        )
+        @override_ignore_status_codes([404])
+        def _test():
+            aiohttp_app.loop.run_until_complete(fetch())
+    else:
+        settings = global_settings()
+
+        @override_generic_settings(settings, {'enabled': False})
+        def _test():
+            aiohttp_app.loop.run_until_complete(fetch())
+
+    _test()
+
+
+@pytest.mark.parametrize('nr_enabled', [True, False])
+@pytest.mark.parametrize('method', [
+    'GET',
+    'POST',
+    'PUT',
+    'PATCH',
+    'DELETE',
+])
+@pytest.mark.parametrize('uri,metric_name', [
+    ('/coro?hello=world', '_target_application:index'),
+    ('/class?hello=world', '_target_application:HelloWorldView._respond'),
+    ('/known_error?hello=world',
+            '_target_application:KnownErrorView._respond'),
+])
+def test_simultaneous_requests(method, uri, metric_name,
+        nr_enabled, aiohttp_app):
+
+    @asyncio.coroutine
+    def fetch():
+        resp = yield from aiohttp_app.client.request(method, uri,
+                headers={'content-type': 'text/plain'})
+        assert resp.status == 200
+        text = yield from resp.text()
+        assert "Hello Aiohttp!" in text
+        return resp
+
+    @asyncio.coroutine
+    def multi_fetch(loop):
+        coros = [fetch() for i in range(2)]
+        combined = asyncio.gather(*coros, loop=loop)
+        responses = yield from combined
+        return responses
+
+    required_attrs = list(BASE_REQUIRED_ATTRS)
+    extra_required = list(BASE_FORGONE_ATTRS)
+
+    required_attrs.extend(extra_required)
+
+    required_attrs.extend(['response.status',
+            'response.headers.contentType'])
+
+    if nr_enabled:
+        transactions = []
+
+        @override_application_settings({'attributes.include': ['request.*']})
+        @validate_transaction_metrics(metric_name,
+            scoped_metrics=[
+                ('Function/%s' % metric_name, 1),
+            ],
+            rollup_metrics=[
+                ('Function/%s' % metric_name, 1),
+                ('Python/Framework/aiohttp/%s' % aiohttp.__version__, 1),
+            ],
+        )
+        @validate_transaction_event_attributes(
+            required_params={
+                'agent': required_attrs,
+                'user': [],
+                'intrinsic': [],
+            },
+            forgone_params={
+                'agent': [],
+                'user': [],
+                'intrinsic': [],
+            },
+        )
+        @count_transactions(transactions)
+        def _test():
+            aiohttp_app.loop.run_until_complete(multi_fetch(aiohttp_app.loop))
+            assert len(transactions) == 2
+    else:
+        settings = global_settings()
+
+        @override_generic_settings(settings, {'enabled': False})
+        def _test():
+            aiohttp_app.loop.run_until_complete(multi_fetch(aiohttp_app.loop))
+
+    _test()
+
+
+@pytest.mark.parametrize('nr_enabled', [True, False])
+def test_system_response_creates_no_transaction(nr_enabled, aiohttp_app):
+    @asyncio.coroutine
+    def fetch():
+        resp = yield from aiohttp_app.client.request('GET', '/404')
+        assert resp.status == 404
+        return resp
+
+    if nr_enabled:
+        transactions = []
+
+        @count_transactions(transactions)
+        def _test():
+            aiohttp_app.loop.run_until_complete(fetch())
+            assert len(transactions) == 0
+    else:
+        settings = global_settings()
+
+        @override_generic_settings(settings, {'enabled': False})
+        def _test():
+            aiohttp_app.loop.run_until_complete(fetch())
+
+    _test()
+
+
+def test_aborted_connection_creates_transaction(aiohttp_app):
+    @asyncio.coroutine
+    def fetch():
+        try:
+            yield from aiohttp_app.client.request('GET', '/hang', timeout=0.1)
+        except asyncio.TimeoutError:
+            try:
+                # Force the client to disconnect (while the server is hanging)
+                yield from aiohttp_app.client.close()
+            # In aiohttp 1.X, this can result in a CancelledError being raised
+            except asyncio.CancelledError:
+                pass
+            yield
+            return
+
+        assert False, "Request did not time out"
+
+    transactions = []
+
+    @count_transactions(transactions)
+    def _test():
+        aiohttp_app.loop.run_until_complete(fetch())
+        assert len(transactions) == 1
+
+    _test()
+
+
+def test_work_after_request_not_recorded(aiohttp_app):
+    resp = aiohttp_app.loop.run_until_complete(
+            aiohttp_app.client.request('GET', '/background'))
+    assert resp.status == 200
+
+    @asyncio.coroutine
+    def timeout():
+        yield from asyncio.sleep(1)
+        aiohttp_app.loop.stop()
+        assert False
+
+    task = aiohttp_app.loop.create_task(timeout())
+    aiohttp_app.loop.run_forever()
+
+    # Check that the timeout didn't fire
+    assert not task.done()
+    task.cancel()

--- a/tests/framework_aiohttp/test_server_cat.py
+++ b/tests/framework_aiohttp/test_server_cat.py
@@ -1,0 +1,202 @@
+import asyncio
+import json
+import pytest
+
+from newrelic.common.object_wrapper import transient_function_wrapper
+from newrelic.common.encoding_utils import deobfuscate
+from testing_support.fixtures import (override_application_settings,
+    make_cross_agent_headers, validate_analytics_catmap_data,
+    validate_transaction_event_attributes)
+
+ENCODING_KEY = '1234567890123456789012345678901234567890'
+test_uris = [
+    ('/error?hello=world', '_target_application:error'),
+    ('/coro?hello=world', '_target_application:index'),
+    ('/class?hello=world', '_target_application:HelloWorldView._respond'),
+]
+
+
+def record_aiohttp1_raw_headers(raw_headers):
+    try:
+        import aiohttp.protocol
+    except ImportError:
+        def pass_through(function):
+            return function
+        return pass_through
+
+    @transient_function_wrapper('aiohttp.protocol', 'HttpParser.parse_headers')
+    def recorder(wrapped, instance, args, kwargs):
+        def _bind_params(lines):
+            return lines
+
+        lines = _bind_params(*args, **kwargs)
+        for line in lines:
+            line = line.decode('utf-8')
+
+            # This is the request, not the response
+            if line.startswith('GET'):
+                break
+
+            if ':' in line:
+                key, value = line.split(':', maxsplit=1)
+                raw_headers[key.strip()] = value.strip()
+
+        return wrapped(*args, **kwargs)
+
+    return recorder
+
+
+@pytest.mark.parametrize(
+    'inbound_payload,expected_intrinsics,forgone_intrinsics,cat_id', [
+
+    # Valid payload from trusted account
+    (["b854df4feb2b1f06", False, "7e249074f277923d", "5d2957be"],
+    {"nr.referringTransactionGuid": "b854df4feb2b1f06",
+    "nr.tripId": "7e249074f277923d",
+    "nr.referringPathHash": "5d2957be"},
+    [],
+    '1#1'),
+
+    # Valid payload from an untrusted account
+    (["b854df4feb2b1f06", False, "7e249074f277923d", "5d2957be"],
+    {},
+    ['nr.referringTransactionGuid', 'nr.tripId', 'nr.referringPathHash'],
+    '80#1'),
+])
+@pytest.mark.parametrize('method', ['GET'])
+@pytest.mark.parametrize('uri,metric_name', test_uris)
+def test_cat_headers(method, uri, metric_name, inbound_payload,
+        expected_intrinsics, forgone_intrinsics, cat_id, aiohttp_app):
+
+    _raw_headers = {}
+
+    @asyncio.coroutine
+    def fetch():
+        headers = make_cross_agent_headers(inbound_payload, ENCODING_KEY,
+                cat_id)
+        resp = yield from aiohttp_app.client.request(method, uri,
+                headers=headers)
+
+        if _raw_headers:
+            raw_headers = _raw_headers
+        else:
+            raw_headers = {k.decode('utf-8'): v.decode('utf-8')
+                    for k, v in resp.raw_headers}
+
+        if expected_intrinsics:
+            # test valid CAT response header
+            assert 'X-NewRelic-App-Data' in raw_headers
+
+            app_data = json.loads(deobfuscate(
+                    raw_headers['X-NewRelic-App-Data'], ENCODING_KEY))
+            assert app_data[0] == cat_id
+            assert app_data[1] == ('WebTransaction/Function/%s' % metric_name)
+        else:
+            assert 'X-NewRelic-App-Data' not in resp.headers
+
+    _custom_settings = {
+            'cross_process_id': '1#1',
+            'encoding_key': ENCODING_KEY,
+            'trusted_account_ids': [1],
+            'cross_application_tracer.enabled': True,
+            'distributed_tracing.enabled': False,
+    }
+
+    # NOTE: the logic-flow of this test can be a bit confusing.
+    #       the override settings and attribute validation occur
+    #       not when the request is made (above) since it does not
+    #       occur inside a transaction. instead, the settings and
+    #       validation are for the new transaction that is made
+    #       asynchronously on the *server side* when the request
+    #       is received and subsequently processed. that code is
+    #       a fixture from conftest.py/_target_application.py
+
+    @validate_analytics_catmap_data('WebTransaction/Function/%s' % metric_name,
+            expected_attributes=expected_intrinsics,
+            non_expected_attributes=forgone_intrinsics)
+    @override_application_settings(_custom_settings)
+    @record_aiohttp1_raw_headers(_raw_headers)
+    def _test():
+        aiohttp_app.loop.run_until_complete(fetch())
+
+    _test()
+
+
+account_id = '33'
+primary_application_id = '2827902'
+
+inbound_payload = {
+    "v": [0, 1],
+    "d": {
+        "ac": account_id,
+        "ap": primary_application_id,
+        "id": "7d3efb1b173fecfa",
+        "tx": "e8b91a159289ff74",
+        "pr": 1.234567,
+        "sa": True,
+        "ti": 1518469636035,
+        "tr": "d6b4ba0c3a712ca",
+        "ty": "App"
+    }
+}
+
+expected_attributes = {
+    'agent': [],
+    'user': [],
+    'intrinsic': {
+        "traceId": "d6b4ba0c3a712ca",
+        "priority": 1.234567,
+        "sampled": True,
+        "parent.type": "App",
+        "parent.app": primary_application_id,
+        "parent.account": account_id,
+        "parent.transportType": "HTTP",
+        "parentId": "e8b91a159289ff74",
+        "parentSpanId": "7d3efb1b173fecfa"
+    }
+}
+
+unexpected_attributes = {
+    'agent': [],
+    'user': [],
+    'intrinsic': [
+        "grandparentId", "cross_process_id", "nr.tripId", "nr.pathHash"
+    ]
+}
+
+
+@pytest.mark.parametrize('uri,metric_name', test_uris)
+def test_distributed_tracing_headers(uri, metric_name, aiohttp_app):
+    @asyncio.coroutine
+    def fetch():
+        headers = {'newrelic': json.dumps(inbound_payload)}
+        resp = yield from aiohttp_app.client.request('GET', uri,
+                headers=headers)
+
+        # better cat does not send a response in the headers
+        assert 'newrelic' not in resp.headers
+
+        # old-cat headers should not be in the response
+        assert 'X-NewRelic-App-Data' not in resp.headers
+
+    # NOTE: the logic-flow of this test can be a bit confusing.
+    #       the override settings and attribute validation occur
+    #       not when the request is made (above) since it does not
+    #       occur inside a transaction. instead, the settings and
+    #       validation are for the new transaction that is made
+    #       asynchronously on the *server side* when the request
+    #       is received and subsequently processed. that code is
+    #       a fixture from conftest.py/_target_application.py
+
+    @validate_transaction_event_attributes(
+        expected_attributes, unexpected_attributes)
+    @override_application_settings({
+        'account_id': '33',
+        'trusted_account_key': '33',
+        'primary_application_id': primary_application_id,
+        'distributed_tracing.enabled': True
+    })
+    def _test():
+        aiohttp_app.loop.run_until_complete(fetch())
+
+    _test()

--- a/tests/framework_aiohttp/test_ws.py
+++ b/tests/framework_aiohttp/test_ws.py
@@ -1,0 +1,25 @@
+import asyncio
+import aiohttp
+from testing_support.fixtures import function_not_called
+
+version_info = tuple(int(_) for _ in aiohttp.__version__.split('.')[:2])
+
+
+@function_not_called('newrelic.core.stats_engine',
+            'StatsEngine.record_transaction')
+def test_websocket(aiohttp_app):
+    @asyncio.coroutine
+    def ws_write():
+        ws = yield from aiohttp_app.client.ws_connect('/ws')
+        try:
+            for _ in range(2):
+                result = ws.send_str('Hello')
+                if hasattr(result, '__await__'):
+                    yield from result.__await__()
+                msg = yield from ws.receive()
+                assert msg.data == '/Hello'
+        finally:
+            yield from ws.close(code=1000)
+            assert ws.close_code == 1000
+
+    aiohttp_app.loop.run_until_complete(ws_write())

--- a/tests/framework_aiohttp/tox.ini
+++ b/tests/framework_aiohttp/tox.ini
@@ -1,34 +1,35 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py35,py36}-aiohttp{1,22,2}-{with,without}-extensions,
-    {py35,py36,py37}-aiohttp34-{with,without}-extensions,
-    {py35,py36,py37,py38,py39}-aiohttp3-{with,without}-extensions,
-    pypy3-aiohttp3-without-extensions,
-
-[jenkins]
-max_group_size = 7
+    {py35,py36}-aiohttp{01,0202,02},
+    {py35,py36,py37}-aiohttp0304,
+    {py35,py36,py37,py38,py39,pypy3}-aiohttp03
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
 
 [testenv]
 deps =
-    aiohttp1: multidict<3
-    aiohttp22: multidict<3
+    aiohttp01: multidict<3
+    aiohttp0202: multidict<3
 
-    aiohttp22: yarl<0.13
+    aiohttp0202: yarl<0.13
 
-    aiohttp1: aiohttp<2
-    aiohttp22: aiohttp<2.3
-    aiohttp2: aiohttp<3
-    aiohttp34: aiohttp<3.5
-    aiohttp3: aiohttp<4
+    aiohttp01: aiohttp<2
+    aiohttp0202: aiohttp<2.3
+    aiohttp02: aiohttp<3
+    aiohttp0304: aiohttp<3.5
+    aiohttp03: aiohttp<4
+    
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
+
 commands = py.test -v []
 
 install_command=

--- a/tests/framework_aiohttp/tox.ini
+++ b/tests/framework_aiohttp/tox.ini
@@ -1,0 +1,35 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py35,py36}-aiohttp{1,22,2}-{with,without}-extensions,
+    {py35,py36,py37}-aiohttp34-{with,without}-extensions,
+    {py35,py36,py37,py38,py39}-aiohttp3-{with,without}-extensions,
+    pypy3-aiohttp3-without-extensions,
+
+[jenkins]
+max_group_size = 7
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    aiohttp1: multidict<3
+    aiohttp22: multidict<3
+
+    aiohttp22: yarl<0.13
+
+    aiohttp1: aiohttp<2
+    aiohttp22: aiohttp<2.3
+    aiohttp2: aiohttp<3
+    aiohttp34: aiohttp<3.5
+    aiohttp3: aiohttp<4
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}

--- a/tests/framework_tornado/test_externals.py
+++ b/tests/framework_tornado/test_externals.py
@@ -28,15 +28,6 @@ def external():
         yield external
 
 
-def _get_open_port():
-    # https://stackoverflow.com/questions/2838244/get-open-tcp-port-in-python/2838309#2838309
-    s = socket.socket()
-    s.bind(('', 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
 @background_task(name='make_request')
 def make_request(port, req_type, client_cls, count=1, raise_error=True,
         as_kwargs=True, **kwargs):
@@ -222,8 +213,7 @@ def cat_response_handler(self):
 
 @pytest.fixture(scope='module')
 def cat_response_server():
-    port = _get_open_port()
-    external = MockExternalHTTPServer(handler=cat_response_handler, port=port)
+    external = MockExternalHTTPServer(handler=cat_response_handler)
     with external:
         yield external
 

--- a/tests/testing_support/external_fixtures.py
+++ b/tests/testing_support/external_fixtures.py
@@ -13,7 +13,186 @@
 # limitations under the License.
 
 from newrelic.api.external_trace import ExternalTrace
-from newrelic.common.object_wrapper import transient_function_wrapper
+from newrelic.api.transaction import current_transaction
+from newrelic.common.encoding_utils import (json_encode, json_decode,
+    obfuscate, deobfuscate, DistributedTracePayload)
+from newrelic.common.object_wrapper import (transient_function_wrapper,
+        function_wrapper)
+
+OUTBOUND_TRACE_KEYS_REQUIRED = (
+        'ty', 'ac', 'ap', 'tr', 'pr', 'sa', 'ti')
+
+
+
+def validate_outbound_headers(header_id='X-NewRelic-ID',
+        header_transaction='X-NewRelic-Transaction'):
+    transaction = current_transaction()
+    headers = transaction._test_request_headers
+    settings = transaction.settings
+    encoding_key = settings.encoding_key
+
+    assert header_id in headers
+
+    values = headers[header_id]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    cross_process_id = deobfuscate(value, encoding_key)
+    assert cross_process_id == settings.cross_process_id
+
+    assert header_transaction in headers
+
+    values = headers[header_transaction]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    (guid, record_tt, trip_id, path_hash) = \
+            json_decode(deobfuscate(value, encoding_key))
+
+    assert guid == transaction.guid
+    assert record_tt == transaction.record_tt
+    assert trip_id == transaction.trip_id
+    assert path_hash == transaction.path_hash
+
+
+def validate_distributed_tracing_header(header='newrelic'):
+    transaction = current_transaction()
+    headers = transaction._test_request_headers
+    account_id = transaction.settings.account_id
+    application_id = transaction.settings.primary_application_id
+
+    assert header in headers, headers
+
+    values = headers[header]
+    if isinstance(values, list):
+        assert len(values) == 1, headers
+        assert isinstance(values[0], type(''))
+        value = values[0]
+    else:
+        value = values
+
+    # Parse payload
+    payload = DistributedTracePayload.from_http_safe(value)
+
+    # Distributed Tracing v0.1 is currently implemented
+    assert payload['v'] == [0, 1], payload['v']
+
+    data = payload['d']
+
+    # Verify all required keys are present
+    assert all(k in data for k in OUTBOUND_TRACE_KEYS_REQUIRED)
+
+    # Type will always be App (not mobile / browser)
+    assert data['ty'] == 'App'
+
+    # Verify account/app id
+    assert data['ac'] == account_id
+    assert data['ap'] == application_id
+
+    # Verify data belonging to this transaction
+    assert data['tx'] == transaction.guid
+
+    # If span events are enabled, id should be sent
+    # otherwise, id should be omitted
+    if transaction.settings.span_events.enabled:
+        assert 'id' in data
+    else:
+        assert 'id' not in data
+
+    # Verify referring transaction information
+    assert len(data['tr']) == 32
+    if transaction.referring_transaction_guid is not None:
+        assert data['tr'] == transaction._trace_id
+    else:
+        assert data['tr'].startswith(transaction.guid)
+
+    assert 'pa' not in data
+
+    # Verify timestamp is an integer
+    assert isinstance(data['ti'], int)
+
+    # Verify that priority is a float
+    assert isinstance(data['pr'], float)
+
+
+@function_wrapper
+def validate_cross_process_headers(wrapped, instance, args, kwargs):
+    result = wrapped(*args, **kwargs)
+
+    transaction = current_transaction()
+    settings = transaction.settings
+
+    if settings.distributed_tracing.enabled:
+        validate_distributed_tracing_header()
+    else:
+        validate_outbound_headers()
+
+    return result
+
+def create_incoming_headers(transaction):
+    settings = transaction.settings
+    encoding_key = settings.encoding_key
+
+    headers = []
+
+    cross_process_id = '1#2'
+    path = 'test'
+    queue_time = 1.0
+    duration = 2.0
+    read_length = 1024
+    guid = '0123456789012345'
+    record_tt = False
+
+    payload = (cross_process_id, path, queue_time, duration, read_length,
+            guid, record_tt)
+    app_data = json_encode(payload)
+
+    value = obfuscate(app_data, encoding_key)
+
+    assert isinstance(value, type(''))
+
+    headers.append(('X-NewRelic-App-Data', value))
+
+    return headers
+
+
+def validate_external_node_params(params=[], forgone_params=[]):
+    """
+    Validate the parameters on the external node.
+
+    params: a list of tuples
+    forgone_params: a flat list
+    """
+    @transient_function_wrapper('newrelic.api.external_trace',
+            'ExternalTrace.process_response_headers')
+    def _validate_external_node_params(wrapped, instance, args, kwargs):
+        result = wrapped(*args, **kwargs)
+
+        # This is only validating that logic to extract cross process
+        # header and update params in ExternalTrace is succeeding. This
+        # is actually done after the ExternalTrace __exit__() is called
+        # with the ExternalNode only being updated by virtue of the
+        # original params dictionary being aliased rather than copied.
+        # So isn't strictly validating that params ended up in the actual
+        # ExternalNode in the transaction trace.
+
+        for name, value in params:
+            assert instance.params[name] == value
+
+        for name in forgone_params:
+            assert name not in instance.params
+
+        return result
+
+    return _validate_external_node_params
 
 
 def validate_synthetics_external_trace_header(required_header=(),

--- a/tests/testing_support/external_fixtures.py
+++ b/tests/testing_support/external_fixtures.py
@@ -23,7 +23,6 @@ OUTBOUND_TRACE_KEYS_REQUIRED = (
         'ty', 'ac', 'ap', 'tr', 'pr', 'sa', 'ti')
 
 
-
 def validate_outbound_headers(header_id='X-NewRelic-ID',
         header_transaction='X-NewRelic-Transaction'):
     transaction = current_transaction()

--- a/tests/testing_support/mock_external_http_server.py
+++ b/tests/testing_support/mock_external_http_server.py
@@ -49,21 +49,26 @@ class MockExternalHTTPServer(threading.Thread):
                 (BaseHTTPServer.BaseHTTPRequestHandler, object,),
                 {'do_GET': handler})
 
-        # If port not set, try to bind to a port until successful
-        retries = 5  # Set retry limit to prevent infinite loops
-        while not port and retries > 0:
-            retries -= 1
-            try:
-                # Obtain random open port
-                port = self.get_open_port()
-                # Attempt to bind to port
-                self.httpd = BaseHTTPServer.HTTPServer(('localhost', port), handler)
-            except OSError as exc:
-                # Reraise errors other than port already in use
-                if "Address already in use" not in exc:
-                    raise
+        if port:
+            self.httpd = BaseHTTPServer.HTTPServer(('localhost', port), handler)
+            self.port = port
+        else:
+            # If port not set, try to bind to a port until successful
+            retries = 5  # Set retry limit to prevent infinite loops
+            self.port = None  # Initialize empty
+            while not self.port and retries > 0:
+                retries -= 1
+                try:
+                    # Obtain random open port
+                    port = self.get_open_port()
+                    # Attempt to bind to port
+                    self.httpd = BaseHTTPServer.HTTPServer(('localhost', port), handler)
+                    self.port = port
+                except OSError as exc:
+                    # Reraise errors other than port already in use
+                    if "Address already in use" not in exc:
+                        raise
 
-        self.port = port
 
     @staticmethod
     def get_open_port():

--- a/tests/testing_support/mock_external_http_server.py
+++ b/tests/testing_support/mock_external_http_server.py
@@ -44,13 +44,26 @@ class MockExternalHTTPServer(threading.Thread):
 
     def __init__(self, handler=simple_get, port=None, *args, **kwargs):
         super(MockExternalHTTPServer, self).__init__(*args, **kwargs)
-        self.port = port or self.get_open_port()
+        self.daemon = True
         handler = type('ResponseHandler',
                 (BaseHTTPServer.BaseHTTPRequestHandler, object,),
                 {'do_GET': handler})
-        self.httpd = BaseHTTPServer.HTTPServer(('localhost', self.port),
-                handler)
-        self.daemon = True
+
+        # If port not set, try to bind to a port until successful
+        retries = 5  # Set retry limit to prevent infinite loops
+        while not port and retries > 0:
+            retries -= 1
+            try:
+                # Obtain random open port
+                port = self.get_open_port()
+                # Attempt to bind to port
+                self.httpd = BaseHTTPServer.HTTPServer(('localhost', port), handler)
+            except OSError as exc:
+                # Reraise errors other than port already in use
+                if "Address already in use" not in exc:
+                    raise
+
+        self.port = port
 
     @staticmethod
     def get_open_port():


### PR DESCRIPTION
Sidekick: @a-feld 

# Overview
* Porting aiohttp tests from internal repo.
* Cleans up test language.
* Upgrades `MockExternalHttpServer` (and subclasses) to bind to a random open port when unspecified, with retrying.
* Tweak tornado tests using above class to utilize new functionality.

# Related Github Issue

PYTHON-3821

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
