### PR TITLE
PYTHON-3788 bmemcached Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,16 +234,109 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+      redis:
         image: redis
-        env:
-          POSTGRES_PASSWORD: redis
         ports:
           - 8080:6379
           - 8081:6379
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y-%m-%d")"
+      shell: bash
+
+    - name: Cache Tox and Pip (Linux)
+      if: startsWith(runner.os, 'Linux')
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.test-directory }}-${{ hashFiles('tests/${{ matrix.test-directory }}/tox.ini', 'tests/base_requirements.txt') }}-${{ steps.get-date.outputs.date }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.test-directory }}-${{ hashFiles('tests/${{ matrix.test-directory }}/tox.ini', 'tests/base_requirements.txt') }}-
+          ${{ runner.os }}-${{ matrix.test-directory }}-
+
+    # Set up all versions of python
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy3
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -U wheel setuptools tox virtualenv!=20.0.24
+
+    - name: Test
+      run: |
+        tox -vv -p auto -c tests/${{ matrix.test-directory }}/tox.ini
+      env:
+        TOX_PARALLEL_NO_SPINNER: 1
+        PY_COLORS: 0
+
+  memcached:
+
+    strategy:
+      matrix:
+        test-directory: 
+          - datastore_bmemcached
+
+    runs-on: ubuntu-latest
+
+    services:
+      memcached:
+        image: memcached
+        ports:
+          - 8080:11211
+          - 8081:11211
+        # Set health checks to wait until memcached has started
+        options: >-
+          --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/tests/datastore_bmemcached/conftest.py
+++ b/tests/datastore_bmemcached/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.api.memcache_trace',
+    'newrelic.hooks.datastore_bmemcached',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_bmemcached)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/datastore_bmemcached/test_memcache.py
+++ b/tests/datastore_bmemcached/test_memcache.py
@@ -1,14 +1,15 @@
 import os
+from testing_support.db_settings import memcached_settings
 import bmemcached
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import set_background_task
 
 from testing_support.fixtures import validate_transaction_metrics
+from testing_support.db_settings import memcached_settings
 
 
-def _e(key, default):
-    return os.environ.get(key, default)
+DB_SETTINGS = memcached_settings()[0]
 
 MEMCACHED_HOST = DB_SETTINGS['host']
 MEMCACHED_PORT = DB_SETTINGS['port']

--- a/tests/datastore_bmemcached/test_memcache.py
+++ b/tests/datastore_bmemcached/test_memcache.py
@@ -1,0 +1,80 @@
+import os
+import bmemcached
+
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import set_background_task
+
+from testing_support.fixtures import validate_transaction_metrics
+
+
+def _e(key, default):
+    return os.environ.get(key, default)
+
+MEMCACHED_HOST = DB_SETTINGS['host']
+MEMCACHED_PORT = DB_SETTINGS['port']
+MEMCACHED_NAMESPACE = str(os.getpid())
+MEMCACHED_ADDR = '%s:%s' % (MEMCACHED_HOST, MEMCACHED_PORT)
+
+_test_bt_set_get_delete_scoped_metrics = [
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_test_bt_set_get_delete_rollup_metrics = [
+        ('Datastore/all', 3),
+        ('Datastore/allOther', 3),
+        ('Datastore/Memcached/all', 3),
+        ('Datastore/Memcached/allOther', 3),
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+@validate_transaction_metrics(
+        'test_memcache:test_bt_set_get_delete',
+        scoped_metrics=_test_bt_set_get_delete_scoped_metrics,
+        rollup_metrics=_test_bt_set_get_delete_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_bt_set_get_delete():
+    set_background_task(True)
+    client = bmemcached.Client([MEMCACHED_ADDR])
+
+    key = MEMCACHED_NAMESPACE + 'key'
+
+    client.set(key, 'value')
+    value = client.get(key)
+    client.delete(key)
+
+    assert value == 'value'
+
+_test_wt_set_get_delete_scoped_metrics = [
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_test_wt_set_get_delete_rollup_metrics = [
+        ('Datastore/all', 3),
+        ('Datastore/allWeb', 3),
+        ('Datastore/Memcached/all', 3),
+        ('Datastore/Memcached/allWeb', 3),
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+@validate_transaction_metrics(
+        'test_memcache:test_wt_set_get_delete',
+        scoped_metrics=_test_wt_set_get_delete_scoped_metrics,
+        rollup_metrics=_test_wt_set_get_delete_rollup_metrics,
+        background_task=False)
+@background_task()
+def test_wt_set_get_delete():
+    set_background_task(False)
+    client = bmemcached.Client([MEMCACHED_ADDR])
+
+    key = MEMCACHED_NAMESPACE + 'key'
+
+    client.set(key, 'value')
+    value = client.get(key)
+    client.delete(key)
+
+    assert value == 'value'

--- a/tests/datastore_bmemcached/tox.ini
+++ b/tests/datastore_bmemcached/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
+    pypy-without-extensions,
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    python-binary-memcached<0.27
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/datastore_bmemcached/tox.ini
+++ b/tests/datastore_bmemcached/tox.ini
@@ -1,23 +1,25 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
-    pypy-without-extensions,
+    {pypy,py27,py35,py36,py37,py38,py39}-memcached030
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
 
 [testenv]
 deps =
-    python-binary-memcached<0.27
+    memcached030: python-binary-memcached<0.31
+
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 
 install_command=
     pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
-

--- a/tests/testing_support/db_settings.py
+++ b/tests/testing_support/db_settings.py
@@ -66,3 +66,31 @@ def redis_settings():
         for instance_num in range(instances)
     ]
     return settings
+
+
+def memcached_settings():
+    """Return a list of dict of settings for connecting to memcached.
+
+    Will return the correct settings, depending on which of the environments it
+    is running in. It attempts to set variables in the following order, where
+    later environments override earlier ones.
+
+        1. Local
+        2. Github Actions
+    """
+
+    if "GITHUB_ACTIONS" in os.environ:
+        instances = 2
+        base_port = 8080
+    else:
+        instances = 1
+        base_port = 11211
+
+    settings = [
+        {
+            "host": "localhost",
+            "port": base_port + instance_num,
+        }
+        for instance_num in range(instances)
+    ]
+    return settings


### PR DESCRIPTION
Sidekick: @umaannamalai 

# Overview

* Added memcached based testing workflow
* Imported bmemcached tests from internal repo
* Overhauled memcached settings from tddium
* Upgraded memcached tested version to latest

# Related Github Issue

PYTHON-3788

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
