### PR TITLE
PYTHON-3790 memcache Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -328,6 +328,7 @@ jobs:
       matrix:
         test-directory: 
           - datastore_bmemcached
+          - datastore_memcache
 
     runs-on: ubuntu-latest
 

--- a/tests/datastore_memcache/conftest.py
+++ b/tests/datastore_memcache/conftest.py
@@ -1,0 +1,71 @@
+import random
+import string
+import pytest
+import memcache
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+from testing_support.db_settings import memcached_settings
+
+_coverage_source = [
+    'newrelic.api.memcache_trace',
+    'newrelic.hooks.datastore_memcache',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_memcache)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass
+
+@pytest.fixture(scope='session')
+def memcached_multi():
+    """Generate keys that will go onto different servers"""
+    DB_SETTINGS = memcached_settings()
+    db_servers = ['%s:%s' % (s['host'], s['port']) for s in DB_SETTINGS]
+
+    clients = [memcache.Client([s]) for s in db_servers]
+    client_all = memcache.Client(db_servers)
+    num_servers = len(db_servers)
+
+    for try_num in range(10 * num_servers):
+        multi_dict = {}
+        for i in range(num_servers):
+            random_chars = (random.choice(string.ascii_uppercase)
+                    for _ in range(10))
+            key_candidate = ''.join(random_chars)
+            multi_dict[key_candidate] = key_candidate
+
+        client_all.set_multi(multi_dict)
+
+        server_hit = [False] * num_servers
+
+        for key in multi_dict.keys():
+            for i in range(num_servers):
+                if clients[i].get(key):
+                    server_hit[i] = True
+
+        if all(server_hit):
+            break
+    else:
+        assert False, "memcached_multi failed to map keys to multiple servers."
+
+    return multi_dict

--- a/tests/datastore_memcache/test_all_methods_wrapped.py
+++ b/tests/datastore_memcache/test_all_methods_wrapped.py
@@ -1,0 +1,13 @@
+import memcache
+from newrelic.hooks.datastore_memcache import (_memcache_client_methods,
+        _memcache_multi_methods)
+
+def test_all_methods_wrapped():
+    client = memcache.Client([])
+
+    all_methods = (list(_memcache_client_methods) +
+            list(_memcache_multi_methods))
+
+    for m in all_methods:
+        method = getattr(client, m)
+        assert hasattr(method, '__wrapped__')

--- a/tests/datastore_memcache/test_memcache.py
+++ b/tests/datastore_memcache/test_memcache.py
@@ -1,0 +1,99 @@
+import memcache
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    override_application_settings)
+from testing_support.db_settings import memcached_settings
+from testing_support.util import instance_hostname
+
+from newrelic.api.background_task import background_task
+from newrelic.common.object_wrapper import wrap_function_wrapper
+
+DB_SETTINGS = memcached_settings()[0]
+MEMCACHED_ADDR = '%s:%s' % (DB_SETTINGS['host'], DB_SETTINGS['port'])
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+}
+
+# Metrics
+
+_base_scoped_metrics = [
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_base_rollup_metrics = [
+        ('Datastore/all', 3),
+        ('Datastore/allOther', 3),
+        ('Datastore/Memcached/all', 3),
+        ('Datastore/Memcached/allOther', 3),
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_disable_scoped_metrics = list(_base_scoped_metrics)
+_disable_rollup_metrics = list(_base_rollup_metrics)
+
+_enable_scoped_metrics = list(_base_scoped_metrics)
+_enable_rollup_metrics = list(_base_rollup_metrics)
+
+_host = instance_hostname(DB_SETTINGS['host'])
+_port = DB_SETTINGS['port']
+
+_instance_metric_name = 'Datastore/instance/Memcached/%s/%s' % (_host, _port)
+
+_enable_rollup_metrics.append(
+        (_instance_metric_name, 3)
+)
+
+_disable_rollup_metrics.append(
+        (_instance_metric_name, None)
+)
+
+# Query
+
+def _exercise_db(client):
+    key = DB_SETTINGS['namespace'] + 'key'
+    client.set(key, 'value')
+    value = client.get(key)
+    client.delete(key)
+    assert value == 'value'
+
+# Tests
+
+@override_application_settings(_enable_instance_settings)
+@validate_transaction_metrics(
+        'test_memcache:test_set_get_delete_enable',
+        scoped_metrics=_enable_scoped_metrics,
+        rollup_metrics=_enable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_set_get_delete_enable():
+    client = memcache.Client([MEMCACHED_ADDR])
+    _exercise_db(client)
+
+@override_application_settings(_disable_instance_settings)
+@validate_transaction_metrics(
+        'test_memcache:test_set_get_delete_disable',
+        scoped_metrics=_disable_scoped_metrics,
+        rollup_metrics=_disable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_set_get_delete_disable():
+    instance_info_called = [False]
+
+    def check_instance_info_call(wrapped, instance, args, kwargs):
+        instance_info_called[0] = True
+
+        return wrapped(*args, **kwargs)
+
+    wrap_function_wrapper('newrelic.hooks.datastore_memcache',
+            '_instance_info', check_instance_info_call)
+    client = memcache.Client([MEMCACHED_ADDR])
+    _exercise_db(client)
+    assert not instance_info_called[0], "memcached _instance_info was called"

--- a/tests/datastore_memcache/test_multiple_dbs.py
+++ b/tests/datastore_memcache/test_multiple_dbs.py
@@ -1,0 +1,109 @@
+import pytest
+import memcache
+
+from newrelic.api.background_task import background_task
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    override_application_settings)
+from testing_support.db_settings import memcached_settings
+from testing_support.util import instance_hostname
+
+DB_MULTIPLE_SETTINGS = memcached_settings()
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+}
+
+# Metrics
+
+_base_scoped_metrics = (
+    ('Datastore/operation/Memcached/get_multi', 1),
+    ('Datastore/operation/Memcached/set_multi', 1),
+)
+
+_base_rollup_metrics = (
+    ('Datastore/all', 2),
+    ('Datastore/allOther', 2),
+    ('Datastore/Memcached/all', 2),
+    ('Datastore/Memcached/allOther', 2),
+    ('Datastore/operation/Memcached/set_multi', 1),
+    ('Datastore/operation/Memcached/get_multi', 1),
+)
+
+_disable_scoped_metrics = list(_base_scoped_metrics)
+_disable_rollup_metrics = list(_base_rollup_metrics)
+
+_enable_scoped_metrics = list(_base_scoped_metrics)
+_enable_rollup_metrics = list(_base_rollup_metrics)
+
+if len(DB_MULTIPLE_SETTINGS) > 1:
+    memcached_1 = DB_MULTIPLE_SETTINGS[0]
+    memcached_2 = DB_MULTIPLE_SETTINGS[1]
+
+    host_1 = instance_hostname(memcached_1['host'])
+    port_1 = memcached_1['port']
+
+    host_2 = instance_hostname(memcached_2['host'])
+    port_2 = memcached_2['port']
+
+    instance_metric_name_1 = 'Datastore/instance/Memcached/%s/%s' % (host_1,
+            port_1)
+    instance_metric_name_2 = 'Datastore/instance/Memcached/%s/%s' % (host_2,
+            port_2)
+
+    _enable_rollup_metrics.extend([
+            (instance_metric_name_1, None),
+            (instance_metric_name_2, None),
+    ])
+
+    _disable_rollup_metrics.extend([
+            (instance_metric_name_1, None),
+            (instance_metric_name_2, None),
+    ])
+
+def exercise_memcached(client, multi_dict):
+    client.set_multi(multi_dict)
+    client.get_multi(multi_dict.keys())
+
+transaction_metric_prefix = 'test_multiple_dbs:test_multiple_datastores'
+
+@pytest.mark.skipif(len(DB_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_enable_instance_settings)
+@validate_transaction_metrics(transaction_metric_prefix+'_enabled',
+        scoped_metrics=_enable_scoped_metrics,
+        rollup_metrics=_enable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multiple_datastores_enabled(memcached_multi):
+    memcached1 = DB_MULTIPLE_SETTINGS[0]
+    memcached2 = DB_MULTIPLE_SETTINGS[1]
+    settings = [memcached1, memcached2]
+    servers = ["%s:%s" % (x['host'], x['port']) for x in settings]
+
+    client = memcache.Client(servers=servers)
+
+    exercise_memcached(client, memcached_multi)
+
+@pytest.mark.skipif(len(DB_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_disable_instance_settings)
+@validate_transaction_metrics(transaction_metric_prefix+'_disabled',
+        scoped_metrics=_disable_scoped_metrics,
+        rollup_metrics=_disable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multiple_datastores_disabled(memcached_multi):
+    memcached1 = DB_MULTIPLE_SETTINGS[0]
+    memcached2 = DB_MULTIPLE_SETTINGS[1]
+    settings = [memcached1, memcached2]
+    servers = ["%s:%s" % (x['host'], x['port']) for x in settings]
+
+    client = memcache.Client(servers=servers)
+
+    exercise_memcached(client, memcached_multi)

--- a/tests/datastore_memcache/test_span_event.py
+++ b/tests/datastore_memcache/test_span_event.py
@@ -1,0 +1,102 @@
+import pytest
+import memcache
+
+from newrelic.api.transaction import current_transaction
+from testing_support.fixtures import override_application_settings
+from testing_support.validators.validate_span_events import (
+        validate_span_events)
+from testing_support.db_settings import memcached_settings
+from testing_support.util import instance_hostname
+
+from newrelic.api.background_task import background_task
+
+DB_SETTINGS = memcached_settings()[0]
+MEMCACHED_ADDR = '%s:%s' % (DB_SETTINGS['host'], DB_SETTINGS['port'])
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+    'distributed_tracing.enabled': True,
+    'span_events.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+    'distributed_tracing.enabled': True,
+    'span_events.enabled': True,
+}
+
+
+# Query
+
+def _exercise_db(client):
+    key = DB_SETTINGS['namespace'] + 'key'
+    client.set(key, 'value')
+    value = client.get(key)
+    client.delete(key)
+    assert value == 'value'
+
+
+# Tests
+
+@pytest.mark.parametrize('instance_enabled', (True, False))
+def test_span_events(instance_enabled):
+    guid = 'dbb533c53b749e0b'
+    priority = 0.5
+
+    common = {
+        'type': 'Span',
+        'transactionId': guid,
+        'priority': priority,
+        'sampled': True,
+        'category': 'datastore',
+        'component': 'Memcached',
+        'span.kind': 'client',
+    }
+
+    exact_agents = {}
+    if instance_enabled:
+        settings = _enable_instance_settings
+        hostname = instance_hostname(DB_SETTINGS['host'])
+        exact_agents.update({
+            'peer.address': '%s:%s' % (hostname, DB_SETTINGS['port']),
+            'peer.hostname': hostname,
+        })
+    else:
+        settings = _disable_instance_settings
+        exact_agents.update({
+            'peer.address': 'Unknown:Unknown',
+            'peer.hostname': 'Unknown',
+        })
+
+    query_1 = common.copy()
+    query_1['name'] = 'Datastore/operation/Memcached/set'
+
+    query_2 = common.copy()
+    query_2['name'] = 'Datastore/operation/Memcached/get'
+
+    query_3 = common.copy()
+    query_3['name'] = 'Datastore/operation/Memcached/delete'
+
+    @validate_span_events(count=1, exact_intrinsics=query_1,
+            exact_agents=exact_agents,
+            unexpected_agents=('db.instance',))
+    @validate_span_events(count=1, exact_intrinsics=query_2,
+            exact_agents=exact_agents,
+            unexpected_agents=('db.instance',))
+    @validate_span_events(count=1, exact_intrinsics=query_3,
+            exact_agents=exact_agents,
+            unexpected_agents=('db.instance',))
+    @validate_span_events(count=0, expected_intrinsics=('db.statement',))
+    @override_application_settings(settings)
+    @background_task(name='span_events')
+    def _test():
+        txn = current_transaction()
+        txn.guid = guid
+        txn._priority = priority
+        txn._sampled = True
+
+        client = memcache.Client([MEMCACHED_ADDR])
+        _exercise_db(client)
+
+    _test()

--- a/tests/datastore_memcache/tox.ini
+++ b/tests/datastore_memcache/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}-memcached01
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    memcached01: python-memcached<2
+
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/testing_support/db_settings.py
+++ b/tests/testing_support/db_settings.py
@@ -90,6 +90,7 @@ def memcached_settings():
         {
             "host": "localhost",
             "port": base_port + instance_num,
+            "namespace": str(os.getpid()),
         }
         for instance_num in range(instances)
     ]


### PR DESCRIPTION
Sidekick: @carrieedwards 

# Overview
* Added memcache tests from internal repo.
* Cleaned up namespacing to use `os.getpid()`
* Reduced testing matrix

# Related Github Issue

PYTHON-3790

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
