### PR TITLE
PYTHON-3789 elasticsearch Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -416,3 +416,100 @@ jobs:
       env:
         TOX_PARALLEL_NO_SPINNER: 1
         PY_COLORS: 0
+
+  elasticsearch:
+
+    strategy:
+      matrix:
+        test-directory: 
+          - datastore_elasticsearch
+
+    runs-on: ubuntu-latest
+
+    services:
+      es01:
+        image: elasticsearch:1.4.4
+        env:
+          "discovery.type": "single-node"
+        ports:
+          - 8080:9200
+          - 8081:9200
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "curl --silent --fail localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y-%m-%d")"
+      shell: bash
+
+    - name: Cache Tox and Pip (Linux)
+      if: startsWith(runner.os, 'Linux')
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.test-directory }}-${{ hashFiles('tests/${{ matrix.test-directory }}/tox.ini', 'tests/base_requirements.txt') }}-${{ steps.get-date.outputs.date }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.test-directory }}-${{ hashFiles('tests/${{ matrix.test-directory }}/tox.ini', 'tests/base_requirements.txt') }}-
+          ${{ runner.os }}-${{ matrix.test-directory }}-
+
+    # Set up all versions of python
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.5
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy3
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - name: Install Dependencies
+      run: |
+        pip install -U pip
+        pip install -U wheel setuptools tox virtualenv!=20.0.24
+
+    - name: Test
+      run: |
+        tox -vv -p auto -c tests/${{ matrix.test-directory }}/tox.ini
+      env:
+        TOX_PARALLEL_NO_SPINNER: 1
+        PY_COLORS: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -434,7 +434,7 @@ jobs:
         ports:
           - 8080:9200
           - 8081:9200
-        # Set health checks to wait until redis has started
+        # Set health checks to wait until elasticsearch has started
         options: >-
           --health-cmd "curl --silent --fail localhost:9200/_cluster/health || exit 1"
           --health-interval 10s

--- a/tests/datastore_elasticsearch/conftest.py
+++ b/tests/datastore_elasticsearch/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.hooks.datastore_elasticsearch',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_elasticsearch)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/datastore_elasticsearch/test_connection.py
+++ b/tests/datastore_elasticsearch/test_connection.py
@@ -1,0 +1,18 @@
+from elasticsearch.connection.base import Connection
+
+
+def test_connection_default():
+    conn = Connection()
+    assert conn._nr_host_port == ('localhost', '9200')
+
+def test_connection_host_arg():
+    conn = Connection('the_host')
+    assert conn._nr_host_port == ('the_host', '9200')
+
+def test_connection_args():
+    conn = Connection('the_host', 9999)
+    assert conn._nr_host_port == ('the_host', '9999')
+
+def test_connection_kwargs():
+    conn = Connection(host='foo', port=8888)
+    assert conn._nr_host_port == ('foo', '8888')

--- a/tests/datastore_elasticsearch/test_database_duration.py
+++ b/tests/datastore_elasticsearch/test_database_duration.py
@@ -11,12 +11,12 @@ ES_SETTINGS = elasticsearch_settings()[0]
 ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
 
 def _exercise_es(es):
-    es.index("contacts", "person",
-            {"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
-    es.index("contacts", "person",
-            {"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
-    es.index("contacts", "person",
-            {"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
     es.indices.refresh('contacts')
 
 @validate_database_duration()

--- a/tests/datastore_elasticsearch/test_database_duration.py
+++ b/tests/datastore_elasticsearch/test_database_duration.py
@@ -5,9 +5,9 @@ from elasticsearch import Elasticsearch
 from newrelic.api.background_task import background_task
 
 from testing_support.fixtures import validate_database_duration
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 
-ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_SETTINGS = elasticsearch_settings()[0]
 ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
 
 def _exercise_es(es):

--- a/tests/datastore_elasticsearch/test_database_duration.py
+++ b/tests/datastore_elasticsearch/test_database_duration.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+from elasticsearch import Elasticsearch
+
+from newrelic.api.background_task import background_task
+
+from testing_support.fixtures import validate_database_duration
+from testing_support.settings import elasticsearch_multiple_settings
+
+ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
+
+def _exercise_es(es):
+    es.index("contacts", "person",
+            {"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
+    es.index("contacts", "person",
+            {"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
+    es.index("contacts", "person",
+            {"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
+    es.indices.refresh('contacts')
+
+@validate_database_duration()
+@background_task()
+def test_elasticsearch_database_duration():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)
+
+@validate_database_duration()
+@background_task()
+def test_elasticsearch_and_sqlite_database_duration():
+
+    # Make Elasticsearch queries
+
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)
+
+    # Make sqlite queries
+
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+
+    cur.execute("CREATE TABLE people (name text, age int)")
+    cur.execute("INSERT INTO people VALUES ('Bob', 22)")
+
+    conn.commit()
+    conn.close()

--- a/tests/datastore_elasticsearch/test_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_elasticsearch.py
@@ -5,10 +5,10 @@ from newrelic.api.background_task import background_task
 
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors, override_application_settings)
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 from testing_support.util import instance_hostname
 
-ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_SETTINGS = elasticsearch_settings()[0]
 ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
 
 # Settings

--- a/tests/datastore_elasticsearch/test_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_elasticsearch.py
@@ -139,16 +139,16 @@ _disable_rollup_metrics.append(
 # Query
 
 def _exercise_es(es):
-    es.index("contacts", "person",
-            {"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
-    es.index("contacts", "person",
-            {"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
-    es.index("contacts", "person",
-            {"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
+    es.index(index="contacts", doc_type="person",
+            body={"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
     es.indices.refresh('contacts')
-    es.index("address", "employee", {"name": "Sherlock",
+    es.index(index="address", doc_type="employee", body={"name": "Sherlock",
         "address": "221B Baker Street, London"}, id=1)
-    es.index("address", "employee", {"name": "Bilbo",
+    es.index(index="address", doc_type="employee", body={"name": "Bilbo",
         "address": "Bag End, Bagshot row, Hobbiton, Shire"}, id=2)
     es.search(index='contacts', q='name:Joe')
     es.search(index='contacts', q='name:jessica')

--- a/tests/datastore_elasticsearch/test_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_elasticsearch.py
@@ -1,0 +1,195 @@
+from elasticsearch import Elasticsearch
+import elasticsearch.client
+
+from newrelic.api.background_task import background_task
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    validate_transaction_errors, override_application_settings)
+from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.util import instance_hostname
+
+ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+}
+
+# Metrics
+
+_base_scoped_metrics = [
+    ('Datastore/statement/Elasticsearch/_all/cluster.health', 1),
+    ('Datastore/statement/Elasticsearch/_all/search', 2),
+    ('Datastore/statement/Elasticsearch/address/index', 2),
+    ('Datastore/statement/Elasticsearch/address/search', 1),
+    ('Datastore/statement/Elasticsearch/contacts/index', 3),
+    ('Datastore/statement/Elasticsearch/contacts/indices.refresh', 1),
+    ('Datastore/statement/Elasticsearch/contacts/search', 2),
+    ('Datastore/statement/Elasticsearch/other/search', 2),
+]
+
+_base_rollup_metrics = [
+    ('Datastore/operation/Elasticsearch/cluster.health', 1),
+    ('Datastore/operation/Elasticsearch/index', 5),
+    ('Datastore/operation/Elasticsearch/indices.refresh', 1),
+    ('Datastore/operation/Elasticsearch/search', 7),
+    ('Datastore/statement/Elasticsearch/_all/cluster.health', 1),
+    ('Datastore/statement/Elasticsearch/_all/search', 2),
+    ('Datastore/statement/Elasticsearch/address/index', 2),
+    ('Datastore/statement/Elasticsearch/address/search', 1),
+    ('Datastore/statement/Elasticsearch/contacts/index', 3),
+    ('Datastore/statement/Elasticsearch/contacts/indices.refresh', 1),
+    ('Datastore/statement/Elasticsearch/contacts/search', 2),
+    ('Datastore/statement/Elasticsearch/other/search', 2),
+]
+
+# Version support
+
+_all_count = 14
+
+try:
+    import elasticsearch.client.cat
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/cat.health', 1))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/cat.health', 1))
+    _all_count += 1
+except ImportError:
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/cat.health', None))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/cat.health', None))
+
+try:
+    import elasticsearch.client.nodes
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/nodes.info', 1))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/nodes.info', 1))
+    _all_count += 1
+except ImportError:
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/nodes.info', None))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/nodes.info', None))
+
+if (hasattr(elasticsearch.client, 'SnapshotClient') and
+        hasattr(elasticsearch.client.SnapshotClient, 'status')):
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/snapshot.status', 1))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/snapshot.status', 1))
+    _all_count += 1
+else:
+    _base_scoped_metrics.append(
+            ('Datastore/operation/Elasticsearch/snapshot.status', None))
+    _base_rollup_metrics.append(
+            ('Datastore/operation/Elasticsearch/snapshot.status', None))
+
+if hasattr(elasticsearch.client.IndicesClient, 'status'):
+    _base_scoped_metrics.append(
+        ('Datastore/statement/Elasticsearch/_all/indices.status', 1))
+    _base_rollup_metrics.extend([
+        ('Datastore/operation/Elasticsearch/indices.status', 1),
+        ('Datastore/statement/Elasticsearch/_all/indices.status', 1),
+    ])
+    _all_count += 1
+else:
+    _base_scoped_metrics.append(
+        ('Datastore/operation/Elasticsearch/indices.status', None))
+    _base_rollup_metrics.extend([
+        ('Datastore/operation/Elasticsearch/indices.status', None),
+        ('Datastore/statement/Elasticsearch/_all/indices.status', None),
+    ])
+
+_base_rollup_metrics.extend([
+    ('Datastore/all', _all_count),
+    ('Datastore/allOther', _all_count),
+    ('Datastore/Elasticsearch/all', _all_count),
+    ('Datastore/Elasticsearch/allOther', _all_count),
+])
+
+# Instance info
+
+_disable_scoped_metrics = list(_base_scoped_metrics)
+_disable_rollup_metrics = list(_base_rollup_metrics)
+
+_enable_scoped_metrics = list(_base_scoped_metrics)
+_enable_rollup_metrics = list(_base_rollup_metrics)
+
+_host = instance_hostname(ES_SETTINGS['host'])
+_port = ES_SETTINGS['port']
+
+_instance_metric_name = 'Datastore/instance/Elasticsearch/%s/%s' % (
+        _host, _port)
+
+_enable_rollup_metrics.append(
+        (_instance_metric_name, _all_count)
+)
+
+_disable_rollup_metrics.append(
+        (_instance_metric_name, None)
+)
+
+# Query
+
+def _exercise_es(es):
+    es.index("contacts", "person",
+            {"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
+    es.index("contacts", "person",
+            {"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
+    es.index("contacts", "person",
+            {"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
+    es.indices.refresh('contacts')
+    es.index("address", "employee", {"name": "Sherlock",
+        "address": "221B Baker Street, London"}, id=1)
+    es.index("address", "employee", {"name": "Bilbo",
+        "address": "Bag End, Bagshot row, Hobbiton, Shire"}, id=2)
+    es.search(index='contacts', q='name:Joe')
+    es.search(index='contacts', q='name:jessica')
+    es.search(index='address', q='name:Sherlock')
+    es.search(index=['contacts', 'address'], q='name:Bilbo')
+    es.search(index='contacts,address', q='name:Bilbo')
+    es.search(index='*', q='name:Bilbo')
+    es.search(q='name:Bilbo')
+    es.cluster.health()
+
+    if hasattr(es, 'cat'):
+        es.cat.health()
+    if hasattr(es, 'nodes'):
+        es.nodes.info()
+    if hasattr(es, 'snapshot') and hasattr(es.snapshot, 'status'):
+        es.snapshot.status()
+    if hasattr(es.indices, 'status'):
+        es.indices.status()
+
+# Test
+
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics(
+        'test_elasticsearch:test_elasticsearch_operation_disabled',
+        scoped_metrics=_disable_scoped_metrics,
+        rollup_metrics=_disable_rollup_metrics,
+        background_task=True)
+@override_application_settings(_disable_instance_settings)
+@background_task()
+def test_elasticsearch_operation_disabled():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)
+
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics(
+        'test_elasticsearch:test_elasticsearch_operation_enabled',
+        scoped_metrics=_enable_scoped_metrics,
+        rollup_metrics=_enable_rollup_metrics,
+        background_task=True)
+@override_application_settings(_enable_instance_settings)
+@background_task()
+def test_elasticsearch_operation_enabled():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)

--- a/tests/datastore_elasticsearch/test_instrumented_methods.py
+++ b/tests/datastore_elasticsearch/test_instrumented_methods.py
@@ -1,0 +1,57 @@
+import elasticsearch
+import elasticsearch.client
+
+from newrelic.hooks.datastore_elasticsearch import (
+        _elasticsearch_client_methods,
+        _elasticsearch_client_indices_methods,
+        _elasticsearch_client_cat_methods,
+        _elasticsearch_client_cluster_methods,
+        _elasticsearch_client_nodes_methods,
+        _elasticsearch_client_snapshot_methods,
+        _elasticsearch_client_tasks_methods,
+        _elasticsearch_client_ingest_methods,
+)
+
+def _test_methods_wrapped(object, method_name_tuples):
+    for method_name, _ in method_name_tuples:
+        method = getattr(object, method_name, None)
+        if method is not None:
+            err = '%s.%s isnt being wrapped' % (object, method)
+            assert hasattr(method, '__wrapped__'), err
+
+def test_instrumented_methods_client():
+    _test_methods_wrapped(elasticsearch.Elasticsearch,
+            _elasticsearch_client_methods)
+
+def test_instrumented_methods_client_indices():
+    _test_methods_wrapped(elasticsearch.client.IndicesClient,
+            _elasticsearch_client_indices_methods)
+
+def test_instrumented_methods_client_cluster():
+    _test_methods_wrapped(elasticsearch.client.ClusterClient,
+            _elasticsearch_client_cluster_methods)
+
+def test_instrumented_methods_client_cat():
+    if hasattr(elasticsearch.client, 'CatClient'):
+        _test_methods_wrapped(elasticsearch.client.CatClient,
+                _elasticsearch_client_cat_methods)
+
+def test_instrumented_methods_client_nodes():
+    if hasattr(elasticsearch.client, 'NodesClient'):
+        _test_methods_wrapped(elasticsearch.client.NodesClient,
+                _elasticsearch_client_nodes_methods)
+
+def test_instrumented_methods_client_snapshot():
+    if hasattr(elasticsearch.client, 'SnapshotClient'):
+        _test_methods_wrapped(elasticsearch.client.SnapshotClient,
+                _elasticsearch_client_snapshot_methods)
+
+def test_instrumented_methods_client_tasks():
+    if hasattr(elasticsearch.client, 'TasksClient'):
+        _test_methods_wrapped(elasticsearch.client.TasksClient,
+                _elasticsearch_client_tasks_methods)
+
+def test_instrumented_methods_client_ingest():
+    if hasattr(elasticsearch.client, 'IngestClient'):
+        _test_methods_wrapped(elasticsearch.client.IngestClient,
+                _elasticsearch_client_ingest_methods)

--- a/tests/datastore_elasticsearch/test_mget.py
+++ b/tests/datastore_elasticsearch/test_mget.py
@@ -5,12 +5,12 @@ from elasticsearch.connection_pool import RoundRobinSelector
 
 from testing_support.fixtures import (validate_transaction_metrics,
     override_application_settings)
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 from testing_support.util import instance_hostname
 
 from newrelic.api.background_task import background_task
 
-ES_MULTIPLE_SETTINGS = elasticsearch_multiple_settings()
+ES_MULTIPLE_SETTINGS = elasticsearch_settings()
 
 # Settings
 

--- a/tests/datastore_elasticsearch/test_mget.py
+++ b/tests/datastore_elasticsearch/test_mget.py
@@ -1,0 +1,135 @@
+import pytest
+
+from elasticsearch import Elasticsearch
+from elasticsearch.connection_pool import RoundRobinSelector
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    override_application_settings)
+from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.util import instance_hostname
+
+from newrelic.api.background_task import background_task
+
+ES_MULTIPLE_SETTINGS = elasticsearch_multiple_settings()
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+}
+
+# Metrics
+
+_base_scoped_metrics = (
+    ('Datastore/statement/Elasticsearch/contacts/index', 2),
+)
+
+_base_rollup_metrics = (
+    ('Datastore/all', 3),
+    ('Datastore/allOther', 3),
+    ('Datastore/Elasticsearch/all', 3),
+    ('Datastore/Elasticsearch/allOther', 3),
+    ('Datastore/operation/Elasticsearch/index', 2),
+    ('Datastore/operation/Elasticsearch/mget', 1),
+    ('Datastore/statement/Elasticsearch/contacts/index', 2),
+)
+
+_disable_scoped_metrics = list(_base_scoped_metrics)
+_disable_rollup_metrics = list(_base_rollup_metrics)
+
+_enable_scoped_metrics = list(_base_scoped_metrics)
+_enable_rollup_metrics = list(_base_rollup_metrics)
+
+if len(ES_MULTIPLE_SETTINGS) > 1:
+    es_1 = ES_MULTIPLE_SETTINGS[0]
+    es_2 = ES_MULTIPLE_SETTINGS[1]
+
+    host_1 = instance_hostname(es_1['host'])
+    port_1 = es_1['port']
+
+    host_2 = instance_hostname(es_2['host'])
+    port_2 = es_2['port']
+
+    instance_metric_name_1 = 'Datastore/instance/Elasticsearch/%s/%s' % (
+            host_1, port_1)
+    instance_metric_name_2 = 'Datastore/instance/Elasticsearch/%s/%s' % (
+            host_2, port_2)
+
+    _enable_rollup_metrics.extend([
+            (instance_metric_name_1, 2),
+            (instance_metric_name_2, 1),
+    ])
+
+    _disable_rollup_metrics.extend([
+            (instance_metric_name_1, None),
+            (instance_metric_name_2, None),
+    ])
+
+# Query
+
+def _exercise_es_multi(es):
+    # set on db 1
+    es.index('contacts', 'person',
+            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'},
+            id=1)
+
+    # set on db 2
+    es.index('contacts', 'person',
+            {'name': 'Jane Tester', 'age': 22, 'title': 'Senior QA Engineer'},
+            id=2)
+
+    # ask db 1, will return info from db 1 and 2
+    mget_body = {
+        'docs': [
+            {'_id': 1, '_index': 'contacts'},
+            {'_id': 2, '_index': 'contacts'},
+        ]
+    }
+
+    results = es.mget(mget_body)
+    assert len(results['docs']) == 2
+
+# Test
+
+@pytest.mark.skipif(len(ES_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_enable_instance_settings)
+@validate_transaction_metrics(
+        'test_mget:test_multi_get_enabled',
+        scoped_metrics=_enable_scoped_metrics,
+        rollup_metrics=_enable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multi_get_enabled():
+    urls = ['http://%s:%s' % (db['host'], db['port']) for db in
+            ES_MULTIPLE_SETTINGS]
+    # When selecting a connection from the pool, use the round robin method.
+    # This is actually the default already. Using round robin will ensure that
+    # doing two db calls will mean elastic search is talking to two different
+    # dbs.
+    client = Elasticsearch(urls, selector_class=RoundRobinSelector,
+            randomize_hosts=False)
+    _exercise_es_multi(client)
+
+@pytest.mark.skipif(len(ES_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_disable_instance_settings)
+@validate_transaction_metrics(
+        'test_mget:test_multi_get_disabled',
+        scoped_metrics=_disable_scoped_metrics,
+        rollup_metrics=_disable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multi_get_disabled():
+    urls = ['http://%s:%s' % (db['host'], db['port']) for db in
+            ES_MULTIPLE_SETTINGS]
+    # When selecting a connection from the pool, use the round robin method.
+    # This is actually the default already. Using round robin will ensure that
+    # doing two db calls will mean elastic search is talking to two different
+    # dbs.
+    client = Elasticsearch(urls, selector_class=RoundRobinSelector,
+            randomize_hosts=False)
+    _exercise_es_multi(client)

--- a/tests/datastore_elasticsearch/test_mget.py
+++ b/tests/datastore_elasticsearch/test_mget.py
@@ -72,13 +72,13 @@ if len(ES_MULTIPLE_SETTINGS) > 1:
 
 def _exercise_es_multi(es):
     # set on db 1
-    es.index('contacts', 'person',
-            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'},
+    es.index(index='contacts', doc_type='person',
+            body={'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'},
             id=1)
 
     # set on db 2
-    es.index('contacts', 'person',
-            {'name': 'Jane Tester', 'age': 22, 'title': 'Senior QA Engineer'},
+    es.index(index='contacts', doc_type='person',
+            body={'name': 'Jane Tester', 'age': 22, 'title': 'Senior QA Engineer'},
             id=2)
 
     # ask db 1, will return info from db 1 and 2

--- a/tests/datastore_elasticsearch/test_multiple_dbs.py
+++ b/tests/datastore_elasticsearch/test_multiple_dbs.py
@@ -69,8 +69,8 @@ if len(ES_MULTIPLE_SETTINGS) > 1:
 # Query
 
 def _exercise_es(es):
-    es.index('contacts', 'person',
-            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'}, id=1)
+    es.index(index='contacts', doc_type='person',
+            body={'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'}, id=1)
 
 # Test
 

--- a/tests/datastore_elasticsearch/test_multiple_dbs.py
+++ b/tests/datastore_elasticsearch/test_multiple_dbs.py
@@ -1,0 +1,105 @@
+import pytest
+
+from elasticsearch import Elasticsearch
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    override_application_settings)
+from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.util import instance_hostname
+
+from newrelic.api.background_task import background_task
+
+ES_MULTIPLE_SETTINGS = elasticsearch_multiple_settings()
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+}
+
+# Metrics
+
+_base_scoped_metrics = (
+    ('Datastore/statement/Elasticsearch/contacts/index', 2),
+)
+
+_base_rollup_metrics = (
+    ('Datastore/all', 2),
+    ('Datastore/allOther', 2),
+    ('Datastore/Elasticsearch/all', 2),
+    ('Datastore/Elasticsearch/allOther', 2),
+    ('Datastore/operation/Elasticsearch/index', 2),
+    ('Datastore/statement/Elasticsearch/contacts/index', 2),
+)
+
+_disable_scoped_metrics = list(_base_scoped_metrics)
+_disable_rollup_metrics = list(_base_rollup_metrics)
+
+_enable_scoped_metrics = list(_base_scoped_metrics)
+_enable_rollup_metrics = list(_base_rollup_metrics)
+
+if len(ES_MULTIPLE_SETTINGS) > 1:
+    es_1 = ES_MULTIPLE_SETTINGS[0]
+    es_2 = ES_MULTIPLE_SETTINGS[1]
+
+    host_1 = instance_hostname(es_1['host'])
+    port_1 = es_1['port']
+
+    host_2 = instance_hostname(es_2['host'])
+    port_2 = es_2['port']
+
+    instance_metric_name_1 = 'Datastore/instance/Elasticsearch/%s/%s' % (
+            host_1, port_1)
+    instance_metric_name_2 = 'Datastore/instance/Elasticsearch/%s/%s' % (
+            host_2, port_2)
+
+    _enable_rollup_metrics.extend([
+            (instance_metric_name_1, 1),
+            (instance_metric_name_2, 1),
+    ])
+
+    _disable_rollup_metrics.extend([
+            (instance_metric_name_1, None),
+            (instance_metric_name_2, None),
+    ])
+
+# Query
+
+def _exercise_es(es):
+    es.index('contacts', 'person',
+            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Engineer'}, id=1)
+
+# Test
+
+@pytest.mark.skipif(len(ES_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_enable_instance_settings)
+@validate_transaction_metrics(
+        'test_multiple_dbs:test_multiple_dbs_enabled',
+        scoped_metrics=_enable_scoped_metrics,
+        rollup_metrics=_enable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multiple_dbs_enabled():
+    for db in ES_MULTIPLE_SETTINGS:
+        es_url = 'http://%s:%s' % (db['host'], db['port'])
+        client = Elasticsearch(es_url)
+        _exercise_es(client)
+
+@pytest.mark.skipif(len(ES_MULTIPLE_SETTINGS) < 2,
+        reason='Test environment not configured with multiple databases.')
+@override_application_settings(_disable_instance_settings)
+@validate_transaction_metrics(
+        'test_multiple_dbs:test_multiple_dbs_disabled',
+        scoped_metrics=_disable_scoped_metrics,
+        rollup_metrics=_disable_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_multiple_dbs_disabled():
+    for db in ES_MULTIPLE_SETTINGS:
+        es_url = 'http://%s:%s' % (db['host'], db['port'])
+        client = Elasticsearch(es_url)
+        _exercise_es(client)

--- a/tests/datastore_elasticsearch/test_multiple_dbs.py
+++ b/tests/datastore_elasticsearch/test_multiple_dbs.py
@@ -4,12 +4,12 @@ from elasticsearch import Elasticsearch
 
 from testing_support.fixtures import (validate_transaction_metrics,
     override_application_settings)
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 from testing_support.util import instance_hostname
 
 from newrelic.api.background_task import background_task
 
-ES_MULTIPLE_SETTINGS = elasticsearch_multiple_settings()
+ES_MULTIPLE_SETTINGS = elasticsearch_settings()
 
 # Settings
 

--- a/tests/datastore_elasticsearch/test_trace_node.py
+++ b/tests/datastore_elasticsearch/test_trace_node.py
@@ -1,0 +1,99 @@
+from elasticsearch import Elasticsearch
+
+from testing_support.fixtures import (validate_tt_collector_json,
+    override_application_settings, validate_tt_parenting)
+from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.util import instance_hostname
+
+from newrelic.api.background_task import background_task
+
+ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
+
+# Settings
+
+_enable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+    'datastore_tracer.database_name_reporting.enabled': True,
+}
+_disable_instance_settings = {
+    'datastore_tracer.instance_reporting.enabled': False,
+    'datastore_tracer.database_name_reporting.enabled': False,
+}
+_instance_only_settings = {
+    'datastore_tracer.instance_reporting.enabled': True,
+    'datastore_tracer.database_name_reporting.enabled': False,
+}
+
+# Expected parameters
+
+_enabled_required = {
+    'host': instance_hostname(ES_SETTINGS['host']),
+    'port_path_or_id': str(ES_SETTINGS['port']),
+}
+_enabled_forgone = {
+    'db.instance': 'VALUE NOT USED',
+}
+
+_disabled_required = {}
+_disabled_forgone = {
+    'host': 'VALUE NOT USED',
+    'port_path_or_id': 'VALUE NOT USED',
+    'db.instance': 'VALUE NOT USED',
+}
+
+_instance_only_required = {
+    'host': instance_hostname(ES_SETTINGS['host']),
+    'port_path_or_id': str(ES_SETTINGS['port']),
+}
+_instance_only_forgone = {
+    'db.instance': 'VALUE NOT USED',
+}
+
+_tt_parenting = (
+    'TransactionNode', [
+        ('DatastoreNode', []),
+    ],
+)
+
+
+# Query
+
+def _exercise_es(es):
+    es.index('contacts', 'person',
+            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Master'}, id=1)
+
+
+# Tests
+
+@override_application_settings(_enable_instance_settings)
+@validate_tt_collector_json(
+        datastore_params=_enabled_required,
+        datastore_forgone_params=_enabled_forgone)
+@validate_tt_parenting(_tt_parenting)
+@background_task()
+def test_trace_node_datastore_params_enable_instance():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)
+
+
+@override_application_settings(_disable_instance_settings)
+@validate_tt_collector_json(
+        datastore_params=_disabled_required,
+        datastore_forgone_params=_disabled_forgone)
+@validate_tt_parenting(_tt_parenting)
+@background_task()
+def test_trace_node_datastore_params_disable_instance():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)
+
+
+@override_application_settings(_instance_only_settings)
+@validate_tt_collector_json(
+        datastore_params=_instance_only_required,
+        datastore_forgone_params=_instance_only_forgone)
+@validate_tt_parenting(_tt_parenting)
+@background_task()
+def test_trace_node_datastore_params_instance_only():
+    client = Elasticsearch(ES_URL)
+    _exercise_es(client)

--- a/tests/datastore_elasticsearch/test_trace_node.py
+++ b/tests/datastore_elasticsearch/test_trace_node.py
@@ -2,12 +2,12 @@ from elasticsearch import Elasticsearch
 
 from testing_support.fixtures import (validate_tt_collector_json,
     override_application_settings, validate_tt_parenting)
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 from testing_support.util import instance_hostname
 
 from newrelic.api.background_task import background_task
 
-ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_SETTINGS = elasticsearch_settings()[0]
 ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
 
 # Settings

--- a/tests/datastore_elasticsearch/test_trace_node.py
+++ b/tests/datastore_elasticsearch/test_trace_node.py
@@ -60,8 +60,8 @@ _tt_parenting = (
 # Query
 
 def _exercise_es(es):
-    es.index('contacts', 'person',
-            {'name': 'Joe Tester', 'age': 25, 'title': 'QA Master'}, id=1)
+    es.index(index='contacts', doc_type='person',
+            body={'name': 'Joe Tester', 'age': 25, 'title': 'QA Master'}, id=1)
 
 
 # Tests

--- a/tests/datastore_elasticsearch/test_transport.py
+++ b/tests/datastore_elasticsearch/test_transport.py
@@ -36,7 +36,7 @@ def test_transport_perform_request_urllib3():
     app = application()
     with BackgroundTask(app, 'perform_request_urllib3') as transaction:
         transport = Transport([HOST], connection_class=Urllib3HttpConnection)
-        transport.perform_request('POST', METHOD, PARAMS, DATA)
+        transport.perform_request('POST', METHOD, params=PARAMS, body=DATA)
 
     expected = (ES_SETTINGS['host'], ES_SETTINGS['port'], None)
     assert transaction._nr_datastore_instance_info == expected
@@ -45,7 +45,7 @@ def test_transport_perform_request_requests():
     app = application()
     with BackgroundTask(app, 'perform_request_requests') as transaction:
         transport = Transport([HOST], connection_class=RequestsHttpConnection)
-        transport.perform_request('POST', METHOD, PARAMS, DATA)
+        transport.perform_request('POST', METHOD, params=PARAMS, body=DATA)
 
     expected = (ES_SETTINGS['host'], ES_SETTINGS['port'], None)
     assert transaction._nr_datastore_instance_info == expected

--- a/tests/datastore_elasticsearch/test_transport.py
+++ b/tests/datastore_elasticsearch/test_transport.py
@@ -7,9 +7,9 @@ from elasticsearch.serializer import JSONSerializer
 from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import BackgroundTask
 
-from testing_support.settings import elasticsearch_multiple_settings
+from testing_support.db_settings import elasticsearch_settings
 
-ES_SETTINGS = elasticsearch_multiple_settings()[0]
+ES_SETTINGS = elasticsearch_settings()[0]
 HOST = {
     'host':ES_SETTINGS['host'],
     'port': int(ES_SETTINGS['port'])

--- a/tests/datastore_elasticsearch/test_transport.py
+++ b/tests/datastore_elasticsearch/test_transport.py
@@ -1,0 +1,51 @@
+from elasticsearch.client.utils import _make_path
+from elasticsearch.transport import Transport
+from elasticsearch.connection.http_requests import RequestsHttpConnection
+from elasticsearch.connection.http_urllib3 import Urllib3HttpConnection
+from elasticsearch.serializer import JSONSerializer
+
+from newrelic.api.application import application_instance as application
+from newrelic.api.background_task import BackgroundTask
+
+from testing_support.settings import elasticsearch_multiple_settings
+
+ES_SETTINGS = elasticsearch_multiple_settings()[0]
+HOST = {
+    'host':ES_SETTINGS['host'],
+    'port': int(ES_SETTINGS['port'])
+}
+INDEX = 'contacts'
+DOC_TYPE = 'person'
+ID = 1
+METHOD = _make_path(INDEX, DOC_TYPE, ID)
+PARAMS = {}
+DATA = {"name": "Joe Tester"}
+BODY = JSONSerializer().dumps(DATA).encode('utf-8')
+
+
+def test_transport_get_connection():
+    app = application()
+    with BackgroundTask(app, 'transport_perform_request') as transaction:
+        transport = Transport([HOST])
+        transport.get_connection()
+
+    expected = (ES_SETTINGS['host'], ES_SETTINGS['port'], None)
+    assert transaction._nr_datastore_instance_info == expected
+
+def test_transport_perform_request_urllib3():
+    app = application()
+    with BackgroundTask(app, 'perform_request_urllib3') as transaction:
+        transport = Transport([HOST], connection_class=Urllib3HttpConnection)
+        transport.perform_request('POST', METHOD, PARAMS, DATA)
+
+    expected = (ES_SETTINGS['host'], ES_SETTINGS['port'], None)
+    assert transaction._nr_datastore_instance_info == expected
+
+def test_transport_perform_request_requests():
+    app = application()
+    with BackgroundTask(app, 'perform_request_requests') as transaction:
+        transport = Transport([HOST], connection_class=RequestsHttpConnection)
+        transport.perform_request('POST', METHOD, PARAMS, DATA)
+
+    expected = (ES_SETTINGS['host'], ES_SETTINGS['port'], None)
+    assert transaction._nr_datastore_instance_info == expected

--- a/tests/datastore_elasticsearch/tox.ini
+++ b/tests/datastore_elasticsearch/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39}-elasticsearch{00,01,02,05}-{with,without}-extensions,
+    {pypy,pypy3}-elasticsearch{00,01,02,05}-without-extensions,
+
+[jenkins]
+mostrecent = elasticsearch05
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    requests
+    elasticsearch00: elasticsearch<1.0
+    elasticsearch01: elasticsearch<2.0
+    elasticsearch02: elasticsearch<3.0
+    elasticsearch05: elasticsearch<6.0
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/datastore_elasticsearch/tox.ini
+++ b/tests/datastore_elasticsearch/tox.ini
@@ -1,11 +1,8 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39}-elasticsearch{00,01,02,05}-{with,without}-extensions,
-    {pypy,pypy3}-elasticsearch{00,01,02,05}-without-extensions,
-
-[jenkins]
-mostrecent = elasticsearch05
+    {py27,py35}-elasticsearch{00,01,02}
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}-elasticsearch{05}
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -17,11 +14,15 @@ deps =
     elasticsearch01: elasticsearch<2.0
     elasticsearch02: elasticsearch<3.0
     elasticsearch05: elasticsearch<6.0
+
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 

--- a/tests/datastore_elasticsearch/tox.ini
+++ b/tests/datastore_elasticsearch/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35}-elasticsearch{00,01,02}
-    {py27,py35,py36,py37,py38,py39,pypy,pypy3}-elasticsearch{05}
+    {py27,py35}-elasticsearch{00,01,02,05}
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}-elasticsearch{07}
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -14,6 +14,7 @@ deps =
     elasticsearch01: elasticsearch<2.0
     elasticsearch02: elasticsearch<3.0
     elasticsearch05: elasticsearch<6.0
+    elasticsearch07: elasticsearch<8.0
 
 setenv =
     PYTHONPATH={toxinidir}/..

--- a/tests/testing_support/db_settings.py
+++ b/tests/testing_support/db_settings.py
@@ -117,7 +117,7 @@ def elasticsearch_settings():
     settings = [
         {
             "host": "localhost",
-            "port": base_port + instance_num,
+            "port": str(base_port + instance_num),
             "namespace": str(os.getpid()),
         }
         for instance_num in range(instances)

--- a/tests/testing_support/db_settings.py
+++ b/tests/testing_support/db_settings.py
@@ -94,3 +94,32 @@ def memcached_settings():
         for instance_num in range(instances)
     ]
     return settings
+
+
+def elasticsearch_settings():
+    """Return a list of dict of settings for connecting to elasticsearch.
+
+    Will return the correct settings, depending on which of the environments it
+    is running in. It attempts to set variables in the following order, where
+    later environments override earlier ones.
+
+        1. Local
+        2. Github Actions
+    """
+
+    if "GITHUB_ACTIONS" in os.environ:
+        instances = 2
+        base_port = 8080
+    else:
+        instances = 1
+        base_port = 9200
+
+    settings = [
+        {
+            "host": "localhost",
+            "port": base_port + instance_num,
+            "namespace": str(os.getpid()),
+        }
+        for instance_num in range(instances)
+    ]
+    return settings

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -738,6 +738,59 @@ def validate_synthetics_event(required_attrs=[], forgone_attrs=[],
     return wrapper
 
 
+def validate_database_duration():
+    @transient_function_wrapper('newrelic.core.stats_engine',
+            'StatsEngine.record_transaction')
+    def _validate_database_duration(wrapped, instance, args, kwargs):
+        try:
+            result = wrapped(*args, **kwargs)
+        except:
+            raise
+        else:
+
+            metrics = instance.stats_table
+            transaction_events = instance.transaction_events
+
+            assert transaction_events.num_seen == 1
+
+            event = next(iter(transaction_events))
+            intrinsics = event[0]
+
+            # As long as we are sending 'Database' metrics, then
+            # 'databaseDuration' and 'databaseCallCount' will be
+            # the sum both 'Database' and 'Datastore' values.
+
+            try:
+                database_all = metrics[('Database/all', '')]
+            except KeyError:
+                database_all_duration = 0.0
+                database_all_call_count = 0
+            else:
+                database_all_duration = database_all.total_call_time
+                database_all_call_count = database_all.call_count
+
+            try:
+                datastore_all = metrics[('Datastore/all', '')]
+            except KeyError:
+                datastore_all_duration = 0.0
+                datastore_all_call_count = 0
+            else:
+                datastore_all_duration = datastore_all.total_call_time
+                datastore_all_call_count = datastore_all.call_count
+
+            assert 'databaseDuration' in intrinsics
+            assert 'databaseCallCount' in intrinsics
+
+            assert intrinsics['databaseDuration'] == (database_all_duration +
+                    datastore_all_duration)
+            assert intrinsics['databaseCallCount'] == (
+                    database_all_call_count + datastore_all_call_count)
+
+        return result
+
+    return _validate_database_duration
+
+
 def validate_transaction_event_attributes(required_params={},
         forgone_params={}, exact_attrs={}, index=-1):
 


### PR DESCRIPTION
Sidekick: @a-feld 

# Overview

* Imports elasticsearch tests from internal repo.
* Adds elasticsearch 7 testing.
* Reduces matrix for older elasticsearch versions.

# Related Github Issue

PYTHON-3789

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
