### PR TITLE
PYTHON-3803 pymemcache Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -330,6 +330,7 @@ jobs:
         test-directory: 
           - datastore_bmemcached
           - datastore_memcache
+          - datastore_pymemcache
 
     runs-on: ubuntu-latest
 

--- a/tests/datastore_pymemcache/conftest.py
+++ b/tests/datastore_pymemcache/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.api.memcache_trace',
+    'newrelic.hooks.datastore_pymemcache',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_pymemcache)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/datastore_pymemcache/test_memcache.py
+++ b/tests/datastore_pymemcache/test_memcache.py
@@ -3,20 +3,16 @@ import os
 import pymemcache.client
 
 from testing_support.fixtures import validate_transaction_metrics
+from testing_support.db_settings import memcached_settings
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import set_background_task
 
-def _e(key, default):
-    return os.environ.get(key, default)
+DB_SETTINGS = memcached_settings()[0]
 
-MEMCACHED_HOST = _e('TDDIUM_MEMCACHE_HOST', 'localhost')
-MEMCACHED_PORT = _e('TDDIUM_MEMCACHE_PORT', '11211')
-MEMCACHED_NAMESPACE = ''
-
-MEMCACHED_HOST = _e('MEMCACHED_PORT_11211_TCP_ADDR', MEMCACHED_HOST)
-MEMCACHED_PORT = _e('MEMCACHED_PORT_11211_TCP_PORT', MEMCACHED_PORT)
-MEMCACHED_NAMESPACE = _e('TDDIUM_MEMCACHE_NAMESPACE', MEMCACHED_NAMESPACE)
+MEMCACHED_HOST = DB_SETTINGS["host"]
+MEMCACHED_PORT = DB_SETTINGS["port"]
+MEMCACHED_NAMESPACE = DB_SETTINGS["namespace"]
 
 MEMCACHED_ADDR = (MEMCACHED_HOST, int(MEMCACHED_PORT))
 

--- a/tests/datastore_pymemcache/test_memcache.py
+++ b/tests/datastore_pymemcache/test_memcache.py
@@ -1,0 +1,85 @@
+import os
+
+import pymemcache.client
+
+from testing_support.fixtures import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import set_background_task
+
+def _e(key, default):
+    return os.environ.get(key, default)
+
+MEMCACHED_HOST = _e('TDDIUM_MEMCACHE_HOST', 'localhost')
+MEMCACHED_PORT = _e('TDDIUM_MEMCACHE_PORT', '11211')
+MEMCACHED_NAMESPACE = ''
+
+MEMCACHED_HOST = _e('MEMCACHED_PORT_11211_TCP_ADDR', MEMCACHED_HOST)
+MEMCACHED_PORT = _e('MEMCACHED_PORT_11211_TCP_PORT', MEMCACHED_PORT)
+MEMCACHED_NAMESPACE = _e('TDDIUM_MEMCACHE_NAMESPACE', MEMCACHED_NAMESPACE)
+
+MEMCACHED_ADDR = (MEMCACHED_HOST, int(MEMCACHED_PORT))
+
+_test_bt_set_get_delete_scoped_metrics = [
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_test_bt_set_get_delete_rollup_metrics = [
+        ('Datastore/all', 3),
+        ('Datastore/allOther', 3),
+        ('Datastore/Memcached/all', 3),
+        ('Datastore/Memcached/allOther', 3),
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+@validate_transaction_metrics(
+        'test_memcache:test_bt_set_get_delete',
+        scoped_metrics=_test_bt_set_get_delete_scoped_metrics,
+        rollup_metrics=_test_bt_set_get_delete_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_bt_set_get_delete():
+    set_background_task(True)
+    client = pymemcache.client.Client(MEMCACHED_ADDR)
+
+    key = MEMCACHED_NAMESPACE + 'key'
+
+    client.set(key, b'value')
+    value = client.get(key)
+    client.delete(key)
+
+    assert value == b'value'
+
+_test_wt_set_get_delete_scoped_metrics = [
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+_test_wt_set_get_delete_rollup_metrics = [
+        ('Datastore/all', 3),
+        ('Datastore/allWeb', 3),
+        ('Datastore/Memcached/all', 3),
+        ('Datastore/Memcached/allWeb', 3),
+        ('Datastore/operation/Memcached/set', 1),
+        ('Datastore/operation/Memcached/get', 1),
+        ('Datastore/operation/Memcached/delete', 1)]
+
+@validate_transaction_metrics(
+        'test_memcache:test_wt_set_get_delete',
+        scoped_metrics=_test_wt_set_get_delete_scoped_metrics,
+        rollup_metrics=_test_wt_set_get_delete_rollup_metrics,
+        background_task=False)
+@background_task()
+def test_wt_set_get_delete():
+    set_background_task(False)
+    client = pymemcache.client.Client(MEMCACHED_ADDR)
+
+    key = MEMCACHED_NAMESPACE + 'key'
+
+    client.set(key, b'value')
+    value = client.get(key)
+    client.delete(key)
+
+    assert value == b'value'

--- a/tests/datastore_pymemcache/tox.ini
+++ b/tests/datastore_pymemcache/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
+    {pypy,pypy3}-without-extensions,
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    pymemcache<1.5
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/datastore_pymemcache/tox.ini
+++ b/tests/datastore_pymemcache/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39,pypy,pypy3}
+    {py27,py36,py37,py38,py39,pypy,pypy3}
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
 
 [testenv]
 deps =
-    pymemcache<1.5
+    pymemcache
 
 setenv =
     PYTHONPATH={toxinidir}/..

--- a/tests/datastore_pymemcache/tox.ini
+++ b/tests/datastore_pymemcache/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
-    {pypy,pypy3}-without-extensions,
+    {py27,py35,py36,py37,py38,py39,pypy,pypy3}
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -10,11 +9,15 @@ usefixtures = session_initialization requires_data_collector
 [testenv]
 deps =
     pymemcache<1.5
+
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 

--- a/tests/testing_support/db_settings.py
+++ b/tests/testing_support/db_settings.py
@@ -88,7 +88,7 @@ def memcached_settings():
 
     settings = [
         {
-            "host": "localhost",
+            "host": "127.0.0.1",
             "port": base_port + instance_num,
             "namespace": str(os.getpid()),
         }

--- a/tests/testing_support/util.py
+++ b/tests/testing_support/util.py
@@ -31,7 +31,7 @@ def version2tuple(version_str):
     return tuple(map(_to_int, parts))
 
 def instance_hostname(hostname):
-    if hostname == 'localhost':
+    if hostname == 'localhost' or hostname == '127.0.0.1':
         hostname = socket.gethostname()
     return hostname
 


### PR DESCRIPTION
Sidekick: @carrieedwards 

# Overview
* Importing pymemcache tests from internal repo.

# Related Github Issue

PYTHON-3803

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
