### PR TITLE
PYTHON-3795 oursql Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,6 +237,7 @@ jobs:
       matrix:
         test-directory:
           - datastore_mysqldb
+          - datastore_oursql
 
     runs-on: ubuntu-latest
 

--- a/tests/datastore_oursql/conftest.py
+++ b/tests/datastore_oursql/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.hooks.database_mysqldb',
+    'newrelic.hooks.database_dbapi2',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True,
+    'debug.log_explain_plan_queries': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_oursql)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/datastore_oursql/conftest.py
+++ b/tests/datastore_oursql/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from testing_support.fixtures import (code_coverage_fixture,
         collector_agent_registration_fixture, collector_available_fixture)
@@ -31,3 +32,7 @@ def session_initialization(code_coverage, collector_agent_registration):
 @pytest.fixture(scope='function')
 def requires_data_collector(collector_available_fixture):
     pass
+
+@pytest.fixture(scope="session")
+def table_name():
+    return str("datastore_oursql_%d" % os.getpid())

--- a/tests/datastore_oursql/test_database.py
+++ b/tests/datastore_oursql/test_database.py
@@ -1,0 +1,114 @@
+import oursql
+
+from testing_support.fixtures import (validate_transaction_metrics,
+            validate_database_trace_inputs)
+
+from testing_support.settings import mysql_settings
+
+from newrelic.api.background_task import background_task
+
+DB_SETTINGS = mysql_settings()
+
+_test_execute_via_cursor_scoped_metrics = [
+        ('Function/oursql:Connection', 1),
+        ('Function/oursql:Connection.__enter__', 1),
+        ('Function/oursql:Connection.__exit__', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/select', 2),
+        ('Datastore/statement/MySQL/datastore_oursql/insert', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/update', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/delete', 1),
+        ('Datastore/operation/MySQL/create', 1),
+        ('Datastore/operation/MySQL/drop', 1),
+        ('Datastore/operation/MySQL/commit', 3),
+        ('Datastore/operation/MySQL/rollback', 1)]
+
+_test_execute_via_cursor_rollup_metrics = [
+        ('Datastore/all', 12),
+        ('Datastore/allOther', 12),
+        ('Datastore/MySQL/all', 12),
+        ('Datastore/MySQL/allOther', 12),
+        ('Datastore/operation/MySQL/select', 2),
+        ('Datastore/statement/MySQL/datastore_oursql/select', 2),
+        ('Datastore/operation/MySQL/insert', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/insert', 1),
+        ('Datastore/operation/MySQL/update', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/update', 1),
+        ('Datastore/operation/MySQL/delete', 1),
+        ('Datastore/statement/MySQL/datastore_oursql/delete', 1),
+        ('Datastore/operation/MySQL/create', 1),
+        ('Datastore/operation/MySQL/drop', 1),
+        ('Datastore/operation/MySQL/commit', 3),
+        ('Datastore/operation/MySQL/rollback', 1)]
+
+@validate_transaction_metrics('test_database:test_execute_via_cursor',
+        scoped_metrics=_test_execute_via_cursor_scoped_metrics,
+        rollup_metrics=_test_execute_via_cursor_rollup_metrics,
+        background_task=True)
+@validate_database_trace_inputs(sql_parameters_type=tuple)
+@background_task()
+def test_execute_via_cursor():
+
+    connection = oursql.connect(db=DB_SETTINGS['name'],
+            user=DB_SETTINGS['user'], passwd=DB_SETTINGS['password'],
+            host=DB_SETTINGS['host'], port=DB_SETTINGS['port'])
+
+    with connection as cursor:
+        cursor.execute("""drop table if exists datastore_oursql""")
+
+        cursor.execute("""create table datastore_oursql """
+                """(a integer, b real, c text)""")
+
+        cursor.executemany("""insert into datastore_oursql values (?, ?, ?)""",
+                [(1, 1.0, '1.0'), (2, 2.2, '2.2'), (3, 3.3, '3.3')])
+
+        cursor.execute("""select * from datastore_oursql""")
+
+        # The oursql cursor execute() method takes a non DBAPI2
+        # argument to disable parameter interpolation. Also
+        # changes other behaviour and actually results in a
+        # speedup in execution because the default way creates a
+        # prepared statement every time and then throws it away.
+
+        cursor.execute("""select * from datastore_oursql""", plain_query=True)
+
+        for row in cursor: pass
+
+        cursor.execute("""update datastore_oursql set a=?, b=?, c=? """
+                """where a=?""", (4, 4.0, '4.0', 1))
+
+        cursor.execute("""delete from datastore_oursql where a=2""")
+
+    connection.commit()
+    connection.rollback()
+    connection.commit()
+
+_test_rollback_on_exception_scoped_metrics = [
+        ('Function/oursql:Connection', 1),
+        ('Function/oursql:Connection.__enter__', 1),
+        ('Function/oursql:Connection.__exit__', 1),
+        ('Datastore/operation/MySQL/rollback', 1)]
+
+_test_rollback_on_exception_rollup_metrics = [
+        ('Datastore/all', 2),
+        ('Datastore/allOther', 2),
+        ('Datastore/MySQL/all', 2),
+        ('Datastore/MySQL/allOther', 2),
+        ('Datastore/operation/MySQL/rollback', 1)]
+
+@validate_transaction_metrics('test_database:test_rollback_on_exception',
+        scoped_metrics=_test_rollback_on_exception_scoped_metrics,
+        rollup_metrics=_test_rollback_on_exception_rollup_metrics,
+        background_task=True)
+@validate_database_trace_inputs(sql_parameters_type=tuple)
+@background_task()
+def test_rollback_on_exception():
+
+    try:
+        connection = oursql.connect(db=DB_SETTINGS['name'],
+                user=DB_SETTINGS['user'], passwd=DB_SETTINGS['password'],
+                host=DB_SETTINGS['host'], port=DB_SETTINGS['port'])
+
+        with connection as cursor:
+            raise RuntimeError('error')
+    except RuntimeError:
+        pass

--- a/tests/datastore_oursql/test_database.py
+++ b/tests/datastore_oursql/test_database.py
@@ -3,20 +3,21 @@ import oursql
 from testing_support.fixtures import (validate_transaction_metrics,
             validate_database_trace_inputs)
 
-from testing_support.settings import mysql_settings
+from testing_support.db_settings import mysql_settings
 
 from newrelic.api.background_task import background_task
 
-DB_SETTINGS = mysql_settings()
+DB_SETTINGS = mysql_settings()[0]
+DB_NAMESPACE = DB_SETTINGS["namespace"]
 
 _test_execute_via_cursor_scoped_metrics = [
         ('Function/oursql:Connection', 1),
         ('Function/oursql:Connection.__enter__', 1),
         ('Function/oursql:Connection.__exit__', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/select', 2),
-        ('Datastore/statement/MySQL/datastore_oursql/insert', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/update', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/delete', 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/select' % DB_NAMESPACE, 2),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/insert' % DB_NAMESPACE, 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/update' % DB_NAMESPACE, 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/delete' % DB_NAMESPACE, 1),
         ('Datastore/operation/MySQL/create', 1),
         ('Datastore/operation/MySQL/drop', 1),
         ('Datastore/operation/MySQL/commit', 3),
@@ -28,13 +29,13 @@ _test_execute_via_cursor_rollup_metrics = [
         ('Datastore/MySQL/all', 12),
         ('Datastore/MySQL/allOther', 12),
         ('Datastore/operation/MySQL/select', 2),
-        ('Datastore/statement/MySQL/datastore_oursql/select', 2),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/select' % DB_NAMESPACE, 2),
         ('Datastore/operation/MySQL/insert', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/insert', 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/insert' % DB_NAMESPACE, 1),
         ('Datastore/operation/MySQL/update', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/update', 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/update' % DB_NAMESPACE, 1),
         ('Datastore/operation/MySQL/delete', 1),
-        ('Datastore/statement/MySQL/datastore_oursql/delete', 1),
+        ('Datastore/statement/MySQL/datastore_oursql_%s/delete' % DB_NAMESPACE, 1),
         ('Datastore/operation/MySQL/create', 1),
         ('Datastore/operation/MySQL/drop', 1),
         ('Datastore/operation/MySQL/commit', 3),
@@ -46,22 +47,22 @@ _test_execute_via_cursor_rollup_metrics = [
         background_task=True)
 @validate_database_trace_inputs(sql_parameters_type=tuple)
 @background_task()
-def test_execute_via_cursor():
+def test_execute_via_cursor(table_name):
 
     connection = oursql.connect(db=DB_SETTINGS['name'],
             user=DB_SETTINGS['user'], passwd=DB_SETTINGS['password'],
             host=DB_SETTINGS['host'], port=DB_SETTINGS['port'])
 
     with connection as cursor:
-        cursor.execute("""drop table if exists datastore_oursql""")
+        cursor.execute("""drop table if exists %s""" % table_name)
 
-        cursor.execute("""create table datastore_oursql """
+        cursor.execute("""create table %s """ % table_name +
                 """(a integer, b real, c text)""")
 
-        cursor.executemany("""insert into datastore_oursql values (?, ?, ?)""",
+        cursor.executemany("""insert into %s values (?, ?, ?)""" % table_name,
                 [(1, 1.0, '1.0'), (2, 2.2, '2.2'), (3, 3.3, '3.3')])
 
-        cursor.execute("""select * from datastore_oursql""")
+        cursor.execute("""select * from %s""" % table_name)
 
         # The oursql cursor execute() method takes a non DBAPI2
         # argument to disable parameter interpolation. Also
@@ -69,14 +70,14 @@ def test_execute_via_cursor():
         # speedup in execution because the default way creates a
         # prepared statement every time and then throws it away.
 
-        cursor.execute("""select * from datastore_oursql""", plain_query=True)
+        cursor.execute("""select * from %s""" % table_name, plain_query=True)
 
         for row in cursor: pass
 
-        cursor.execute("""update datastore_oursql set a=?, b=?, c=? """
+        cursor.execute("""update %s set a=?, b=?, c=? """ % table_name +
                 """where a=?""", (4, 4.0, '4.0', 1))
 
-        cursor.execute("""delete from datastore_oursql where a=2""")
+        cursor.execute("""delete from %s where a=2""" % table_name)
 
     connection.commit()
     connection.rollback()

--- a/tests/datastore_oursql/tox.ini
+++ b/tests/datastore_oursql/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    py27-{with,without}-extensions,
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    oursql==0.9.3.2
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+

--- a/tests/datastore_oursql/tox.ini
+++ b/tests/datastore_oursql/tox.ini
@@ -1,7 +1,10 @@
+; NOTE: oursql does not compile properly with mariadb-client bindings. 
+; Debian Jessie is the last version to use mysql-client bindings.
+
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    py27-{with,without}-extensions,
+    py27
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -9,14 +12,17 @@ usefixtures = session_initialization requires_data_collector
 [testenv]
 deps =
     oursql==0.9.3.2
+
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 
 install_command=
     pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
-


### PR DESCRIPTION
Sidekick: @a-feld 

# Overview
* Imports oursql tests from internal repo
* Adds namespacing to tables

# Related Github Issue

PYTHON-3795

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
