### PR TITLE
pyelasticsearch Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -528,6 +528,7 @@ jobs:
       matrix:
         test-directory: 
           - datastore_elasticsearch
+          - datastore_pyelasticsearch
 
     runs-on: ubuntu-latest
 

--- a/tests/datastore_pyelasticsearch/conftest.py
+++ b/tests/datastore_pyelasticsearch/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from testing_support.fixtures import (code_coverage_fixture,
+        collector_agent_registration_fixture, collector_available_fixture)
+
+_coverage_source = [
+    'newrelic.hooks.datastore_pyelasticsearch',
+]
+
+code_coverage = code_coverage_fixture(source=_coverage_source)
+
+_default_settings = {
+    'transaction_tracer.explain_threshold': 0.0,
+    'transaction_tracer.transaction_threshold': 0.0,
+    'transaction_tracer.stack_trace_threshold': 0.0,
+    'debug.log_data_collector_payloads': True,
+    'debug.record_transaction_failure': True
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+        app_name='Python Agent Test (datastore_pyelasticsearch)',
+        default_settings=_default_settings,
+        linked_applications=['Python Agent Test (datastore)'])
+
+@pytest.fixture(scope='session')
+def session_initialization(code_coverage, collector_agent_registration):
+    pass
+
+@pytest.fixture(scope='function')
+def requires_data_collector(collector_available_fixture):
+    pass

--- a/tests/datastore_pyelasticsearch/test_pyelasticsearch.py
+++ b/tests/datastore_pyelasticsearch/test_pyelasticsearch.py
@@ -1,0 +1,101 @@
+import sqlite3
+from pyelasticsearch import ElasticSearch
+
+from testing_support.fixtures import (validate_transaction_metrics,
+    validate_transaction_errors, validate_database_duration)
+from testing_support.settings import elasticsearch_settings
+
+from newrelic.api.background_task import background_task
+
+ES_SETTINGS = elasticsearch_settings()
+ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
+
+def _exercise_es(es):
+    es.index("contacts", "person",
+            {"name": "Joe Tester", "age": 25, "title": "QA Engineer"}, id=1)
+    es.index("contacts", "person",
+            {"name": "Jessica Coder", "age": 32, "title": "Programmer"}, id=2)
+    es.index("contacts", "person",
+            {"name": "Freddy Tester", "age": 29, "title": "Assistant"}, id=3)
+    es.refresh('contacts')
+    es.index("address", "employee", {"name": "Sherlock",
+        "address": "221B Baker Street, London"}, id=1)
+    es.index("address", "employee", {"name": "Bilbo",
+        "address": "Bag End, Bagshot row, Hobbiton, Shire"}, id=2)
+    es.search('name:Joe', index='contacts')
+    es.search('name:jessica', index='contacts')
+    es.search('name:Sherlock', index='address')
+    es.search('name:Bilbo', index=['contacts', 'address'])
+    es.search('name:Bilbo', index='contacts,address')
+    es.search('name:Bilbo', index='*')
+    es.search('name:Bilbo')
+    es.status()
+
+# Common Metrics for tests that use _exercise_es().
+
+_test_pyelasticsearch_scoped_metrics = [
+    ('Datastore/statement/Elasticsearch/contacts/index', 3),
+    ('Datastore/statement/Elasticsearch/contacts/search', 2),
+    ('Datastore/statement/Elasticsearch/address/index', 2),
+    ('Datastore/statement/Elasticsearch/address/search', 1),
+    ('Datastore/statement/Elasticsearch/_all/search', 2),
+    ('Datastore/statement/Elasticsearch/other/search', 2),
+    ('Datastore/statement/Elasticsearch/contacts/refresh', 1),
+    ('Datastore/statement/Elasticsearch/_all/status', 1),
+]
+
+_test_pyelasticsearch_rollup_metrics = [
+    ('Datastore/all', 14),
+    ('Datastore/allOther', 14),
+    ('Datastore/Elasticsearch/all', 14),
+    ('Datastore/Elasticsearch/allOther', 14),
+    ('Datastore/operation/Elasticsearch/index', 5),
+    ('Datastore/operation/Elasticsearch/search', 7),
+    ('Datastore/operation/Elasticsearch/refresh', 1),
+    ('Datastore/operation/Elasticsearch/status', 1),
+    ('Datastore/statement/Elasticsearch/contacts/index', 3),
+    ('Datastore/statement/Elasticsearch/contacts/search', 2),
+    ('Datastore/statement/Elasticsearch/address/index', 2),
+    ('Datastore/statement/Elasticsearch/address/search', 1),
+    ('Datastore/statement/Elasticsearch/_all/search', 2),
+    ('Datastore/statement/Elasticsearch/other/search', 2),
+    ('Datastore/statement/Elasticsearch/contacts/refresh', 1),
+    ('Datastore/statement/Elasticsearch/_all/status', 1),
+]
+
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics(
+        'test_pyelasticsearch:test_pyelasticsearch_operation',
+        scoped_metrics=_test_pyelasticsearch_scoped_metrics,
+        rollup_metrics=_test_pyelasticsearch_rollup_metrics,
+        background_task=True)
+@background_task()
+def test_pyelasticsearch_operation():
+    client = ElasticSearch(ES_URL)
+    _exercise_es(client)
+
+@validate_database_duration()
+@background_task()
+def test_elasticsearch_database_duration():
+    client = ElasticSearch(ES_URL)
+    _exercise_es(client)
+
+@validate_database_duration()
+@background_task()
+def test_elasticsearch_and_sqlite_database_duration():
+
+    # Make ElasticSearch queries
+
+    client = ElasticSearch(ES_URL)
+    _exercise_es(client)
+
+    # Make sqlite queries
+
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+
+    cur.execute("CREATE TABLE contacts (name text, age int)")
+    cur.execute("INSERT INTO contacts VALUES ('Bob', 22)")
+
+    conn.commit()
+    conn.close()

--- a/tests/datastore_pyelasticsearch/test_pyelasticsearch.py
+++ b/tests/datastore_pyelasticsearch/test_pyelasticsearch.py
@@ -3,11 +3,11 @@ from pyelasticsearch import ElasticSearch
 
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors, validate_database_duration)
-from testing_support.settings import elasticsearch_settings
+from testing_support.db_settings import elasticsearch_settings
 
 from newrelic.api.background_task import background_task
 
-ES_SETTINGS = elasticsearch_settings()
+ES_SETTINGS = elasticsearch_settings()[0]
 ES_URL = 'http://%s:%s' % (ES_SETTINGS['host'], ES_SETTINGS['port'])
 
 def _exercise_es(es):

--- a/tests/datastore_pyelasticsearch/tox.ini
+++ b/tests/datastore_pyelasticsearch/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
-    {pypy,pypy3}-without-extensions,
+    py27,py35,py36,py37,py38,py39,pypy,pypy3
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -10,11 +9,15 @@ usefixtures = session_initialization requires_data_collector
 [testenv]
 deps =
     pyelasticsearch<2.0
+
 setenv =
     PYTHONPATH={toxinidir}/..
     TOX_ENVDIR = {envdir}
-    without-extensions: NEW_RELIC_EXTENSIONS = false
-    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+passenv =
+    NEW_RELIC_LICENSE_KEY
+    NEW_RELIC_HOST
+    GITHUB_ACTIONS
 
 commands = py.test -v []
 

--- a/tests/datastore_pyelasticsearch/tox.ini
+++ b/tests/datastore_pyelasticsearch/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 setupdir = {toxinidir}/../..
 envlist =
-    py27,py35,py36,py37,py38,py39,pypy,pypy3
+   py27,py36,pypy
 
 [pytest]
 usefixtures = session_initialization requires_data_collector
@@ -23,4 +23,3 @@ commands = py.test -v []
 
 install_command=
     pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
-

--- a/tests/datastore_pyelasticsearch/tox.ini
+++ b/tests/datastore_pyelasticsearch/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+setupdir = {toxinidir}/../..
+envlist =
+    {py27,py35,py36,py37,py38,py39}-{with,without}-extensions,
+    {pypy,pypy3}-without-extensions,
+
+[pytest]
+usefixtures = session_initialization requires_data_collector
+
+[testenv]
+deps =
+    pyelasticsearch<2.0
+setenv =
+    PYTHONPATH={toxinidir}/..
+    TOX_ENVDIR = {envdir}
+    without-extensions: NEW_RELIC_EXTENSIONS = false
+    with-extensions: NEW_RELIC_EXTENSIONS = true
+
+commands = py.test -v []
+
+install_command=
+    pip install -r {toxinidir}/../base_requirements.txt {opts} {packages}
+


### PR DESCRIPTION
Sidekick: @a-feld 

# Overview

* Import pyelasticsearch tests from internal repo.
* Cleanup tox.ini to remove extension based testing.
