### PR TITLE
Pin setup-python action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,43 +86,43 @@ jobs:
         sudo apt-get install libcurl4-openssl-dev
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
     # Setup pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -186,42 +186,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -288,42 +288,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -382,42 +382,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -480,42 +480,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -578,42 +578,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -673,42 +673,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -767,42 +767,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64
@@ -865,42 +865,42 @@ jobs:
           ${{ runner.os }}-${{ matrix.test-directory }}-
 
     # Set up all versions of python
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 2.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.5
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.6
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.7
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.8
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: 3.9
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy3
         architecture: x64
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@3b3f2de1b1f7c1270fc5b9c37a904fa785e9ae94
       with:
         python-version: pypy2
         architecture: x64


### PR DESCRIPTION
# Overview

* Pin `setup-python` action to known good version using git sha.
  * Following recommendations in [GHA's docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses)