### PR TITLE
Reorder python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -116,20 +127,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    # Setup pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -194,6 +195,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -212,19 +224,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -291,6 +294,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -309,19 +323,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -380,6 +385,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -398,19 +414,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -473,6 +480,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -491,19 +509,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -567,6 +576,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -585,19 +605,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -657,6 +668,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -675,19 +697,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -746,6 +759,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -764,19 +788,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -839,6 +854,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -857,19 +883,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies
@@ -928,6 +945,17 @@ jobs:
     # Set up all versions of python
     - uses: actions/setup-python@v2
       with:
+        python-version: pypy3
+        architecture: x64
+
+    # Set up pypy2 after pypy3 to ensure pypy isn't aliased to pypy3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: pypy2
+        architecture: x64
+
+    - uses: actions/setup-python@v2
+      with:
         python-version: 2.7
         architecture: x64
 
@@ -946,19 +974,10 @@ jobs:
         python-version: 3.8
         architecture: x64
 
+    # Set up python 3.9 last to ensure tox runs CPython
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy3
-        architecture: x64
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: pypy2
         architecture: x64
 
     - name: Install Dependencies


### PR DESCRIPTION
Sidekick: @umaannamalai 

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Reorder python versions.
  * This change makes tox run on CPython 3.9 instead of PyPy2. 

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
