### PR TITLE
Fix crash on non-ascii http referer. #35

### DIFF
--- a/newrelic/api/web_transaction.py
+++ b/newrelic/api/web_transaction.py
@@ -126,6 +126,7 @@ def _parse_synthetics_header(header):
 
 
 def _remove_query_string(url):
+    url = ensure_str(url)
     out = urlparse.urlsplit(url)
     return urlparse.urlunsplit((out.scheme, out.netloc, out.path, '', ''))
 

--- a/tests/agent_features/test_web_transaction.py
+++ b/tests/agent_features/test_web_transaction.py
@@ -60,7 +60,7 @@ def test_base_web_transaction(use_bytes):
         'Content-Length': '0',
         'Content-Type': 'text/plain',
         'Host': 'localhost',
-        'Referer': 'http://example.com?q=1',
+        'Referer': 'http://example.com?q=1&boat=⛵',
         'User-Agent': 'potato',
         'X-Request-Start': str(time.time() - 0.2),
         'newRelic': 'invalid',

--- a/tests/agent_features/test_web_transaction.py
+++ b/tests/agent_features/test_web_transaction.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2010 New Relic, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +22,7 @@ from newrelic.api.web_transaction import WebTransaction
 from testing_support.fixtures import (validate_transaction_metrics,
         validate_attributes)
 from testing_support.sample_applications import simple_app
+import newrelic.packages.six as six
 application = webtest.TestApp(simple_app)
 
 
@@ -71,7 +73,10 @@ def test_base_web_transaction(use_bytes):
 
         for name, value in request_headers.items():
             name = name.encode('utf-8')
-            value = value.encode('utf-8')
+            try:
+                value = value.encode('utf-8')
+            except UnicodeDecodeError:
+                assert six.PY2
             byte_headers[name] = value
 
         request_headers = byte_headers


### PR DESCRIPTION
Thanks to @eykd for the detailed bug report! ❤️ 

This PR fixes a crash that occurs when non-ascii HTTP referers are passed to ASGI applications. The crash is fixed by ensuring the query string value is a decoded string (rather than bytes) prior to calling urlsplit when removing the query string from the referer. A regression test is included.

Fixes: #35 