### PR TITLE
Add httpx response processing. #103

### DIFF
--- a/newrelic/hooks/external_httpx.py
+++ b/newrelic/hooks/external_httpx.py
@@ -32,7 +32,11 @@ def sync_send_wrapper(wrapped, instance, args, kwargs):
                 if header_name not in request.headers:
                     request.headers[header_name] = header_value
 
-        return wrapped(*args, **kwargs)
+        response = wrapped(*args, **kwargs)
+        headers = dict(getattr(response, 'headers', None)).items()
+        tracer.process_response(getattr(response, 'status_code', None), headers)
+
+        return response
 
 
 async def async_send_wrapper(wrapped, instance, args, kwargs):
@@ -46,7 +50,11 @@ async def async_send_wrapper(wrapped, instance, args, kwargs):
                 if header_name not in request.headers:
                     request.headers[header_name] = header_value
 
-        return await wrapped(*args, **kwargs)
+        response = await wrapped(*args, **kwargs)
+        headers = dict(getattr(response, 'headers', None)).items()
+        tracer.process_response(getattr(response, 'status_code', None), headers)
+
+        return response
 
 
 def instrument_httpx_client(module):

--- a/tests/external_httpx/conftest.py
+++ b/tests/external_httpx/conftest.py
@@ -20,9 +20,6 @@ from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
-from testing_support.mock_external_http_server import (
-    MockExternalHTTPHResponseHeadersServer,
-)
 
 _coverage_source = [
     "newrelic.api.external_trace",
@@ -42,12 +39,6 @@ _default_settings = {
 collector_agent_registration = collector_agent_registration_fixture(
     app_name="Python Agent Test (external_httpx)", default_settings=_default_settings
 )
-
-
-@pytest.fixture(scope="session")
-def server():
-    with MockExternalHTTPHResponseHeadersServer() as _server:
-        yield _server
 
 
 @pytest.fixture(scope="session")

--- a/tests/external_httpx/test_client.py
+++ b/tests/external_httpx/test_client.py
@@ -247,6 +247,7 @@ def test_async_cross_process_override_headers(httpx, server, loop):
     assert response.request.headers["newrelic"] == "1234"
 
 
+
 @pytest.mark.parametrize('cat_enabled', [True, False])
 @pytest.mark.parametrize('response_code', [200, 500])
 def test_sync_client_cat_response_processing(cat_enabled, response_code, server, httpx):
@@ -302,8 +303,6 @@ def test_async_client_cat_response_processing(cat_enabled, response_code, httpx,
         ('ExternalTransaction/localhost:%s/1#1/WebTransaction/'
                 'Function/app:beep' % server.port, 1 if cat_enabled else None),
     ]
-
-    expected_metrics = []
 
     @validate_transaction_metrics(
         'test_async_client_cat_response_processing',

--- a/tests/external_httpx/test_client.py
+++ b/tests/external_httpx/test_client.py
@@ -19,16 +19,48 @@ from testing_support.fixtures import (
     override_application_settings,
     validate_transaction_errors,
     validate_transaction_metrics,
+    validate_tt_segment_params,
+    override_application_settings
 )
 from testing_support.validators.validate_cross_process_headers import (
     validate_cross_process_headers,
 )
 
-from newrelic.api.background_task import background_task
 from newrelic.api.transaction import current_transaction
+from newrelic.api.background_task import background_task
+from testing_support.mock_external_http_server import (
+    MockExternalHTTPHResponseHeadersServer)
 
+
+ENCODING_KEY = '1234567890123456789012345678901234567890'
 SCOPED_METRICS = []
 ROLLUP_METRICS = [("External/all", 2), ("External/allOther", 2)]
+
+CAT_RESPONSE_CODE = None
+
+def cat_response_handler(self):
+    global CAT_RESPONSE_CODE
+    # payload
+    # (
+    #     u'1#1', u'WebTransaction/Function/app:beep',
+    #     0, 1.23, -1,
+    #     'dd4a810b7cb7f937',
+    #     False,
+    # )
+    cat_response_header = ('X-NewRelic-App-Data',
+            'ahACFwQUGxpuVVNmQVVbRVZbTVleXBxyQFhUTFBfXx1SREUMV'
+            'V1cQBMeAxgEGAULFR0AHhFQUQJWAAgAUwVQVgJQDgsOEh1UUlhGU2o=')
+    self.send_response(CAT_RESPONSE_CODE)
+    self.send_header(*cat_response_header)
+    self.end_headers()
+    self.wfile.write(b'Example Data')
+
+
+@pytest.fixture(scope='session')
+def server():
+    external = MockExternalHTTPHResponseHeadersServer(handler=cat_response_handler)
+    with external:
+        yield external
 
 
 @pytest.fixture()
@@ -56,8 +88,11 @@ def populate_metrics(server, request):
     rollup_metrics=ROLLUP_METRICS,
     background_task=True,
 )
-@background_task(name="test_sync_client")
-def test_sync_client(httpx, server, method, populate_metrics):
+@background_task(name='test_sync_client')
+def test_sync_client(httpx, server, method):
+    global CAT_RESPONSE_CODE
+    CAT_RESPONSE_CODE = 200
+
     with httpx.Client() as client:
         resolved_method = getattr(client, method)
         resolved_method("http://localhost:%s" % server.port)
@@ -84,8 +119,11 @@ def test_sync_client(httpx, server, method, populate_metrics):
     rollup_metrics=ROLLUP_METRICS,
     background_task=True,
 )
-@background_task(name="test_async_client")
-def test_async_client(httpx, server, loop, method, populate_metrics):
+@background_task(name='test_async_client')
+def test_async_client(httpx, server, loop, method):
+    global CAT_RESPONSE_CODE
+    CAT_RESPONSE_CODE = 200
+
     async def test_async_client():
         async with httpx.AsyncClient() as client:
             resolved_method = getattr(client, method)
@@ -207,3 +245,82 @@ def test_async_cross_process_override_headers(httpx, server, loop):
 
     assert response.status_code == 200
     assert response.request.headers["newrelic"] == "1234"
+
+
+@pytest.mark.parametrize('cat_enabled', [True, False])
+@pytest.mark.parametrize('response_code', [200, 500])
+def test_sync_client_cat_response_processing(cat_enabled, response_code, server, httpx):
+    global CAT_RESPONSE_CODE
+    CAT_RESPONSE_CODE = response_code
+
+    _custom_settings = {
+        'cross_process_id': '1#1',
+        'encoding_key': ENCODING_KEY,
+        'trusted_account_ids': [1],
+        'cross_application_tracer.enabled': cat_enabled,
+        'distributed_tracing.enabled': False,
+        'transaction_tracer.transaction_threshold': 0.0,
+    }
+
+    expected_metrics = [
+        ('ExternalTransaction/localhost:%s/1#1/WebTransaction/'
+                'Function/app:beep' % server.port, 1 if cat_enabled else None),
+    ]
+
+    @validate_transaction_metrics(
+        'test_sync_client_cat_response_processing',
+        background_task=True,
+        rollup_metrics=expected_metrics,
+        scoped_metrics=expected_metrics
+    )
+    @validate_tt_segment_params(exact_params={'http.statusCode': response_code})
+    @override_application_settings(_custom_settings)
+    @background_task(name='test_sync_client_cat_response_processing')
+    def _test():
+        with httpx.Client() as client:
+            response = client.get("http://localhost:%s" % server.port)
+
+    _test()
+
+
+@pytest.mark.parametrize('cat_enabled', [True, False])
+@pytest.mark.parametrize('response_code', [200, 500])
+def test_async_client_cat_response_processing(cat_enabled, response_code, httpx, server, loop):
+    global CAT_RESPONSE_CODE
+    CAT_RESPONSE_CODE = response_code
+
+    _custom_settings = {
+        'cross_process_id': '1#1',
+        'encoding_key': ENCODING_KEY,
+        'trusted_account_ids': [1],
+        'cross_application_tracer.enabled': cat_enabled,
+        'distributed_tracing.enabled': False,
+        'transaction_tracer.transaction_threshold': 0.0,
+    }
+
+    expected_metrics = [
+        ('ExternalTransaction/localhost:%s/1#1/WebTransaction/'
+                'Function/app:beep' % server.port, 1 if cat_enabled else None),
+    ]
+
+    expected_metrics = []
+
+    @validate_transaction_metrics(
+        'test_async_client_cat_response_processing',
+        background_task=True,
+        rollup_metrics=expected_metrics,
+        scoped_metrics=expected_metrics
+    )
+    @validate_tt_segment_params(exact_params={'http.statusCode': response_code})
+    @override_application_settings(_custom_settings)
+    @background_task(name='test_async_client_cat_response_processing')
+    def _test():
+        async def coro():
+            async with httpx.AsyncClient() as client:
+                response = await client.get("http://localhost:%s" % server.port)
+
+            return response
+
+        response = loop.run_until_complete(coro())
+
+    _test()


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This pull request adds functionality to process response headers and add a response status code attribute. It includes tests to verify CAT headers and status code for async and sync clients.

# Related Github Issue
#103 

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
