### PR TITLE
Fix django url import error

### DIFF
--- a/tests/component_djangorestframework/urls.py
+++ b/tests/component_djangorestframework/urls.py
@@ -15,7 +15,10 @@
 try:
     from django.conf.urls.defaults import url
 except ImportError:
-    from django.conf.urls import url
+    try:
+        from django.conf.urls import url
+    except ImportError:
+        from django.urls import re_path as url
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response

--- a/tests/component_tastypie/urls.py
+++ b/tests/component_tastypie/urls.py
@@ -15,7 +15,10 @@
 try:
     from django.conf.urls import url, include
 except ImportError:
-    from django.conf.urls.defaults import url, include
+    try:
+        from django.conf.urls.defaults import url, include
+    except ImportError:
+        from django.urls import re_path as url, include
 
 from tastypie.api import Api
 

--- a/tests/framework_django/urls.py
+++ b/tests/framework_django/urls.py
@@ -15,7 +15,10 @@
 try:
     from django.conf.urls.defaults import url
 except ImportError:
-    from django.conf.urls import url
+    try:
+        from django.conf.urls import url
+    except ImportError:
+        from django.urls import re_path as url
 
 import views
 


### PR DESCRIPTION
Sidekick: @umaannamalai 

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Fix failing django tests with backwards compatible import changes.

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
