### PR TITLE
Fix httpx response header logic.

### DIFF
--- a/newrelic/hooks/external_httpx.py
+++ b/newrelic/hooks/external_httpx.py
@@ -83,7 +83,7 @@ def sync_send_wrapper(wrapped, instance, args, kwargs):
                     request.headers[header_name] = header_value
 
         response = wrapped(*args, **kwargs)
-        headers = dict(getattr(response, "headers", None)).items()
+        headers = dict(getattr(response, "headers", ())).items()
         tracer.process_response(getattr(response, "status_code", None), headers)
 
         return response
@@ -101,7 +101,7 @@ async def async_send_wrapper(wrapped, instance, args, kwargs):
                     request.headers[header_name] = header_value
 
         response = await wrapped(*args, **kwargs)
-        headers = dict(getattr(response, "headers", None)).items()
+        headers = dict(getattr(response, "headers", ())).items()
         tracer.process_response(getattr(response, "status_code", None), headers)
 
         return response

--- a/newrelic/hooks/external_httpx.py
+++ b/newrelic/hooks/external_httpx.py
@@ -22,13 +22,13 @@ from newrelic.common.object_wrapper import wrap_function_wrapper
 
 def newrelic_event_hook(response):
     tracer = current_trace()
-    headers = dict(getattr(response, "headers", None)).items()
+    headers = dict(getattr(response, "headers", ())).items()
     tracer.process_response(getattr(response, "status_code", None), headers)
 
 
 async def newrelic_event_hook_async(response):
     tracer = current_trace()
-    headers = dict(getattr(response, "headers", None)).items()
+    headers = dict(getattr(response, "headers", ())).items()
     tracer.process_response(getattr(response, "status_code", None), headers)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -232,7 +232,7 @@ deps =
     framework_flask-flask0012: flask<0.13
     framework_flask-flask0101: flask<1.2
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/master.zip
-    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/master.zip
+    framework_flask-flaskmaster: flask
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
     framework_grpc-grpclatest: grpcio


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This pull request includes a fix in the use of getattr() to grab response headers for httpx.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
