### PR TITLE
Pin version of uhashring to support py27 for bmemcached.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -161,6 +161,7 @@ deps =
     cross_agent: requests
     datastore_asyncpg: asyncpg
     datastore_bmemcached-memcached030: python-binary-memcached<0.31
+    datastore_bmemcached-memcached030: uhashring<2.0
     datastore_elasticsearch: requests
     datastore_elasticsearch-elasticsearch00: elasticsearch<1.0
     datastore_elasticsearch-elasticsearch01: elasticsearch<2.0


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
uhashring dropped support for Python 2.7 in their 2.0 release. Since bmemcached installs this package, this PR pins a previous version of uhashring so we can continue to support Python 2.7.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
