### PR TITLE
Fixes a bug that when using uvicorn and nginx with an upstream server via a unix socket results in a TypeError.

### DIFF
--- a/newrelic/api/asgi_application.py
+++ b/newrelic/api/asgi_application.py
@@ -225,7 +225,7 @@ class ASGIWebTransaction(WebTransaction):
         self.receive = receive
         self._send = send
         scheme = scope.get("scheme", "http")
-        if "server" in scope:
+        if "server" in scope and scope["server"] is not None:
             host, port = scope["server"] = tuple(scope["server"])
         else:
             host, port = None, None


### PR DESCRIPTION
Stack trace:

	[2021-02-14 05:24:40 +0000] [21] [ERROR] Exception in ASGI application
	Traceback (most recent call last):
	  File "/venv/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 399, in run_asgi
	    result = await app(self.scope, self.receive, self.send)
	  File "/venv/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 45, in __call__
	    return await self.app(scope, receive, send)
	  File "/venv/lib/python3.8/site-packages/newrelic/api/asgi_application.py", line 332, in nr_async_asgi
	    with ASGIWebTransaction(
	  File "/venv/lib/python3.8/site-packages/newrelic/api/asgi_application.py", line 229, in __init__
	    host, port = scope["server"] = tuple(scope["server"])
	TypeError: 'NoneType' object is not iterable
	 - "GET / HTTP/1.0" 500
	Exception ignored in: <function Transaction.__del__ at 0x7f020a19e1f0>
	Traceback (most recent call last):
	  File "/venv/lib/python3.8/site-packages/newrelic/api/transaction.py", line 308, in __del__
	    if self._state == self.STATE_RUNNING:
	AttributeError: 'ASGIWebTransaction' object has no attribute '_state'

Uvicorn will set the asgi scope server property to None if using a unix socket. 
See: https://github.com/encode/uvicorn/blob/bd1a0962d36c66e823e13012df14a0fe7e36cc9c/uvicorn/protocols/http/httptools_impl.py#L133

The newrelic agent assumes this value is a tuple, and tries to split it into two variables for host and port *if* it is defined.

The fix is to check that the value is not None.