### PR TITLE
Refactor NewRelicContextFormatter, add log_record_to_dict

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -60,7 +60,8 @@ class NewRelicContextFormatter(Formatter):
     def __init__(self, *args, **kwargs):
         super(NewRelicContextFormatter, self).__init__()
 
-    def format(self, record):
+    @classmethod
+    def log_record_to_dict(cls, record):
         output = {
             "timestamp": int(record.created * 1000),
             "message": record.getMessage(),
@@ -75,7 +76,7 @@ class NewRelicContextFormatter(Formatter):
         }
         output.update(get_linking_metadata())
 
-        DEFAULT_LOG_RECORD_KEYS = self.DEFAULT_LOG_RECORD_KEYS
+        DEFAULT_LOG_RECORD_KEYS = cls.DEFAULT_LOG_RECORD_KEYS
         if len(record.__dict__) > len(DEFAULT_LOG_RECORD_KEYS):
             for key in record.__dict__:
                 if key not in DEFAULT_LOG_RECORD_KEYS:
@@ -88,4 +89,8 @@ class NewRelicContextFormatter(Formatter):
 
         if record.exc_info:
             output.update(format_exc_info(record.exc_info))
-        return json.dumps(output)
+
+        return output
+
+    def format(self, record):
+        return json.dumps(self.log_record_to_dict(record))


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Refactors the `api.log.NewRelicContextFormatter`, so that converting the log record to a dict, and serializing to JSON, are achievable separately.

## Reasoning

This change makes it easy to add the data exposed by `NewRelicContextFormatter` in custom formatters.

Without this change, a custom formatter has essentially two options:

1. Call `NewRelicContextFormatter.format`, deserialize the returned JSON, extend as desired, then re-serialize.
2. Copy the logic from `NewRelicContextFormatter`. This is undesirable for many reasons, not the least of which is that we can only assume that it will change over time, potentially breaking log integration when it does.

With this change in place, a custom formatter can call `NewRelicContextFormatter.log_record_to_dict` to get the correct values in dict format, extend as desired, then serialize.

# Related Github Issue

I haven't opened one as this is such a small change, it seems appropriate to discuss here rather than the issue tracker.

# Testing

No tests added as functionality is essentially unchanged. I can add a specific test for `log_record_to_dict` if desired.

The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
