### PR TITLE
Fixes a bug that when sanic response header (ex. Content-Length) not logged.

### DIFF
--- a/newrelic/hooks/framework_sanic.py
+++ b/newrelic/hooks/framework_sanic.py
@@ -237,5 +237,5 @@ def instrument_sanic_app(module):
 
 
 def instrument_sanic_response(module):
-    wrap_function_wrapper(module, 'BaseHTTPResponse._parse_headers',
+    wrap_function_wrapper(module, 'BaseHTTPResponse.get_headers',
         _nr_sanic_response_parse_headers)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
In Sanic Framework (version > 19.x), response.headers(ex. `response.headers.contentLength`) are not logging.
I found that newrelic agent patches response hook to old method (it is not called not, and removed in sanic code after [19.12.5](https://github.com/sanic-org/sanic/compare/v19.12.5...master) )

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
