### PR TITLE
Fix NewRelicContextFormatter converts all extra log attributes to strings

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -57,12 +57,7 @@ class NewRelicContextFormatter(Formatter):
         if len(record.__dict__) > len(DEFAULT_LOG_RECORD_KEYS):
             for key in record.__dict__:
                 if key not in DEFAULT_LOG_RECORD_KEYS:
-                    try:
-                        value = str(getattr(record, key))
-                    except Exception:
-                        continue
-
-                    output["extra." + key] = value
+                    output['extra.' + key] = getattr(record, key)
 
         if record.exc_info:
             output.update(format_exc_info(record.exc_info))
@@ -70,4 +65,4 @@ class NewRelicContextFormatter(Formatter):
         return output
 
     def format(self, record):
-        return json.dumps(self.log_record_to_dict(record))
+        return json.dumps(self.log_record_to_dict(record), default=str)

--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -65,4 +65,4 @@ class NewRelicContextFormatter(Formatter):
         return output
 
     def format(self, record):
-        return json.dumps(self.log_record_to_dict(record), default=str)
+        return json.dumps(self.log_record_to_dict(record), default=str, separators=(',', ':'))

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -47,7 +47,20 @@ def log_buffer(caplog):
 
 
 def test_newrelic_logger_no_error(log_buffer):
-    _logger.info(u"Hello %s", u"World", extra={"foo": "bar"})
+    extra = {
+        "string": "foo",
+        "integer": 1,
+        "float": 1.23,
+        "null": None,
+        "array": [1, 2, 3],
+        "bool": True,
+        "non_serializable": {"set"},
+        "object": {
+            "first": "bar",
+            "second": "baz",
+        },
+    }
+    _logger.info(u"Hello %s", u"World", extra=extra)
 
     log_buffer.seek(0)
     message = json.load(log_buffer)
@@ -71,7 +84,17 @@ def test_newrelic_logger_no_error(log_buffer):
         u"logger.name": u"test_logs_in_context",
         u"thread.name": u"MainThread",
         u"process.name": u"MainProcess",
-        u"extra.foo": u"bar",
+        u"extra.string": u"foo",
+        u"extra.integer": 1,
+        u"extra.float": 1.23,
+        u"extra.null": None,
+        u"extra.array": [1, 2, 3],
+        u"extra.bool": True,
+        u"extra.non_serializable": u"set(['set'])" if six.PY2 else u"{'set'}",
+        u"extra.object": {
+            u"first": u"bar",
+            u"second": u"baz",
+        },
     }
 
 


### PR DESCRIPTION
# Overview
- Fix NewRelicContextFormatter converts all extra log attributes to strings (resolves #21).
- Remove whitespaces from JSON log output.

NewRelicContextFormatter converts all extra log attributes to strings. This PR changes the behavior so that attributes are only converted to string if JSON serialization is not possible (by using `default=str` argument). This allows nested dictionary types to be used as log attributes.

For example:
```python
logging.info("Hello world!", extra={"integer": 123, "nested": {"foo": "bar"}})`
```
Before changes:
```json
{"message": "Hello world!", "integer": "123", "nested": "{'foo': 'bar'}"}
```
After changes (whitespaces removed, integer≠string, dictionary≠string):
```json
{"message":"Hello world!","integer":123,"nested":{"foo":"bar"}}
```

# Related Github Issue
https://github.com/newrelic/newrelic-python-agent/issues/21