### PR TITLE
Expected Error Attribute

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -15,7 +15,7 @@
 import json
 import newrelic.packages.six as six
 from logging import Formatter, LogRecord
-from newrelic.api.time_trace import get_linking_metadata
+from newrelic.api.time_trace import get_linking_metadata, _is_expected_error
 
 
 def format_exc_info(exc_info):
@@ -51,6 +51,7 @@ def format_exc_info(exc_info):
     return {
         "error.class": fullname,
         "error.message": message,
+        "error.expected": str(_is_expected_error(fullname, message)),
     }
 
 

--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -51,7 +51,7 @@ def format_exc_info(exc_info):
     return {
         "error.class": fullname,
         "error.message": message,
-        "error.expected": str(_is_expected_error(fullname, message)),
+        "error.expected": _is_expected_error(fullname, message),
     }
 
 

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -22,6 +22,7 @@ from newrelic.core.trace_cache import trace_cache
 from newrelic.core.attribute import (
         process_user_attribute, MAX_NUM_USER_ATTRIBUTES)
 from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
+from newrelic.core.config import global_settings
 
 _logger = logging.getLogger(__name__)
 
@@ -255,7 +256,7 @@ class TimeTrace(object):
             if module:
                 names = ('%s:%s' % (module, name), '%s.%s' % (module, name))
             else:
-                names = (name)
+                names = (name,)
 
             for fullname in names:
                 if not callable(ignore_errors) and fullname in ignore_errors:
@@ -297,6 +298,10 @@ class TimeTrace(object):
                 except Exception:
                     message = '<unprintable %s object>' % type(value).__name__
 
+        # Check against ignore rules in settings
+        if _should_ignore_error(fullname, message):
+            return
+
         # Record a supportability metric if error attributes are being
         # overiden.
         if 'error.class' in self.agent_attributes:
@@ -304,9 +309,11 @@ class TimeTrace(object):
                     'Supportability/'
                     'SpanEvent/Errors/Dropped')
         # Add error details as agent attributes to span event.
-        self._add_agent_attribute('error.class', fullname)
-        self._add_agent_attribute('error.message', message)
-        self._add_agent_attribute('error.exepected', _is_expected_error(fullname, message))
+        self._add_agent_attribute("error.class", fullname)
+        self._add_agent_attribute("error.message", message)
+        self._add_agent_attribute(
+            "error.exepected", _is_expected_error(fullname, message)
+        )
         return fullname, message, tb
 
     def record_exception(self, exc_info=None,
@@ -542,12 +549,42 @@ def get_linking_metadata():
         }
 
 
-def _is_expected_error(fullname, message):
+def _is_expected_error(fullname, message, status_code=None):
+    return _error_matches_rules(
+        "expected",
+        fullname,
+        message,
+        status_code=status_code,
+    )
+
+
+def _should_ignore_error(fullname, message, status_code=None):
+    return _error_matches_rules(
+        "ignore",
+        fullname,
+        message,
+        status_code=status_code,
+    )
+
+
+def _error_matches_rules(
+    rules_prefix,
+    fullname,
+    message=None,
+    status_code=None,
+    classes_rules=None,
+    status_codes_rules=None,
+):
     trace = current_trace()
     settings = trace and trace.settings
+    settings = settings or global_settings()  # Default to global settings
 
-    if settings:
-        pass
+    if not settings:
+        return False
+
+    # TODO Remove default None after settings are implemented
+    classes_rules = getattr(settings.error_collector, "%s_classes" % rules_prefix, None)
+    status_codes_rules = getattr(settings.error_collector, "%s_status_codes" % rules_prefix, None)
 
     return False
 

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -306,6 +306,7 @@ class TimeTrace(object):
         # Add error details as agent attributes to span event.
         self._add_agent_attribute('error.class', fullname)
         self._add_agent_attribute('error.message', message)
+        self._add_agent_attribute('error.exepected', _is_expected_error(fullname, message))
         return fullname, message, tb
 
     def record_exception(self, exc_info=None,
@@ -540,6 +541,15 @@ def get_linking_metadata():
             "entity.type": "SERVICE",
         }
 
+
+def _is_expected_error(fullname, message):
+    trace = current_trace()
+    settings = trace and trace.settings
+
+    if settings:
+        pass
+
+    return False
 
 def record_exception(exc=None, value=None, tb=None, params={},
         ignore_errors=[], application=None):

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -312,7 +312,7 @@ class TimeTrace(object):
         self._add_agent_attribute("error.class", fullname)
         self._add_agent_attribute("error.message", message)
         self._add_agent_attribute(
-            "error.exepected", _is_expected_error(fullname, message)
+            "error.expected", _is_expected_error(fullname, message)
         )
         return fullname, message, tb
 

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -69,6 +69,7 @@ _TRANSACTION_EVENT_DEFAULT_ATTRIBUTES = set((
         'db.statement',
         'error.class',
         'error.message',
+        'error.expected',
         'peer.hostname',
         'peer.address',
 ))

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -41,6 +41,7 @@ from newrelic.core.metric import TimeMetric
 from newrelic.core.stack_trace import exception_stack
 
 from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
+from newrelic.api.time_trace import _is_expected_error
 from newrelic.common.encoding_utils import json_encode
 from newrelic.common.streaming_utils import StreamBuffer
 
@@ -733,6 +734,7 @@ class StatsEngine(object):
                 'type': 'TransactionError',
                 'error.class': error.type,
                 'error.message': error.message,
+                'error.expected': _is_expected_error(error.type, error.message),
                 'timestamp': int(1000.0 * error.start_time),
                 'transactionName': None,
         }

--- a/newrelic/core/transaction_node.py
+++ b/newrelic/core/transaction_node.py
@@ -23,6 +23,8 @@ from collections import namedtuple
 import newrelic.core.error_collector
 import newrelic.core.trace_node
 
+from newrelic.api.time_trace import _is_expected_error
+
 from newrelic.core.metric import ApdexMetric, TimeMetric
 from newrelic.core.string_table import StringTable
 from newrelic.core.attribute import create_user_attributes
@@ -509,6 +511,7 @@ class TransactionNode(_TransactionNode):
         intrinsics['type'] = "TransactionError"
         intrinsics['error.class'] = error.type
         intrinsics['error.message'] = error.message
+        intrinsics['error.expected'] = _is_expected_error(error.type, error.message)
         intrinsics['transactionName'] = self.path
         intrinsics['spanId'] = error.span_id
 

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -79,7 +79,7 @@ BROWSER_INTRINSIC_KEYS = ["beacon", "errorBeacon", "licenseKey",
 ABSENT_BROWSER_KEYS = ['request.method', 'request.headers.contentType',
         'request.headers.contentLength']
 
-ERROR_EVENT_INTRINSICS = ('type', 'error.class', 'error.message', 'timestamp',
+ERROR_EVENT_INTRINSICS = ('type', 'error.class', 'error.message', 'error.expected', 'timestamp',
         'transactionName', 'duration')
 ERROR_PARAMS = ['ohnoes', ]
 ERROR_USER_ATTRS = USER_ATTRS + ERROR_PARAMS
@@ -858,7 +858,7 @@ def test_browser_monitoring_disabled(normal_application):
 
 # Test outside transaction (error traces and events only).
 
-INTRSICS_NO_TRANS = ('type', 'error.class', 'error.message', 'timestamp',
+INTRSICS_NO_TRANS = ('type', 'error.class', 'error.message', 'error.expected', 'timestamp',
         'transactionName')
 
 

--- a/tests/agent_features/test_error_events.py
+++ b/tests/agent_features/test_error_events.py
@@ -41,6 +41,7 @@ fully_featured_application = webtest.TestApp(fully_featured_app)
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'WebTransaction/Uri/',
         'port': 80,     # SERVER_PORT default value in webtest WSGI environ
 }
@@ -58,6 +59,7 @@ def test_transaction_error_event_no_extra_attributes():
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'WebTransaction/Uri/',
         'databaseCallCount': 2,
         'externalCallCount': 2,
@@ -80,6 +82,7 @@ def test_transaction_error_event_lotsa_attributes():
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'OtherTransaction/Uri/',
         'databaseCallCount': 2,
         'externalCallCount': 2,
@@ -100,6 +103,7 @@ def test_transaction_error_background_task():
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'WebTransaction/Uri/',
         'nr.referringTransactionGuid': 7,
 }
@@ -120,6 +124,7 @@ def test_transaction_error_cross_agent():
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'WebTransaction/Uri/',
         'nr.syntheticsResourceId' : SYNTHETICS_RESOURCE_ID,
         'nr.syntheticsJobId' : SYNTHETICS_JOB_ID,
@@ -144,6 +149,7 @@ def test_transaction_error_with_synthetics():
 _intrinsic_attributes = {
         'error.class': callable_name(ERROR),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
         'transactionName' : 'WebTransaction/Uri/'
 }
 
@@ -200,6 +206,7 @@ outside_error = ErrorEventOutsideTransactionError(ERR_MESSAGE)
 _intrinsic_attributes = {
         'error.class': callable_name(outside_error),
         'error.message': ERR_MESSAGE,
+        'error.expected': False,
 }
 
 @reset_core_stats_engine()

--- a/tests/agent_features/test_high_security_mode.py
+++ b/tests/agent_features/test_high_security_mode.py
@@ -427,7 +427,7 @@ def test_other_transaction_error_parameters_hsm_enabled():
 
 _err_message = "Error! :("
 _intrinsic_attributes = {'error.class': callable_name(TestException),
-        'error.message': _err_message}
+        'error.message': _err_message, "error.expected": False}
 
 
 @reset_core_stats_engine()
@@ -444,7 +444,7 @@ def test_non_transaction_error_parameters_hsm_disabled():
 
 
 _intrinsic_attributes = {'error.class': callable_name(TestException),
-        'error.message': STRIP_EXCEPTION_MESSAGE}
+        'error.message': STRIP_EXCEPTION_MESSAGE, "error.expected": False}
 
 
 @reset_core_stats_engine()

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -109,6 +109,7 @@ def test_newrelic_logger_error(log_buffer):
         u"process.name": u"MainProcess",
         u"error.class": u"test_logs_in_context.ExceptionForTest",
         u"error.message": u"",
+        u"error.expected": u"False",
     }
 
 

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -109,7 +109,7 @@ def test_newrelic_logger_error(log_buffer):
         u"process.name": u"MainProcess",
         u"error.class": u"test_logs_in_context.ExceptionForTest",
         u"error.message": u"",
-        u"error.expected": u"False",
+        u"error.expected": False,
     }
 
 

--- a/tests/agent_features/test_span_events.py
+++ b/tests/agent_features/test_span_events.py
@@ -716,6 +716,7 @@ def test_span_event_multiple_errors(trace_type, args):
     exact_agents = {
         'error.class': callable_name(error),
         'error.message': 'whoops',
+        "error.expected": False,
     }
 
     @override_application_settings(_settings)

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -1948,6 +1948,8 @@ def validate_error_event_sample_data(required_attrs={},
                         'error.class'] == required_attrs['error.class']
                 assert intrinsics['error.message'].startswith(
                         required_attrs['error.message'])
+                assert intrinsics[
+                        'error.expected'] == required_attrs['error.expected']
                 assert intrinsics['nr.transactionGuid'] is not None
                 assert intrinsics['spanId'] is not None
 

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -845,6 +845,8 @@ def validate_non_transaction_error_event(required_intrinsics={}, num_errors=1,
                         'error.class'] == required_intrinsics['error.class']
                 assert intrinsics['error.message'].startswith(
                         required_intrinsics['error.message'])
+                assert intrinsics[
+                        'error.expected'] == required_intrinsics['error.expected']
                 now = time.time()
                 assert isinstance(intrinsics['timestamp'], int)
                 assert intrinsics['timestamp'] <= 1000.0 * now
@@ -1834,6 +1836,7 @@ def validate_transaction_event_sample_data(required_attrs,
 
         assert 'error.class' not in intrinsics
         assert 'error.message' not in intrinsics
+        assert 'error.expected' not in intrinsics
         assert 'transactionName' not in intrinsics
 
         _validate_event_attributes(intrinsics,


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Add `error.expected` attribute to span events, and error events. Currently always false.
* Add scaffolding for error rule matching logic.

# Related Github Issue
Closes #194

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
