### PR TITLE
Deprecate error_collector.ignore_errors setting.

### DIFF
--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -262,7 +262,7 @@ class TimeTrace(object):
                 if not callable(ignore_errors) and fullname in ignore_errors:
                     return
 
-                if fullname in settings.error_collector.ignore_errors:
+                if fullname in settings.error_collector.ignore_classes:
                     return
 
             fullname = names[0]

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -652,7 +652,7 @@ _settings.transaction_tracer.attributes.include = []
 _settings.error_collector.enabled = True
 _settings.error_collector.capture_events = True
 _settings.error_collector.capture_source = False
-_settings.error_collector.ignore_errors = []
+_settings.error_collector.ignore_classes = []
 _settings.error_collector.ignore_status_codes = _parse_status_codes(
         '100-102 200-208 226 300-308 404', set())
 _settings.error_collector.expected_classes = []

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -623,7 +623,7 @@ class StatsEngine(object):
             if not callable(ignore_errors) and fullname in ignore_errors:
                 return
 
-            if fullname in error_collector.ignore_errors:
+            if fullname in error_collector.ignore_classes:
                 return
 
             if module:

--- a/newrelic/newrelic.ini
+++ b/newrelic/newrelic.ini
@@ -154,7 +154,13 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors =
+error_collector.ignore_classes =
+
+# Expected errors are reported to the UI but will not affect the
+# Apdex or error rate. To mark specific errors as expected, set this
+# to a space separated list of the Python exception type names to
+# expected. The exception name should be of the form 'module:class'.
+error_collector.expected_classes =
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -21,6 +21,7 @@ except ImportError:
     import urllib.parse as urlparse
 
 from newrelic.config import delete_setting, translate_deprecated_settings
+from newrelic.common.object_names import callable_name
 from newrelic.core.config import (global_settings_dump, flatten_settings,
     apply_config_setting, apply_server_side_settings, Settings,
     fetch_config_setting, global_settings)
@@ -473,8 +474,8 @@ translate_settings_tests = [
             1200, 1200)
     ),
 (
-        TSetting('error_collector.ignore_errors', "builtins:ValueError", []),
-        TSetting('error_collector.ignore_classes', "builtins:ValueError", [])
+        TSetting('error_collector.ignore_errors', callable_name(ValueError), []),
+        TSetting('error_collector.ignore_classes', callable_name(ValueError), [])
     ),
 
 ]

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -472,6 +472,10 @@ translate_settings_tests = [
         TSetting('event_harvest_config.harvest_limits.custom_event_data',
             1200, 1200)
     ),
+(
+        TSetting('error_collector.ignore_errors', "builtins:ValueError", []),
+        TSetting('error_collector.ignore_classes', "builtins:ValueError", [])
+    ),
 
 ]
 

--- a/tests/agent_features/test_ignore_expected_errors.py
+++ b/tests/agent_features/test_ignore_expected_errors.py
@@ -39,7 +39,7 @@ expected_runtime_error_settings = {
     "error_collector.expected_classes": _runtime_error_name
 }
 ignore_runtime_error_settings = {
-    "error_collector.ignore_errors": _runtime_error_name
+    "error_collector.ignore_classes": _runtime_error_name
 }  # TODO Change this to the new setting
 combined_runtime_error_settings = {}
 combined_runtime_error_settings.update(expected_runtime_error_settings)


### PR DESCRIPTION
This PR deprecates the  error_collector.ignore_errors setting in favor of  error_collector.ignore_classes setting.

Closes #192. 