### PR TITLE
Add notice_error API

### DIFF
--- a/newrelic/agent.py
+++ b/newrelic/agent.py
@@ -38,7 +38,8 @@ from newrelic.api.time_trace import (
         current_trace as __current_trace,
         get_linking_metadata as __get_linking_metadata,
         add_custom_span_attribute as __add_custom_span_attribute,
-        record_exception as __record_exception)
+        record_exception as __record_exception,
+        notice_error as __notice_error)
 
 from newrelic.api.transaction import (
         current_transaction as __current_transaction,
@@ -242,6 +243,8 @@ add_framework_info = __wrap_api_call(__add_framework_info,
         'add_framework_info')
 record_exception = __wrap_api_call(__record_exception,
         'record_exception')
+notice_error = __wrap_api_call(__notice_error,
+        'notice_error')
 get_browser_timing_header = __wrap_api_call(__get_browser_timing_header,
         'get_browser_timing_header')
 get_browser_timing_footer = __wrap_api_call(__get_browser_timing_footer,

--- a/newrelic/api/application.py
+++ b/newrelic/api/application.py
@@ -121,11 +121,11 @@ class Application(object):
         self._agent.record_exception(self._name, exc, value, tb, params,
                 ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
         if not self.active:
             return
 
-        self._agent.notice_error(self._name, error=error, attributes=attributes, expected=expected)
+        self._agent.notice_error(self._name, error=error, attributes=attributes, expected=expected, ignore=ignore)
 
     def record_custom_metric(self, name, value):
         if self.active:

--- a/newrelic/api/application.py
+++ b/newrelic/api/application.py
@@ -121,11 +121,18 @@ class Application(object):
         self._agent.record_exception(self._name, exc, value, tb, params,
                 ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         if not self.active:
             return
 
-        self._agent.notice_error(self._name, error=error, attributes=attributes, expected=expected, ignore=ignore)
+        self._agent.notice_error(
+            self._name,
+            error=error,
+            attributes=attributes,
+            expected=expected,
+            ignore=ignore,
+            status_code=status_code,
+        )
 
     def record_custom_metric(self, name, value):
         if self.active:

--- a/newrelic/api/application.py
+++ b/newrelic/api/application.py
@@ -113,12 +113,19 @@ class Application(object):
 
     def record_exception(self, exc=None, value=None, tb=None, params={},
             ignore_errors=[]):
+        # Deprecated, but deprecation warning are handled by underlying function calls
 
         if not self.active:
             return
 
         self._agent.record_exception(self._name, exc, value, tb, params,
                 ignore_errors)
+
+    def notice_error(self, error=None, attributes={}, expected=None):
+        if not self.active:
+            return
+
+        self._agent.notice_error(self._name, error=error, attributes=attributes, expected=expected)
 
     def record_custom_metric(self, name, value):
         if self.active:

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -192,7 +192,7 @@ class TimeTrace(object):
 
         self.user_attributes[key] = value
 
-    def _observe_exception(self, exc_info=None, ignore=None, expected=None):
+    def _observe_exception(self, exc_info=None, ignore=None, expected=None, status_code=None):
         # Bail out if the transaction is not active or
         # collection of errors not enabled.
 
@@ -295,7 +295,12 @@ class TimeTrace(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(module=module, name=name, message=message)
+            should_ignore = should_ignore_error(
+                                module=module, 
+                                name=name, 
+                                message=message, 
+                                status_code=status_code,
+                            )
             if should_ignore:
                 return
 
@@ -314,7 +319,12 @@ class TimeTrace(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(module=module, name=name, message=message)
+            is_expected = is_expected_error(
+                                module=module, 
+                                name=name, 
+                                message=message, 
+                                status_code=status_code,
+                            )
 
         # Record a supportability metric if error attributes are being
         # overiden.
@@ -330,8 +340,13 @@ class TimeTrace(object):
 
         return fullname, message, tb, is_expected
 
-    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
-        recorded = self._observe_exception(error, ignore=ignore, expected=expected)
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
+        recorded = self._observe_exception(
+                        error, 
+                        ignore=ignore, 
+                        expected=expected, 
+                        status_code=status_code,
+                    )
         if recorded:
             fullname, message, tb, is_expected = recorded
             transaction = self.transaction
@@ -621,11 +636,23 @@ def record_exception(exc=None, value=None, tb=None, params={},
                     ignore_errors)
 
 
-def notice_error(error=None, attributes={}, expected=None, ignore=None, application=None):
+def notice_error(error=None, attributes={}, expected=None, ignore=None, application=None, status_code=None):
     if application is None:
         trace = current_trace()
         if trace:
-            trace.notice_error(error, attributes, expected, ignore)
+            trace.notice_error(
+                error=error,
+                attributes=attributes,
+                expected=expected,
+                ignore=ignore,
+                status_code=status_code,
+            )
     else:
         if application.enabled:
-            application.notice_error(error, attributes, expected, ignore)
+            application.notice_error(
+                error=error,
+                attributes=attributes,
+                expected=expected,
+                ignore=ignore,
+                status_code=status_code,
+            )

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -399,6 +399,8 @@ class TimeTrace(object):
         # Check ignore_errors callables
         # We check these here separatly from the notice_error implementation
         # to preserve previous functionality in precedence
+        should_ignore = None
+        
         if hasattr(transaction, '_ignore_errors'):
             should_ignore = transaction._ignore_errors(exc, value, tb)
             if should_ignore:

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -1500,7 +1500,7 @@ class Transaction(object):
                     params=params,
                     ignore_errors=ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         settings = self._settings
 
         if not settings:
@@ -1514,7 +1514,13 @@ class Transaction(object):
 
         current_span = trace_cache().current_trace()
         if current_span:
-            current_span.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
+            current_span.notice_error(
+                error=error,
+                attributes=attributes,
+                expected=expected,
+                ignore=ignore,
+                status_code=status_code,
+            )
 
     def _create_error_node(self, settings, fullname, message,
                            expected, custom_params, span_id, tb):

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -1481,6 +1481,7 @@ class Transaction(object):
 
     def record_exception(self, exc=None, value=None, tb=None,
                          params={}, ignore_errors=[]):
+        # Deprecated, but deprecation warning are handled by underlying function calls
         settings = self._settings
 
         if not settings:
@@ -1498,6 +1499,22 @@ class Transaction(object):
                     (exc, value, tb),
                     params=params,
                     ignore_errors=ignore_errors)
+
+    def notice_error(self, error=None, attributes={}, expected=None):
+        settings = self._settings
+
+        if not settings:
+            return
+
+        if not settings.error_collector.enabled:
+            return
+
+        if not settings.collect_errors and not settings.collect_error_events:
+            return
+
+        current_span = trace_cache().current_trace()
+        if current_span:
+            current_span.notice_error(error=error, attributes=attributes, expected=expected)
 
     def _create_error_node(self, settings, fullname, message,
                            expected, custom_params, span_id, tb):

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -1500,7 +1500,7 @@ class Transaction(object):
                     params=params,
                     ignore_errors=ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
         settings = self._settings
 
         if not settings:
@@ -1514,7 +1514,7 @@ class Transaction(object):
 
         current_span = trace_cache().current_trace()
         if current_span:
-            current_span.notice_error(error=error, attributes=attributes, expected=expected)
+            current_span.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
 
     def _create_error_node(self, settings, fullname, message,
                            expected, custom_params, span_id, tb):

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -505,12 +505,20 @@ class Agent(object):
 
     def record_exception(self, app_name, exc=None, value=None, tb=None,
             params={}, ignore_errors=[]):
+        # Deprecated, but deprecation warning are handled by underlying function calls
 
         application = self._applications.get(app_name, None)
         if application is None or not application.active:
             return
 
         application.record_exception(exc, value, tb, params, ignore_errors)
+
+    def notice_error(self, app_name, error=None, attributes={}, expected=None):
+        application = self._applications.get(app_name, None)
+        if application is None or not application.active:
+            return
+
+        application.notice_error(error=error, attributes=attributes, expected=expected)
 
     def record_custom_metric(self, app_name, name, value):
         """Records a basic metric for the named application. If there has

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -513,12 +513,12 @@ class Agent(object):
 
         application.record_exception(exc, value, tb, params, ignore_errors)
 
-    def notice_error(self, app_name, error=None, attributes={}, expected=None):
+    def notice_error(self, app_name, error=None, attributes={}, expected=None, ignore=None):
         application = self._applications.get(app_name, None)
         if application is None or not application.active:
             return
 
-        application.notice_error(error=error, attributes=attributes, expected=expected)
+        application.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
 
     def record_custom_metric(self, app_name, name, value):
         """Records a basic metric for the named application. If there has

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -513,12 +513,18 @@ class Agent(object):
 
         application.record_exception(exc, value, tb, params, ignore_errors)
 
-    def notice_error(self, app_name, error=None, attributes={}, expected=None, ignore=None):
+    def notice_error(self, app_name, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         application = self._applications.get(app_name, None)
         if application is None or not application.active:
             return
 
-        application.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
+        application.notice_error(
+            error=error,
+            attributes=attributes,
+            expected=expected,
+            ignore=ignore,
+            status_code=status_code,
+        )
 
     def record_custom_metric(self, app_name, name, value):
         """Records a basic metric for the named application. If there has

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -713,7 +713,26 @@ class Application(object):
 
     def record_exception(self, exc=None, value=None, tb=None, params={},
             ignore_errors=[]):
+        """Record a global exception against the application independent
+        of a specific transaction.
 
+        Deprecated, but deprecation warning are handled by underlying function calls
+        """
+
+        if not self._active_session:
+            return
+
+        with self._stats_lock:
+            # It may still actually be rejected if no exception
+            # supplied or if was in the ignored list. For now
+            # always attempt anyway and also increment the events
+            # count still so that short harvest is extended.
+
+            self._global_events_account += 1
+            self._stats_engine.record_exception(exc, value, tb,
+                    params, ignore_errors)
+
+    def notice_error(self, error=None, attributes={}, expected=None):
         """Record a global exception against the application independent
         of a specific transaction.
 
@@ -729,8 +748,7 @@ class Application(object):
             # count still so that short harvest is extended.
 
             self._global_events_account += 1
-            self._stats_engine.record_exception(exc, value, tb,
-                    params, ignore_errors)
+            self._stats_engine.notice_error(error=error, attributes=attributes, expected=expected)
 
     def record_custom_metric(self, name, value):
         """Record a custom metric against the application independent

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -732,7 +732,7 @@ class Application(object):
             self._stats_engine.record_exception(exc, value, tb,
                     params, ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         """Record a global exception against the application independent
         of a specific transaction.
 
@@ -748,7 +748,13 @@ class Application(object):
             # count still so that short harvest is extended.
 
             self._global_events_account += 1
-            self._stats_engine.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
+            self._stats_engine.notice_error(
+                error=error,
+                attributes=attributes,
+                expected=expected,
+                ignore=ignore,
+                status_code=status_code,
+            )
 
     def record_custom_metric(self, name, value):
         """Record a custom metric against the application independent

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -732,7 +732,7 @@ class Application(object):
             self._stats_engine.record_exception(exc, value, tb,
                     params, ignore_errors)
 
-    def notice_error(self, error=None, attributes={}, expected=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
         """Record a global exception against the application independent
         of a specific transaction.
 
@@ -748,7 +748,7 @@ class Application(object):
             # count still so that short harvest is extended.
 
             self._global_events_account += 1
-            self._stats_engine.notice_error(error=error, attributes=attributes, expected=expected)
+            self._stats_engine.notice_error(error=error, attributes=attributes, expected=expected, ignore=ignore)
 
     def record_custom_metric(self, name, value):
         """Record a custom metric against the application independent

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -24,6 +24,7 @@ import copy
 import logging
 import operator
 import random
+import warnings
 import zlib
 import time
 import sys
@@ -565,7 +566,39 @@ class StatsEngine(object):
 
     def record_exception(self, exc=None, value=None, tb=None, params={},
             ignore_errors=[]):
+        # Deprecation Warning
+        warnings.warn((
+            'The record_exception function is deprecated. Please use the '
+            'new api named notice_error instead.'
+        ), DeprecationWarning)
 
+        # Pull from sys.exc_info if no exception is passed
+        if None in (exc, value, tb):
+            exc, value, tb = sys.exc_info()
+
+        # If no exception to report, exit
+        if None in (exc, value, tb):
+            return
+
+        # Check ignore_errors callables
+        if callable(ignore_errors):
+            should_ignore = ignore_errors(exc, value, tb)
+            if should_ignore:
+                return
+
+        # Check ignore_errors iterables
+        elif ignore_errors:
+            module = value.__class__.__module__
+            name = value.__class__.__name__
+
+            names = ("%s:%s" % (module, name), "%s.%s" % (module, name))
+            for fullname in names:
+                if fullname in ignore_errors:
+                    return
+
+        self.notice_error(error=(exc, value, tb), attributes=params)
+
+    def notice_error(self, error=None, attributes={}, expected=None):
         settings = self.__settings
 
         if not settings:
@@ -579,6 +612,16 @@ class StatsEngine(object):
         if not settings.collect_errors and not settings.collect_error_events:
             return
 
+        # Pull from sys.exc_info if no exception is passed
+        if not error or None in error:
+            error = sys.exc_info()
+
+        # If no exception to report, exit
+        if not error or None in error:
+            return
+
+        exc, value, tb = error
+
         # If no exception details provided, use current exception.
 
         if exc is None and value is None and tb is None:
@@ -588,20 +631,6 @@ class StatsEngine(object):
 
         if exc is None or value is None or tb is None:
             return
-
-        # Where ignore_errors is a callable it should return a
-        # tri-state variable with the following behavior.
-        #
-        #   True - Ignore the error.
-        #   False- Record the error.
-        #   None - Use the default ignore rules.
-
-        should_ignore = None
-
-        if callable(ignore_errors):
-            should_ignore = ignore_errors(exc, value, tb)
-            if should_ignore:
-                return
 
         module = value.__class__.__module__
         name = value.__class__.__name__
@@ -636,60 +665,56 @@ class StatsEngine(object):
                     message = '<unprintable %s object>' % type(value).__name__
 
         # Check against ignore_error rules
-        if should_ignore is None:
-            if not callable(ignore_errors) and fullname in ignore_errors:
-                return
+        if should_ignore_error(module=module, name=name, message=message):
+            return
 
-            if should_ignore_error(module=module, name=name, message=message):
-                return
-
-        # Only add params if High Security Mode is off.
+        # Only add attributes if High Security Mode is off.
 
         if settings.high_security:
-            if params:
+            if attributes:
                 _logger.debug('Cannot add custom parameters in '
                         'High Security Mode.')
-            attributes = []
+            user_attributes = []
         else:
-            custom_params = {}
+            custom_attributes = {}
 
             try:
-                for k, v in params.items():
+                for k, v in attributes.items():
                     name, val = process_user_attribute(k, v)
                     if name:
-                        custom_params[name] = val
+                        custom_attributes[name] = val
             except Exception:
                 _logger.debug('Parameters failed to validate for unknown '
                         'reason. Dropping parameters for error: %r. Check '
                         'traceback for clues.', fullname, exc_info=True)
-                custom_params = {}
+                custom_attributes = {}
 
-            attributes = create_user_attributes(custom_params,
+            user_attributes = create_user_attributes(custom_attributes,
                     settings.attribute_filter)
 
         # Record the exception details.
 
-        params = {}
+        attributes = {}
 
-        params["stack_trace"] = exception_stack(tb)
+        attributes["stack_trace"] = exception_stack(tb)
 
-        # filter custom error specific params using attribute filter (user)
-        params['userAttributes'] = {}
-        for attr in attributes:
+        # filter custom error specific attributes using attribute filter (user)
+        attributes['userAttributes'] = {}
+        for attr in user_attributes:
             if attr.destinations & DST_ERROR_COLLECTOR:
-                params['userAttributes'][attr.name] = attr.value
+                attributes['userAttributes'][attr.name] = attr.value
 
         error_details = TracedError(
                 start_time=time.time(),
                 path='Exception',
                 message=message,
                 type=fullname,
-                parameters=params)
+                parameters=attributes)
 
         # Save this error as a trace and an event.
 
         if error_collector.capture_events and settings.collect_error_events:
-            event = self._error_event(error_details)
+            event = self._error_event(error_details, expected=expected)
             self._error_events.add(event)
 
         if settings.collect_errors and (len(self.__transaction_errors) <
@@ -701,16 +726,17 @@ class StatsEngine(object):
         self.record_time_metric(TimeMetric(name='Errors/all', scope='',
                 duration=0.0, exclusive=None))
 
-    def _error_event(self, error):
+    def _error_event(self, error, expected=None):
 
         # This method is for recording error events outside of transactions,
         # don't let the poorly named 'type' attribute fool you.
 
         # Retrieve expected bool from error or interpret
-        if hasattr(error, "expected"):
-            expected = error.expected
-        else:
-            expected = is_expected_error(fullname=error.type, message=error.message)
+        if expected is None:
+            if hasattr(error, "expected"):
+                expected = error.expected
+            else:
+                expected = is_expected_error(fullname=error.type, message=error.message)
 
         intrinsics = {
                 'type': 'TransactionError',

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -600,7 +600,7 @@ class StatsEngine(object):
 
         self.notice_error(error=(exc, value, tb), attributes=params, ignore=should_ignore)
 
-    def notice_error(self, error=None, attributes={}, expected=None, ignore=None):
+    def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         settings = self.__settings
 
         if not settings:
@@ -696,7 +696,12 @@ class StatsEngine(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(module=module, name=name, message=message)
+            should_ignore = should_ignore_error(
+                                module=module, 
+                                name=name, 
+                                message=message, 
+                                status_code=status_code,
+                            )
             if should_ignore:
                 return
 
@@ -711,7 +716,12 @@ class StatsEngine(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(module=module, name=name, message=message)
+            is_expected = is_expected_error(
+                                module=module, 
+                                name=name, 
+                                message=message, 
+                                status_code=status_code,
+                            )
 
         # Only add attributes if High Security Mode is off.
 

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -583,6 +583,8 @@ class StatsEngine(object):
         # Check ignore_errors callables
         # We check these here separatly from the notice_error implementation
         # to preserve previous functionality in precedence
+        should_ignore = None
+
         if callable(ignore_errors):
             should_ignore = ignore_errors(exc, value, tb)
             if should_ignore:

--- a/newrelic/core/transaction_node.py
+++ b/newrelic/core/transaction_node.py
@@ -311,7 +311,7 @@ class TransactionNode(_TransactionNode):
             params = {}
             params["stack_trace"] = error.stack_trace
 
-            intrinsics = {'spanId': error.span_id}
+            intrinsics = {'spanId': error.span_id, 'error.expected': error.expected}
             intrinsics.update(self.trace_intrinsics)
             params['intrinsics'] = intrinsics
 

--- a/tests/agent_features/test_notice_error.py
+++ b/tests/agent_features/test_notice_error.py
@@ -1,0 +1,417 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from newrelic.api.application import (application_settings,
+        application_instance as application)
+from newrelic.api.background_task import background_task
+from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
+from newrelic.api.time_trace import notice_error
+
+from newrelic.common.object_names import callable_name
+
+from testing_support.fixtures import (validate_transaction_errors,
+        override_application_settings, core_application_stats_engine_error,
+        error_is_saved, reset_core_stats_engine, validate_application_errors,
+        validate_transaction_error_trace_count,
+        validate_application_error_trace_count,
+        validate_transaction_error_event_count,
+        validate_application_error_event_count)
+
+
+_runtime_error_name = callable_name(RuntimeError)
+_type_error_name = callable_name(TypeError)
+
+# =============== Test errors during a transaction ===============
+
+_test_notice_error_sys_exc_info = [
+        (_runtime_error_name, 'one')]
+
+@validate_transaction_errors(errors=_test_notice_error_sys_exc_info)
+@background_task()
+def test_notice_error_sys_exc_info():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error(sys.exc_info())
+
+_test_notice_error_no_exc_info = [
+        (_runtime_error_name, 'one')]
+
+@validate_transaction_errors(errors=_test_notice_error_no_exc_info)
+@background_task()
+def test_notice_error_no_exc_info():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error()
+
+_test_notice_error_custom_params = [
+        (_runtime_error_name, 'one')]
+
+@validate_transaction_errors(errors=_test_notice_error_custom_params,
+        required_params=[('key', 'value')])
+@background_task()
+def test_notice_error_custom_params():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error(sys.exc_info(), attributes={'key': 'value'})
+
+_test_notice_error_multiple_different_type = [
+        (_runtime_error_name, 'one'),
+        (_type_error_name, 'two')]
+
+@validate_transaction_errors(errors=_test_notice_error_multiple_different_type)
+@background_task()
+def test_notice_error_multiple_different_type():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error()
+
+    try:
+        raise TypeError('two')
+    except TypeError:
+        notice_error()
+
+_test_notice_error_multiple_same_type = [
+        (_runtime_error_name, 'one'),
+        (_runtime_error_name, 'two')]
+
+@validate_transaction_errors(errors=_test_notice_error_multiple_same_type)
+@background_task()
+def test_notice_error_multiple_same_type():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error()
+
+    try:
+        raise RuntimeError('two')
+    except RuntimeError:
+        notice_error()
+
+# =============== Test errors outside a transaction ===============
+
+_test_application_exception = [
+        (_runtime_error_name, 'one')]
+
+@reset_core_stats_engine()
+@validate_application_errors(errors=_test_application_exception)
+def test_application_exception():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        application_instance = application()
+        notice_error(application=application_instance)
+
+_test_application_exception_sys_exc_info = [
+        (_runtime_error_name, 'one')]
+
+@reset_core_stats_engine()
+@validate_application_errors(errors=_test_application_exception_sys_exc_info)
+def test_application_exception_sys_exec_info():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        application_instance = application()
+        notice_error(sys.exc_info(), application=application_instance)
+
+_test_application_exception_custom_params = [
+        (_runtime_error_name, 'one')]
+
+@reset_core_stats_engine()
+@validate_application_errors(errors=_test_application_exception_custom_params,
+        required_params=[('key', 'value')])
+def test_application_exception_custom_params():
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        application_instance = application()
+        notice_error(attributes={'key': 'value'},
+                application=application_instance)
+
+_test_application_exception_multiple = [
+        (_runtime_error_name, 'one'),
+        (_runtime_error_name, 'one')]
+
+@reset_core_stats_engine()
+@validate_application_errors(errors=_test_application_exception_multiple)
+@background_task()
+def test_application_exception_multiple():
+    """Exceptions submitted straight to the stats engine doesn't check for
+    duplicates
+    """
+    application_instance = application()
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error(application=application_instance)
+
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error(application=application_instance)
+
+# =============== Test exception message stripping/whitelisting ===============
+
+_test_notice_error_strip_message_disabled = [
+        (_runtime_error_name, 'one')]
+
+_strip_message_disabled_settings = {
+        'strip_exception_messages.enabled': False,
+}
+
+@validate_transaction_errors(errors=_test_notice_error_strip_message_disabled)
+@override_application_settings(_strip_message_disabled_settings)
+@background_task()
+def test_notice_error_strip_message_disabled():
+    settings = application_settings()
+    assert not settings.strip_exception_messages.enabled
+
+    try:
+        raise RuntimeError('one')
+    except RuntimeError:
+        notice_error()
+
+class ErrorOne(Exception):
+    message = 'error one message'
+
+_error_one_name = callable_name(ErrorOne)
+
+@override_application_settings(_strip_message_disabled_settings)
+@background_task()
+def test_notice_error_strip_message_disabled_outside_transaction():
+    settings = application_settings()
+    assert not settings.strip_exception_messages.enabled
+
+    try:
+        assert not error_is_saved(ErrorOne)
+        raise ErrorOne(ErrorOne.message)
+    except ErrorOne:
+        application_instance = application()
+        application_instance.notice_error()
+
+    my_error = core_application_stats_engine_error(_error_one_name)
+    assert my_error.message == ErrorOne.message
+
+_test_notice_error_strip_message_enabled = [
+        (_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
+
+_strip_message_enabled_settings = {
+        'strip_exception_messages.enabled': True,
+}
+
+@validate_transaction_errors(errors=_test_notice_error_strip_message_enabled)
+@override_application_settings(_strip_message_enabled_settings)
+@background_task()
+def test_notice_error_strip_message_enabled():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+
+    try:
+        raise RuntimeError('message not displayed')
+    except RuntimeError:
+        notice_error()
+
+class ErrorTwo(Exception):
+    message = 'error two message'
+
+_error_two_name = callable_name(ErrorTwo)
+
+@override_application_settings(_strip_message_enabled_settings)
+@background_task()
+def test_notice_error_strip_message_enabled_outside_transaction():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+
+    try:
+        assert not error_is_saved(ErrorTwo)
+        raise ErrorTwo(ErrorTwo.message)
+    except ErrorTwo:
+        application_instance = application()
+        application_instance.notice_error()
+
+    my_error = core_application_stats_engine_error(_error_two_name)
+    assert my_error.message == STRIP_EXCEPTION_MESSAGE
+
+_test_notice_error_strip_message_in_whitelist = [
+        (_runtime_error_name, 'original error message')]
+
+_strip_message_in_whitelist_settings = {
+        'strip_exception_messages.enabled': True,
+        'strip_exception_messages.whitelist': [_runtime_error_name],
+}
+
+@validate_transaction_errors(errors=_test_notice_error_strip_message_in_whitelist)
+@override_application_settings(_strip_message_in_whitelist_settings)
+@background_task()
+def test_notice_error_strip_message_in_whitelist():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+    assert _runtime_error_name in settings.strip_exception_messages.whitelist
+
+    try:
+        raise RuntimeError('original error message')
+    except RuntimeError:
+        notice_error()
+
+class ErrorThree(Exception):
+    message = 'error three message'
+
+_error_three_name = callable_name(ErrorThree)
+
+_strip_message_in_whitelist_settings_outside_transaction = {
+        'strip_exception_messages.enabled': True,
+        'strip_exception_messages.whitelist': [_error_three_name],
+}
+
+@override_application_settings(
+        _strip_message_in_whitelist_settings_outside_transaction)
+@background_task()
+def test_notice_error_strip_message_in_whitelist_outside_transaction():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+    assert _error_three_name in settings.strip_exception_messages.whitelist
+
+    try:
+        assert not error_is_saved(ErrorThree)
+        raise ErrorThree(ErrorThree.message)
+    except ErrorThree:
+        application_instance = application()
+        application_instance.notice_error()
+
+    my_error = core_application_stats_engine_error(_error_three_name)
+    assert my_error.message == ErrorThree.message
+
+_test_notice_error_strip_message_not_in_whitelist = [
+        (_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
+
+_strip_message_not_in_whitelist_settings = {
+        'strip_exception_messages.enabled': True,
+        'strip_exception_messages.whitelist': ['FooError', 'BarError'],
+}
+
+@validate_transaction_errors(errors=_test_notice_error_strip_message_not_in_whitelist)
+@override_application_settings(_strip_message_not_in_whitelist_settings)
+@background_task()
+def test_notice_error_strip_message_not_in_whitelist():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+    assert _runtime_error_name not in settings.strip_exception_messages.whitelist
+
+    try:
+        raise RuntimeError('message not displayed')
+    except RuntimeError:
+        notice_error()
+
+class ErrorFour(Exception):
+    message = 'error four message'
+
+_error_four_name = callable_name(ErrorFour)
+
+_strip_message_not_in_whitelist_settings_outside_transaction = {
+        'strip_exception_messages.enabled': True,
+        'strip_exception_messages.whitelist': ['ValueError', 'BarError'],
+}
+
+@override_application_settings(
+        _strip_message_not_in_whitelist_settings_outside_transaction)
+@background_task()
+def test_notice_error_strip_message_not_in_whitelist_outside_transaction():
+    settings = application_settings()
+    assert settings.strip_exception_messages.enabled
+    assert _error_four_name not in settings.strip_exception_messages.whitelist
+
+    try:
+        assert not error_is_saved(ErrorFour)
+        raise ErrorFour(ErrorFour.message)
+    except ErrorFour:
+        application_instance = application()
+        application_instance.notice_error()
+
+    my_error = core_application_stats_engine_error(_error_four_name)
+    assert my_error.message == STRIP_EXCEPTION_MESSAGE
+
+# =============== Test exception limits ===============
+
+def _raise_errors(num_errors, application=None):
+    for i in range(num_errors):
+        try:
+            raise RuntimeError('error'+str(i))
+        except RuntimeError:
+            notice_error(application=application)
+
+_errors_per_transaction_limit = 5
+_num_errors_transaction = 6
+_errors_per_harvest_limit = 20
+_num_errors_app = 26
+_error_event_limit = 25
+
+@override_application_settings(
+        {'agent_limits.errors_per_transaction': _errors_per_transaction_limit})
+@validate_transaction_error_trace_count(_errors_per_transaction_limit)
+@background_task()
+def test_transaction_error_trace_limit():
+    _raise_errors(_num_errors_transaction)
+
+@override_application_settings(
+        {'agent_limits.errors_per_harvest': _errors_per_harvest_limit})
+@reset_core_stats_engine()
+@validate_application_error_trace_count(_errors_per_harvest_limit)
+def test_application_error_trace_limit():
+    _raise_errors(_num_errors_app, application())
+
+# The limit for errors on transactions is shared for traces and errors
+
+@override_application_settings({
+        'agent_limits.errors_per_transaction': _errors_per_transaction_limit,
+        'error_collector.max_event_samples_stored': _error_event_limit})
+@validate_transaction_error_event_count(_errors_per_transaction_limit)
+@background_task()
+def test_transaction_error_event_limit():
+    _raise_errors(_num_errors_transaction)
+
+# The harvest limit for error traces doesn't affect events
+
+@override_application_settings({
+        'agent_limits.errors_per_harvest': _errors_per_harvest_limit,
+        'event_harvest_config.harvest_limits.error_event_data':
+            _error_event_limit})
+@reset_core_stats_engine()
+@validate_application_error_event_count(_error_event_limit)
+def test_application_error_event_limit():
+    _raise_errors(_num_errors_app, application())
+
+# =============== Test params is not a dict ===============
+
+@reset_core_stats_engine()
+@validate_transaction_error_trace_count(num_errors=1)
+@background_task()
+def test_transaction_notice_error_params_not_a_dict():
+    try:
+        raise RuntimeError()
+    except RuntimeError:
+        notice_error(sys.exc_info(), attributes=[1,2,3])
+
+@reset_core_stats_engine()
+@validate_application_error_trace_count(num_errors=1)
+def test_application_notice_error_params_not_a_dict():
+    try:
+        raise RuntimeError()
+    except RuntimeError:
+        notice_error(sys.exc_info(), attributes=[1,2,3],
+                application=application())


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Add new `notice_error` api to conform to the standards of other agents.
* Forward old record_exception calls to new API.
* Add deprecation warning to record_exception.

# Related Github Issue
Include a link to the related GitHub issue, if applicable
Closes #196
Closes #197

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
