### PR TITLE
Temporarily disable flask tests for v2 release.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -233,7 +233,7 @@ deps =
     framework_flask: Flask-Compress
     framework_flask-flask0012: flask<0.13
     framework_flask-flask0101: flask<1.2
-    framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/master.zip
+    framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
     framework_flask-flaskmaster: flask
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,8 @@ envlist =
     python-framework_fastapi-{py36,py37,py38},
     python-framework_flask-{pypy,py27}-flask0012,
     python-framework_flask-{pypy,py27,py36,py37,py38,pypy3}-flask0101,
-    python-framework_flask-{py36,py37,py38,pypy3}-flaskmaster,
+    ; disabled until v2 support is released
+    ; python-framework_flask-{py36,py37,py38,pypy3}-flaskmaster,
     grpc-framework_grpc-{py27,py36}-grpc0125,
     grpc-framework_grpc-{py27,py36,py37,py38,py39}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
@@ -233,8 +234,9 @@ deps =
     framework_flask: Flask-Compress
     framework_flask-flask0012: flask<0.13
     framework_flask-flask0101: flask<1.2
+    framework_flask-flasklatest: flask
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
-    framework_flask-flaskmaster: flask
+    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
     framework_grpc-grpclatest: grpcio


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Disables flask tests for latest version, pinning to versions <2. 
* Changes base branch name of werkzeug and flask to main.

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
