### PR TITLE
Add ignore/expected status codes API to notice_error

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -27,7 +27,7 @@ def format_exc_info(exc_info):
     return {
         "error.class": fullname,
         "error.message": message,
-        "error.expected": is_expected_error(module=module, name=name, message=message),
+        "error.expected": is_expected_error(exc_info),
     }
 
 

--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+from newrelic.common.object_names import parse_exc_info
 import newrelic.packages.six as six
 from logging import Formatter, LogRecord
 from newrelic.api.time_trace import get_linking_metadata
@@ -20,34 +21,8 @@ from newrelic.core.config import is_expected_error
 
 
 def format_exc_info(exc_info):
-    _, value, tb = exc_info
-
-    module = value.__class__.__module__
-    name = value.__class__.__name__
-
-    if module:
-        fullname = "{}:{}".format(module, name)
-    else:
-        fullname = name
-
-    try:
-
-        # Favor unicode in exception messages.
-
-        message = six.text_type(value)
-
-    except Exception:
-        try:
-
-            # If exception cannot be represented in unicode, this means
-            # that it is a byte string encoded with an encoding
-            # that is not compatible with the default system encoding.
-            # So, just pass this byte string along.
-
-            message = str(value)
-
-        except Exception:
-            message = "<unprintable %s object>" % type(value).__name__
+    _, _, fullnames, message = parse_exc_info(exc_info)
+    fullname = fullnames[0]
 
     return {
         "error.class": fullname,

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -226,7 +226,7 @@ class TimeTrace(object):
         if exc is None or value is None or tb is None:
             return
 
-        module, name, fullnames, message = parse_exc_info(exc_info)
+        module, name, fullnames, message = parse_exc_info((exc, value, tb))
         fullname = fullnames[0]
 
         # Check to see if we need to strip the message before recording it.
@@ -272,12 +272,7 @@ class TimeTrace(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(
-                                module=module, 
-                                name=name, 
-                                message=message, 
-                                status_code=status_code,
-                            )
+            should_ignore = should_ignore_error((exc, value, tb), status_code=status_code)
             if should_ignore:
                 return
 
@@ -296,12 +291,7 @@ class TimeTrace(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(
-                                module=module, 
-                                name=name, 
-                                message=message, 
-                                status_code=status_code,
-                            )
+            is_expected = is_expected_error((exc, value, tb), status_code=status_code)
 
         # Record a supportability metric if error attributes are being
         # overiden.

--- a/newrelic/common/object_names.py
+++ b/newrelic/common/object_names.py
@@ -406,3 +406,36 @@ def expand_builtin_exception_name(name):
 
 def _is_py3_method(target):
     return six.PY3 and inspect.ismethod(target)
+
+def parse_exc_info(exc_info):
+    """Parse exc_info and return commonly used strings."""
+    _, value, _ = exc_info
+
+    module = value.__class__.__module__
+    name = value.__class__.__name__
+
+    if module:
+        fullnames = ("%s:%s" % (module, name), "%s.%s" % (module, name))
+    else:
+        fullnames = (name,)
+
+    try:
+
+        # Favor unicode in exception messages.
+
+        message = six.text_type(value)
+
+    except Exception:
+        try:
+
+            # If exception cannot be represented in unicode, this means
+            # that it is a byte string encoded with an encoding
+            # that is not compatible with the default system encoding.
+            # So, just pass this byte string along.
+
+            message = str(value)
+
+        except Exception:
+            message = "<unprintable %s object>" % type(value).__name__
+
+    return (module, name, fullnames, message)

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -1133,8 +1133,8 @@ def error_matches_rules(
         return False
 
     # Retrieve settings based on prefix
-    classes_rules = getattr(settings.error_collector, "%s_classes" % rules_prefix)
-    status_codes_rules = getattr(settings.error_collector, "%s_status_codes" % rules_prefix)
+    classes_rules = getattr(settings.error_collector, "%s_classes" % rules_prefix, set())
+    status_codes_rules = getattr(settings.error_collector, "%s_status_codes" % rules_prefix, set())
 
     module, name, fullnames, message = parse_exc_info(exc_info)
     fullname = fullnames[0]

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -23,6 +23,7 @@ the global defaults or those from local agent configuration.
 
 """
 
+from newrelic.common.object_names import parse_exc_info
 import os
 import logging
 import copy

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -673,12 +673,7 @@ class StatsEngine(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(
-                                module=module, 
-                                name=name, 
-                                message=message, 
-                                status_code=status_code,
-                            )
+            should_ignore = should_ignore_error((exc, value, tb), status_code=status_code)
             if should_ignore:
                 return
 
@@ -693,12 +688,7 @@ class StatsEngine(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(
-                                module=module, 
-                                name=name, 
-                                message=message, 
-                                status_code=status_code,
-                            )
+            is_expected = is_expected_error((exc, value, tb), status_code=status_code)
 
         # Only add attributes if High Security Mode is off.
 

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -44,6 +44,7 @@ from newrelic.core.stack_trace import exception_stack
 from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
 from newrelic.core.config import is_expected_error, should_ignore_error
 from newrelic.common.encoding_utils import json_encode
+from newrelic.common.object_names import parse_exc_info
 from newrelic.common.streaming_utils import StreamBuffer
 
 _logger = logging.getLogger(__name__)
@@ -592,11 +593,8 @@ class StatsEngine(object):
 
         # Check ignore_errors iterables
         if should_ignore is None and not callable(ignore_errors):
-            module = value.__class__.__module__
-            name = value.__class__.__name__
-
-            names = ("%s:%s" % (module, name), "%s.%s" % (module, name))
-            for fullname in names:
+            _, _, fullnames, _ = parse_exc_info((exc, value, tb))
+            for fullname in fullnames:
                 if fullname in ignore_errors:
                     return
 
@@ -636,37 +634,14 @@ class StatsEngine(object):
         if exc is None or value is None or tb is None:
             return
 
-        module = value.__class__.__module__
-        name = value.__class__.__name__
-
-        if module:
-            fullname = '%s:%s' % (module, name)
-        else:
-            fullname = name
+        module, name, fullnames, message = parse_exc_info((exc, value, tb))
+        fullname = fullnames[0]
 
         # Check to see if we need to strip the message before recording it.
 
         if (settings.strip_exception_messages.enabled and
                 fullname not in settings.strip_exception_messages.whitelist):
             message = STRIP_EXCEPTION_MESSAGE
-        else:
-            try:
-                # Favor unicode in exception messages.
-
-                message = six.text_type(value)
-
-            except Exception:
-                try:
-
-                    # If exception cannot be represented in unicode, this means
-                    # that it is a byte string encoded with an encoding
-                    # that is not compatible with the default system encoding.
-                    # So, just pass this byte string along.
-
-                    message = str(value)
-
-                except Exception:
-                    message = '<unprintable %s object>' % type(value).__name__
 
         # Where expected or ignore are a callable they should return a
         # tri-state variable with the following behavior.


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Adds support for ignore/expected status_codes within notice_error.
* Encapsulate parsing of message, and names from exceptions for reusability.
* Add testing for status_codes functionality.
* Add testing for mixed ignore and expected settings with overrides.
* Expand test file to include all current cases.

# Related Github Issue
Closes #202

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
