### PR TITLE
Add iterable logic to notice_error

### DIFF
--- a/newrelic/api/application.py
+++ b/newrelic/api/application.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import threading
+import warnings
 
 import newrelic.core.config
 import newrelic.core.agent
@@ -113,13 +114,13 @@ class Application(object):
 
     def record_exception(self, exc=None, value=None, tb=None, params={},
             ignore_errors=[]):
-        # Deprecated, but deprecation warning are handled by underlying function calls
+        # Deprecation Warning
+        warnings.warn((
+            'The record_exception function is deprecated. Please use the '
+            'new api named notice_error instead.'
+        ), DeprecationWarning)
 
-        if not self.active:
-            return
-
-        self._agent.record_exception(self._name, exc, value, tb, params,
-                ignore_errors)
+        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         if not self.active:

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -1479,26 +1479,14 @@ class Transaction(object):
         self._group = group
         self._name = name
 
-    def record_exception(self, exc=None, value=None, tb=None,
-                         params={}, ignore_errors=[]):
-        # Deprecated, but deprecation warning are handled by underlying function calls
-        settings = self._settings
+    def record_exception(self, exc=None, value=None, tb=None, params={}, ignore_errors=[]):
+        # Deprecation Warning
+        warnings.warn((
+            'The record_exception function is deprecated. Please use the '
+            'new api named notice_error instead.'
+        ), DeprecationWarning)
 
-        if not settings:
-            return
-
-        if not settings.error_collector.enabled:
-            return
-
-        if not settings.collect_errors and not settings.collect_error_events:
-            return
-
-        current_span = trace_cache().current_trace()
-        if current_span:
-            current_span.record_exception(
-                    (exc, value, tb),
-                    params=params,
-                    ignore_errors=ignore_errors)
+        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         settings = self._settings

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -511,7 +511,7 @@ class Agent(object):
             'new api named notice_error instead.'
         ), DeprecationWarning)
 
-        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
+        self.notice_error(app_name, error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, app_name, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         application = self._applications.get(app_name, None)

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -26,6 +26,7 @@ import logging
 import threading
 import atexit
 import traceback
+import warnings
 
 import newrelic
 import newrelic.core.config
@@ -503,15 +504,14 @@ class Agent(object):
         from newrelic.core.thread_utilization import _utilization_trackers
         _utilization_trackers.clear()
 
-    def record_exception(self, app_name, exc=None, value=None, tb=None,
-            params={}, ignore_errors=[]):
-        # Deprecated, but deprecation warning are handled by underlying function calls
+    def record_exception(self, app_name, exc=None, value=None, tb=None, params={}, ignore_errors=[]):
+        # Deprecation Warning
+        warnings.warn((
+            'The record_exception function is deprecated. Please use the '
+            'new api named notice_error instead.'
+        ), DeprecationWarning)
 
-        application = self._applications.get(app_name, None)
-        if application is None or not application.active:
-            return
-
-        application.record_exception(exc, value, tb, params, ignore_errors)
+        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, app_name, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         application = self._applications.get(app_name, None)

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -24,6 +24,7 @@ import time
 import os
 import traceback
 import imp
+import warnings
 
 from functools import partial
 
@@ -711,26 +712,18 @@ class Application(object):
 
                 self._data_samplers.remove(data_sampler)
 
-    def record_exception(self, exc=None, value=None, tb=None, params={},
-            ignore_errors=[]):
+    def record_exception(self, exc=None, value=None, tb=None, params={}, ignore_errors=[]):
         """Record a global exception against the application independent
         of a specific transaction.
 
-        Deprecated, but deprecation warning are handled by underlying function calls
         """
+        # Deprecation Warning
+        warnings.warn((
+            'The record_exception function is deprecated. Please use the '
+            'new api named notice_error instead.'
+        ), DeprecationWarning)
 
-        if not self._active_session:
-            return
-
-        with self._stats_lock:
-            # It may still actually be rejected if no exception
-            # supplied or if was in the ignored list. For now
-            # always attempt anyway and also increment the events
-            # count still so that short harvest is extended.
-
-            self._global_events_account += 1
-            self._stats_engine.record_exception(exc, value, tb,
-                    params, ignore_errors)
+        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         """Record a global exception against the application independent

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -573,32 +573,7 @@ class StatsEngine(object):
             'new api named notice_error instead.'
         ), DeprecationWarning)
 
-        # Pull from sys.exc_info if no exception is passed
-        if None in (exc, value, tb):
-            exc, value, tb = sys.exc_info()
-
-        # If no exception to report, exit
-        if None in (exc, value, tb):
-            return
-
-        # Check ignore_errors callables
-        # We check these here separatly from the notice_error implementation
-        # to preserve previous functionality in precedence
-        should_ignore = None
-
-        if callable(ignore_errors):
-            should_ignore = ignore_errors(exc, value, tb)
-            if should_ignore:
-                return
-
-        # Check ignore_errors iterables
-        if should_ignore is None and not callable(ignore_errors):
-            _, _, fullnames, _ = parse_exc_info((exc, value, tb))
-            for fullname in fullnames:
-                if fullname in ignore_errors:
-                    return
-
-        self.notice_error(error=(exc, value, tb), attributes=params, ignore=should_ignore)
+        self.notice_error(error=(exc, value, tb), attributes=params, ignore=ignore_errors)
 
     def notice_error(self, error=None, attributes={}, expected=None, ignore=None, status_code=None):
         settings = self.__settings

--- a/tests/agent_features/test_ignore_expected_errors.py
+++ b/tests/agent_features/test_ignore_expected_errors.py
@@ -347,7 +347,7 @@ def test_mixed_ignore_expected_settings_outside_transaction(
     )
     @override_application_settings(settings)
     def _test():
-        exercise(override_expected, override_ignore)
+        exercise(override_expected, override_ignore, status_code=418)
 
     _test()
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Add previous functionality back to notice_error api.
  * ignore and expected arguments now can take an iterable of class names.  
* Reduce record_exception functions to include no logic and simply redirect to notice_error
* Remove some duplicated logic in notice_error for exc_info=None

# Related Github Issue
Closes #214

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
