### PR TITLE
Add safe_str method to NewRelicContextFormatter

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -65,4 +65,11 @@ class NewRelicContextFormatter(Formatter):
         return output
 
     def format(self, record):
-        return json.dumps(self.log_record_to_dict(record), default=str, separators=(',', ':'))
+        def safe_str(object, *args, **kwargs):
+            """Convert object to str, catching any errors raised."""
+            try:
+                return str(object, *args, **kwargs)
+            except:
+                return "<unprintable %s object>" % type(object).__name__
+
+        return json.dumps(self.log_record_to_dict(record), default=safe_str, separators=(',', ':'))

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -46,6 +46,14 @@ def log_buffer(caplog):
     _logger.removeHandler(_handler)
 
 
+class NonPrintableObject(object):
+    def __str__(self):
+        raise RuntimeError("Unable to print object.")
+
+    def __repr__(self):
+        raise RuntimeError("Unable to print object.")
+
+
 def test_newrelic_logger_no_error(log_buffer):
     extra = {
         "string": "foo",
@@ -55,6 +63,7 @@ def test_newrelic_logger_no_error(log_buffer):
         "array": [1, 2, 3],
         "bool": True,
         "non_serializable": {"set"},
+        "non_printable": NonPrintableObject(),
         "object": {
             "first": "bar",
             "second": "baz",
@@ -91,6 +100,7 @@ def test_newrelic_logger_no_error(log_buffer):
         u"extra.array": [1, 2, 3],
         u"extra.bool": True,
         u"extra.non_serializable": u"set(['set'])" if six.PY2 else u"{'set'}",
+        u"extra.non_printable": u"<unprintable NonPrintableObject object>",
         u"extra.object": {
             u"first": u"bar",
             u"second": u"baz",


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Add safe_str method to NewRelicContextFormatter to prevent all possible crashes.

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
