### PR TITLE
Remove record_exception uses in codebase.

### DIFF
--- a/newrelic/admin/validate_config.py
+++ b/newrelic/admin/validate_config.py
@@ -26,7 +26,7 @@ def _run_validation_test():
     from newrelic.api.external_trace import external_trace
     from newrelic.api.function_trace import function_trace
     from newrelic.api.transaction import add_custom_parameter
-    from newrelic.api.time_trace import record_exception
+    from newrelic.api.time_trace import notice_error
     from newrelic.api.wsgi_application import wsgi_application
 
     @external_trace(library='test',
@@ -58,7 +58,7 @@ def _run_validation_test():
         try:
             _function5()
         except:
-            record_exception(params=(params or {
+            notice_error(attributes=(params or {
                     'err-key-2': 2, 'err-key-3': 3.0}),
                     application=application)
 

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -401,7 +401,7 @@ class Transaction(object):
         # Record error if one was registered.
 
         if exc is not None and value is not None and tb is not None:
-            root.record_exception((exc, value, tb))
+            root.notice_error((exc, value, tb))
 
         # Record the end time for transaction and then
         # calculate the duration.

--- a/newrelic/api/wsgi_application.py
+++ b/newrelic/api/wsgi_application.py
@@ -19,7 +19,7 @@ import functools
 
 from newrelic.api.application import application_instance
 from newrelic.api.transaction import current_transaction
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.api.web_transaction import WSGIWebTransaction
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.html_insertion import insert_html_snippet, verify_body_exists
@@ -57,7 +57,7 @@ class _WSGIApplicationIterable(object):
             raise
 
         except:  # Catch all
-            record_exception()
+            notice_error()
             raise
 
         finally:

--- a/tests/agent_features/test_asgi_distributed_tracing.py
+++ b/tests/agent_features/test_asgi_distributed_tracing.py
@@ -200,6 +200,6 @@ def test_distributed_tracing_metrics(web_transaction, gen_error, has_parent):
                 try:
                     1 / 0
                 except ZeroDivisionError:
-                    transaction.record_exception()
+                    transaction.notice_error()
 
     _test()

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -18,7 +18,7 @@ import webtest
 from newrelic.api.application import application_instance as application
 from newrelic.api.message_transaction import message_transaction
 from newrelic.api.transaction import add_custom_parameter
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.api.wsgi_application import wsgi_application
 from newrelic.common.object_names import callable_name
 
@@ -102,7 +102,7 @@ def normal_wsgi_application(environ, start_response):
     try:
         raise ValueError('Transaction had bad value')
     except ValueError:
-        record_exception(params={ERROR_PARAMS[0]: 'param-value'})
+        notice_error(attributes={ERROR_PARAMS[0]: 'param-value'})
 
     return [output]
 
@@ -886,8 +886,8 @@ def test_error_outside_transaction():
         raise OutsideWithParamsError("Error outside transaction")
     except OutsideWithParamsError:
         application_instance = application()
-        application_instance.record_exception(
-                params={'test_key': 'test_value'})
+        application_instance.notice_error(
+                attributes={'test_key': 'test_value'})
 
 
 class OutsideNoParamsError(Exception):
@@ -919,8 +919,8 @@ def test_error_outside_transaction_excluded_user_param():
         raise OutsideNoParamsError("Error outside transaction")
     except OutsideNoParamsError:
         application_instance = application()
-        application_instance.record_exception(
-                params={'test_key': 'test_value'})
+        application_instance.notice_error(
+                attributes={'test_key': 'test_value'})
 
 
 # Test routing key agent attribute.

--- a/tests/agent_features/test_distributed_tracing.py
+++ b/tests/agent_features/test_distributed_tracing.py
@@ -195,7 +195,7 @@ def test_distributed_trace_attributes(span_events, accept_payload):
         try:
             raise ValueError('cookies')
         except ValueError:
-            txn.record_exception()
+            txn.notice_error()
 
     _test()
 
@@ -220,7 +220,7 @@ def test_distributed_trace_attrs_omitted():
     try:
         raise ValueError('cookies')
     except ValueError:
-        txn.record_exception()
+        txn.notice_error()
 
 
 # test our distributed_trace metrics by creating a transaction and then forcing
@@ -284,7 +284,7 @@ def test_distributed_tracing_metrics(web_transaction, gen_error, has_parent):
                 try:
                     1 / 0
                 except ZeroDivisionError:
-                    transaction.record_exception()
+                    transaction.notice_error()
 
     _test()
 

--- a/tests/agent_features/test_error_events.py
+++ b/tests/agent_features/test_error_events.py
@@ -18,7 +18,7 @@ import webtest
 
 from newrelic.api.application import (application_instance as application,
         application_settings)
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.common.object_names import callable_name
 
 from testing_support.fixtures import (validate_error_event_sample_data,
@@ -216,7 +216,7 @@ def test_error_event_outside_transaction():
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        record_exception(*sys.exc_info(), application=app)
+        notice_error(sys.exc_info(), application=app)
 
 _err_params = {'key': 'value'}
 
@@ -228,7 +228,7 @@ def test_error_event_with_params_outside_transaction():
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        record_exception(*sys.exc_info(), params=_err_params,
+        notice_error(sys.exc_info(), attributes=_err_params,
                 application=app)
 
 @reset_core_stats_engine()
@@ -239,7 +239,7 @@ def test_multiple_error_events_outside_transaction():
         try:
             raise ErrorEventOutsideTransactionError(ERR_MESSAGE+str(i))
         except ErrorEventOutsideTransactionError:
-            record_exception(*sys.exc_info(), application=app)
+            notice_error(sys.exc_info(), application=app)
 
 @reset_core_stats_engine()
 @override_application_settings({'error_collector.enabled' : False})
@@ -249,7 +249,7 @@ def test_error_event_outside_transaction_error_collector_disabled():
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        record_exception(*sys.exc_info(), application=app)
+        notice_error(sys.exc_info(), application=app)
 
 @reset_core_stats_engine()
 @override_application_settings({'error_collector.capture_events' : False})
@@ -259,7 +259,7 @@ def test_error_event_outside_transaction_capture_events_disabled():
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        record_exception(*sys.exc_info(), application=app)
+        notice_error(sys.exc_info(), application=app)
 
 @reset_core_stats_engine()
 @override_application_settings({'collect_error_events' : False})
@@ -269,4 +269,4 @@ def test_error_event_outside_transaction_collect_error_events_false():
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        record_exception(*sys.exc_info(), application=app)
+        notice_error(sys.exc_info(), application=app)

--- a/tests/agent_features/test_exception_messages.py
+++ b/tests/agent_features/test_exception_messages.py
@@ -18,7 +18,7 @@ import pytest
 
 from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import background_task
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 
 from testing_support.fixtures import (validate_transaction_exception_message,
         set_default_encoding, validate_application_exception_message,
@@ -44,7 +44,7 @@ def test_py2_transaction_exception_message_unicode():
     try:
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('ascii')
@@ -56,7 +56,7 @@ def test_py2_transaction_exception_message_unicode_english():
     try:
         raise ValueError(UNICODE_ENGLISH)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('ascii')
@@ -67,7 +67,7 @@ def test_py2_transaction_exception_message_bytes_english():
     try:
         raise ValueError(BYTES_ENGLISH)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('ascii')
@@ -81,7 +81,7 @@ def test_py2_transaction_exception_message_bytes_non_english():
     try:
         raise ValueError(BYTES_UTF8_ENCODED)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('ascii')
@@ -99,7 +99,7 @@ def test_py2_transaction_exception_message_bytes_implicit_encoding_non_english()
 
         raise ValueError('I💜🐍')
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('utf-8')
@@ -112,7 +112,7 @@ def test_py2_transaction_exception_message_unicode_utf8_encoding():
     try:
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @set_default_encoding('utf-8')
@@ -129,7 +129,7 @@ def test_py2_transaction_exception_message_bytes_utf8_encoding_non_english():
 
         raise ValueError('I💜🐍')
     except ValueError:
-        record_exception()
+        notice_error()
 
 # ---------------- Python 3
 
@@ -142,7 +142,7 @@ def test_py3_transaction_exception_message_bytes_non_english_unicode():
     try:
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY2, reason="Testing Python 3 string behavior")
 @validate_transaction_exception_message(UNICODE_ENGLISH)
@@ -153,7 +153,7 @@ def test_py3_transaction_exception_message_unicode_english():
     try:
         raise ValueError(UNICODE_ENGLISH)
     except ValueError:
-        record_exception()
+        notice_error()
 
 @pytest.mark.skipif(six.PY2, reason="Testing Python 3 string behavior")
 @validate_transaction_exception_message(INCORRECTLY_DECODED_BYTES_PY3)
@@ -169,7 +169,7 @@ def test_py3_transaction_exception_message_bytes_non_english():
     try:
         raise ValueError(BYTES_UTF8_ENCODED)
     except ValueError:
-        record_exception()
+        notice_error()
 
 # =================== Exception messages outside transaction ====================
 
@@ -186,7 +186,7 @@ def test_py2_application_exception_message_unicode():
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -199,7 +199,7 @@ def test_py2_application_exception_message_unicode_english():
         raise ValueError(UNICODE_ENGLISH)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -211,7 +211,7 @@ def test_py2_application_exception_message_bytes_english():
         raise ValueError(BYTES_ENGLISH)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -226,7 +226,7 @@ def test_py2_application_exception_message_bytes_non_english():
         raise ValueError(BYTES_UTF8_ENCODED)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -245,7 +245,7 @@ def test_py2_application_exception_message_bytes_implicit_encoding_non_english()
         raise ValueError('I💜🐍')
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -259,7 +259,7 @@ def test_py2_application_exception_message_unicode_utf8_encoding():
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY3, reason="Testing Python 2 string behavior")
 @reset_core_stats_engine()
@@ -277,7 +277,7 @@ def test_py2_application_exception_message_bytes_utf8_encoding_non_english():
         raise ValueError('I💜🐍')
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 # ---------------- Python 3
 
@@ -291,7 +291,7 @@ def test_py3_application_exception_message_bytes_non_english_unicode():
         raise ValueError(UNICODE_MESSAGE)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY2, reason="Testing Python 3 string behavior")
 @reset_core_stats_engine()
@@ -303,7 +303,7 @@ def test_py3_application_exception_message_unicode_english():
         raise ValueError(UNICODE_ENGLISH)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)
 
 @pytest.mark.skipif(six.PY2, reason="Testing Python 3 string behavior")
 @reset_core_stats_engine()
@@ -320,4 +320,4 @@ def test_py3_application_exception_message_bytes_non_english():
         raise ValueError(BYTES_UTF8_ENCODED)
     except ValueError:
         app = application()
-        record_exception(application=app)
+        notice_error(application=app)

--- a/tests/agent_features/test_high_security_mode.py
+++ b/tests/agent_features/test_high_security_mode.py
@@ -19,7 +19,7 @@ import webtest
 
 from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import background_task
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.message_trace import MessageTrace
 from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
@@ -409,7 +409,7 @@ def test_other_transaction_error_parameters_hsm_disabled():
     try:
         raise TestException('test message')
     except Exception:
-        record_exception(params={'key-2': 'value-2'})
+        notice_error(attributes={'key-2': 'value-2'})
 
 
 @override_application_settings(_test_transaction_settings_hsm_enabled)
@@ -422,7 +422,7 @@ def test_other_transaction_error_parameters_hsm_enabled():
     try:
         raise TestException('test message')
     except Exception:
-        record_exception(params={'key-2': 'value-2'})
+        notice_error(attributes={'key-2': 'value-2'})
 
 
 _err_message = "Error! :("
@@ -440,7 +440,7 @@ def test_non_transaction_error_parameters_hsm_disabled():
         raise TestException(_err_message)
     except Exception:
         app = application()
-        record_exception(params={'key-1': 'value-1'}, application=app)
+        notice_error(attributes={'key-1': 'value-1'}, application=app)
 
 
 _intrinsic_attributes = {'error.class': callable_name(TestException),
@@ -457,7 +457,7 @@ def test_non_transaction_error_parameters_hsm_enabled():
         raise TestException(_err_message)
     except Exception:
         app = application()
-        record_exception(params={'key-1': 'value-1'}, application=app)
+        notice_error(attributes={'key-1': 'value-1'}, application=app)
 
 
 @wsgi_application()

--- a/tests/agent_features/test_ignore_expected_errors.py
+++ b/tests/agent_features/test_ignore_expected_errors.py
@@ -415,3 +415,4 @@ def test_overrides_outside_transaction(override, result, parameter):
         exercise(**kwargs)
 
     _test()
+

--- a/tests/agent_features/test_priority_sampling.py
+++ b/tests/agent_features/test_priority_sampling.py
@@ -66,14 +66,14 @@ def test_priority_used_in_transaction_error_events(first_transaction_saved):
             try:
                 raise ValueError('OOPS')
             except ValueError:
-                txn.record_exception()
+                txn.notice_error()
 
         with BackgroundTask(application(), name='T2') as txn:
             txn._priority = second_priority
             try:
                 raise ValueError('OOPS')
             except ValueError:
-                txn.record_exception()
+                txn.notice_error()
 
         # Stats engine
         stats_engine = core_application_stats_engine()

--- a/tests/agent_features/test_span_events.py
+++ b/tests/agent_features/test_span_events.py
@@ -663,7 +663,7 @@ def test_span_event_error_attributes_observed(trace_type, args):
 @validate_span_events(count=1,
         exact_agents={'error.class': ERROR_NAME, 'error.message': 'whoops'})
 @background_task(name='test_span_event_notice_error_overrides_observed')
-def test_span_event_record_exception_overrides_observed(trace_type, args):
+def test_span_event_notice_error_overrides_observed(trace_type, args):
     try:
         with trace_type(*args):
             try:

--- a/tests/agent_features/test_span_events.py
+++ b/tests/agent_features/test_span_events.py
@@ -17,7 +17,7 @@ import sys
 
 from newrelic.api.transaction import current_transaction
 from newrelic.api.time_trace import (current_trace,
-        add_custom_span_attribute, record_exception)
+        add_custom_span_attribute, notice_error, record_exception)
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
 
@@ -735,14 +735,14 @@ def test_span_event_multiple_errors(trace_type, args):
             try:
                 raise RuntimeError("whoaa")
             except:
-                record_exception()
+                notice_error()
             try:
                 raise RuntimeError("whoo")
             except:
-                record_exception()
+                notice_error()
             try:
                 raise ValueError("whoops")
             except:
-                record_exception()
+                notice_error()
 
     _test()

--- a/tests/agent_features/test_supportability_metrics.py
+++ b/tests/agent_features/test_supportability_metrics.py
@@ -62,28 +62,9 @@ def test_uses_api_twice():
 
 
 _unscoped_metrics = [
-        ('Supportability/api/record_exception', 1),
+        ('Supportability/api/r', 1),
         ('Supportability/api/background_task', None),
 ]
-
-
-@validate_transaction_metrics(
-        'test_supportability_metrics:test_record_exception',
-        custom_metrics=_unscoped_metrics,
-        background_task=True)
-@newrelic.agent.background_task()
-def test_record_exception():
-    try:
-        1 / 0
-    except ZeroDivisionError:
-        newrelic.agent.record_exception(sys.exc_info())
-
-
-_unscoped_metrics = [
-        ('Supportability/api/notice_error', 1),
-        ('Supportability/api/background_task', None),
-]
-
 
 @validate_transaction_metrics(
         'test_supportability_metrics:test_notice_error',

--- a/tests/agent_features/test_supportability_metrics.py
+++ b/tests/agent_features/test_supportability_metrics.py
@@ -62,7 +62,7 @@ def test_uses_api_twice():
 
 
 _unscoped_metrics = [
-        ('Supportability/api/r', 1),
+        ('Supportability/api/notice_error', 1),
         ('Supportability/api/background_task', None),
 ]
 

--- a/tests/agent_features/test_supportability_metrics.py
+++ b/tests/agent_features/test_supportability_metrics.py
@@ -80,6 +80,24 @@ def test_record_exception():
 
 
 _unscoped_metrics = [
+        ('Supportability/api/notice_error', 1),
+        ('Supportability/api/background_task', None),
+]
+
+
+@validate_transaction_metrics(
+        'test_supportability_metrics:test_notice_error',
+        custom_metrics=_unscoped_metrics,
+        background_task=True)
+@newrelic.agent.background_task()
+def test_notice_error():
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        newrelic.agent.notice_error(sys.exc_info())
+
+
+_unscoped_metrics = [
         ('Supportability/api/end_of_transaction', 1),
         ('Supportability/api/function_trace', None),
         ('Supportability/api/background_task', None),

--- a/tests/cross_agent/test_distributed_tracing.py
+++ b/tests/cross_agent/test_distributed_tracing.py
@@ -106,7 +106,7 @@ def target_wsgi_application(environ, start_response):
         try:
             1 / 0
         except ZeroDivisionError:
-            txn.record_exception()
+            txn.notice_error()
 
     extra_inbound_payloads = test_settings['extra_inbound_payloads']
     for payload, expected_result in extra_inbound_payloads:

--- a/tests/cross_agent/test_w3c_trace_context.py
+++ b/tests/cross_agent/test_w3c_trace_context.py
@@ -131,7 +131,7 @@ def target_wsgi_application(environ, start_response):
         try:
             raise ValueError("oops")
         except:
-            transaction.record_exception()
+            transaction.notice_error()
 
     if '.inbound_headers' in environ:
         transaction.accept_distributed_trace_headers(

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -2387,7 +2387,7 @@ def core_application_stats_engine_error(error_type, app_name=None):
     and return the first error with the type of error_type. If none found,
     return None.
 
-    Useful for verifying that application.record_exception() works, since
+    Useful for verifying that application.notice_error() works, since
     the error is saved outside of a transaction. Must use a unique error
     type per test in a single test file, so that it returns the error you
     expect. (If you have 2 tests that record the same type of exception, then
@@ -2404,7 +2404,7 @@ def core_application_stats_engine_error(error_type, app_name=None):
 def error_is_saved(error, app_name=None):
     """Return True, if an error of a particular type has already been saved.
 
-    Before calling application.record_exception() in a test, it's good to
+    Before calling application.notice_error() in a test, it's good to
     check if that type of error has already been saved, so you know that
     there will only be a single example of a type of Error in error_data()
     when you verify that the exception was recorded correctly.
@@ -2416,7 +2416,7 @@ def error_is_saved(error, app_name=None):
             raise ErrorOne('error one message')
         except ErrorOne:
             application_instance = application()
-            application_instance.record_exception()
+            application_instance.notice_error()
 
         my_error = core_application_stats_engine_error(_error_one_name)
         assert my_error.message == 'error one message'

--- a/tests/testing_support/sample_applications.py
+++ b/tests/testing_support/sample_applications.py
@@ -19,7 +19,7 @@ except ImportError:
 
 import sqlite3 as db
 
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.api.transaction import (add_custom_parameter,
         get_browser_timing_header, get_browser_timing_footer,
         record_custom_event)
@@ -96,9 +96,9 @@ def fully_featured_app(environ, start_response):
                 raise ValueError(environ['err_message'] + str(i))
             except ValueError:
                 if use_user_attrs:
-                    record_exception(params=_err_param)
+                    notice_error(attributes=_err_param)
                 else:
-                    record_exception()
+                    notice_error()
 
     text = '<html><head>%s</head><body><p>RESPONSE</p>%s</body></html>'
 

--- a/tests/testing_support/sample_asgi_applications.py
+++ b/tests/testing_support/sample_asgi_applications.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.time_trace import record_exception
+from newrelic.api.time_trace import notice_error
 from newrelic.api.transaction import add_custom_parameter, current_transaction
 from newrelic.api.asgi_application import ASGIApplicationWrapper
 
@@ -102,7 +102,7 @@ async def normal_asgi_application(scope, receive, send):
     try:
         raise ValueError("Transaction had bad value")
     except ValueError:
-        record_exception(params={"ohnoes": "param-value"})
+        notice_error(attributes={"ohnoes": "param-value"})
 
     await send(
         {"type": "http.response.start", "status": 200, "headers": response_headers}


### PR DESCRIPTION
This PR removes all outstanding uses of the record_exception API in the current agent codebase and replaces them with the new notice_error API.

Closes #209