### PR TITLE
Fix logging in http exceptions

### DIFF
--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -114,7 +114,7 @@ class AgentProtocol(object):
                 "Disconnection of the agent has been requested by the data "
                 "collector for the application where the agent run was "
                 "%(agent_run_id)s. Please contact New Relic support for "
-                "further information."
+                "further information. content=%(content)s"
             ),
         ),
         429: (
@@ -248,7 +248,7 @@ class AgentProtocol(object):
                     "params": {
                         k: v for k, v in params.items() if k in self.PARAMS_ALLOWLIST
                     },
-                    "content": payload,
+                    "content": data,
                     "agent_run_id": self._run_token,
                 },
             )


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Previously error messages for 410s would log content of response from data collector which includes reason for disconnect. Restoring this behavior.
  * Add content back to 410 logging messages
  * Correct `content` extra to use response content, instead of request payload, matching original implementation.

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
