### PR TITLE
Add non PID specific total memory metric.

### DIFF
--- a/newrelic/samplers/memory_usage.py
+++ b/newrelic/samplers/memory_usage.py
@@ -25,8 +25,16 @@ from newrelic.samplers.decorators import data_source_generator
 PID = os.getpid()
 
 
-@data_source_generator(name='Memory Usage')
+@data_source_generator(name="Memory Usage")
 def memory_usage_data_source():
-    yield ('Memory/Physical', physical_memory_used())
-    yield ('Memory/Physical/%d' % (PID), physical_memory_used())
-    yield ('Memory/Physical/Utilization/%d' % (PID), physical_memory_used()/total_physical_memory())
+    yield ("Memory/Physical", physical_memory_used())
+    yield ("Memory/Physical/%d" % (PID), physical_memory_used())
+
+    yield (
+        "Memory/Physical/Utilization",
+        physical_memory_used() / total_physical_memory(),
+    )
+    yield (
+        "Memory/Physical/Utilization/%d" % (PID),
+        physical_memory_used() / total_physical_memory(),
+    )

--- a/newrelic/samplers/memory_usage.py
+++ b/newrelic/samplers/memory_usage.py
@@ -27,5 +27,6 @@ PID = os.getpid()
 
 @data_source_generator(name='Memory Usage')
 def memory_usage_data_source():
+    yield ('Memory/Physical', physical_memory_used())
     yield ('Memory/Physical/%d' % (PID), physical_memory_used())
     yield ('Memory/Physical/Utilization/%d' % (PID), physical_memory_used()/total_physical_memory())

--- a/tests/agent_unittests/test_sampler_metrics.py
+++ b/tests/agent_unittests/test_sampler_metrics.py
@@ -153,6 +153,7 @@ def test_cpu_metrics_collection(cpu_data_source):
 EXPECTED_MEMORY_METRICS = (
     "Memory/Physical",
     "Memory/Physical/%d" % PID,
+    "Memory/Physical/Utilization",
     "Memory/Physical/Utilization/%d" % PID,
 )
 

--- a/tests/agent_unittests/test_sampler_metrics.py
+++ b/tests/agent_unittests/test_sampler_metrics.py
@@ -151,6 +151,7 @@ def test_cpu_metrics_collection(cpu_data_source):
 
 
 EXPECTED_MEMORY_METRICS = (
+    "Memory/Physical",
     "Memory/Physical/%d" % PID,
     "Memory/Physical/Utilization/%d" % PID,
 )


### PR DESCRIPTION
Currently, the agent yields up total memory metrics for each detected PID. This PR adds a non PID specific total memory metric for compatibility with the query being used in the NR UI for the _All hosts by memory usage_ graph (found in the Charts section of the Summary page).
