### PR TITLE
Pyramid (transaction naming): lower exception view precedence

### DIFF
--- a/newrelic/hooks/framework_pyramid.py
+++ b/newrelic/hooks/framework_pyramid.py
@@ -98,7 +98,11 @@ def view_handler_wrapper(wrapped, instance, args, kwargs):
 
     name = callable_name(view_callable)
 
-    transaction.set_transaction_name(name)
+    # set exception views to priority=1 so they won't take precedence over
+    # the original view callable
+    transaction.set_transaction_name(
+        name,
+        priority=1 if args and isinstance(args[0], Exception) else 2)
 
     with FunctionTrace(name) as trace:
         try:
@@ -157,7 +161,7 @@ def default_view_mapper_wrapper(wrapped, instance, args, kwargs):
                     inst = getattr(request, '__view__', None)
                     if inst is not None:
                         name = callable_name(getattr(inst, attr))
-                        transaction.set_transaction_name(name, priority=1)
+                        transaction.set_transaction_name(name, priority=2)
                         tracer.name = name
                 else:
                     inst = getattr(request, '__view__', None)
@@ -165,7 +169,7 @@ def default_view_mapper_wrapper(wrapped, instance, args, kwargs):
                         method = getattr(inst, '__call__')
                         if method:
                             name = callable_name(method)
-                            transaction.set_transaction_name(name, priority=1)
+                            transaction.set_transaction_name(name, priority=2)
                             tracer.name = name
 
     return _wrapper

--- a/tests/framework_pyramid/test_application.py
+++ b/tests/framework_pyramid/test_application.py
@@ -80,7 +80,7 @@ _test_not_found_as_exception_response_scoped_metrics = [
 
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics(
-    'pyramid.httpexceptions:default_exceptionresponse_view',
+    '_test_application:not_found_exception_response',
     scoped_metrics=_test_not_found_as_exception_response_scoped_metrics)
 def test_not_found_as_exception_response():
     application = target_application()
@@ -98,7 +98,7 @@ _test_not_found_raises_NotFound_scoped_metrics = [
 
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics(
-    'pyramid.httpexceptions:default_exceptionresponse_view',
+    '_test_application:raise_not_found',
     scoped_metrics=_test_not_found_raises_NotFound_scoped_metrics)
 def test_application_not_found_raises_NotFound():
     application = target_application()
@@ -154,7 +154,7 @@ _test_redirect_scoped_metrics = [
 
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics(
-    'pyramid.httpexceptions:default_exceptionresponse_view',
+    '_test_application:redirect',
     scoped_metrics=_test_redirect_scoped_metrics)
 def test_application_redirect():
     application = target_application()

--- a/tests/framework_pyramid/test_cornice.py
+++ b/tests/framework_pyramid/test_cornice.py
@@ -91,7 +91,7 @@ else:
     _test_cornice_error_errors = ['exceptions:RuntimeError']
 
 @validate_transaction_errors(errors=_test_cornice_error_errors)
-@validate_transaction_metrics('cornice.pyramidhook:handle_exceptions',
+@validate_transaction_metrics('_test_application:cornice_error_get_info',
         scoped_metrics=_test_cornice_error_scoped_metrics)
 def test_cornice_error():
     application = target_application()


### PR DESCRIPTION
# Overview
For the Pyramid framework, use a higher priority=2 when calling set_transaction_name
* in the view_handler_wrapper (for non-exception views only)
* for both calls in the default_view_mapper_wrapper._wrapper since we have an instance of the registered view_callable in both cases

similar to how exception handler prioritization is handled in the Flask hooks module.

# Related Github Issue
https://github.com/newrelic/newrelic-python-agent/issues/236

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.

TODO:
- [ ] add unit tests

