### PR TITLE
Update error handler instrumentation point for Flask v2 

### DIFF
--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -354,14 +354,6 @@ def instrument_flask_templating(module):
     wrap_function_trace(module, "render_template_string")
 
 
-# def instrument_flask_scaffold(module):
-#     # The _register_error_handler() method was moved to the scaffold class
-#     # in Flask version 2.0.0.
-#     if hasattr(module.Scaffold, '_register_error_handler'):
-#         wrap_function_wrapper(module, 'Flask._register_error_handler',
-#                 _nr_wrapper_Flask__register_error_handler_)
-
-
 def _nr_wrapper_Blueprint_endpoint_(wrapped, instance, args, kwargs):
     return _nr_wrapper_endpoint_(wrapped(*args, **kwargs))
 

--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -17,18 +17,23 @@
 """
 
 from newrelic.api.wsgi_application import wrap_wsgi_application
-from newrelic.api.function_trace import (FunctionTrace, wrap_function_trace,
-        FunctionTraceWrapper)
+from newrelic.api.function_trace import (
+    FunctionTrace,
+    wrap_function_trace,
+    FunctionTraceWrapper,
+)
 from newrelic.api.transaction import current_transaction
 from newrelic.api.time_trace import notice_error
 
-from newrelic.common.object_wrapper import (wrap_function_wrapper,
-        function_wrapper)
+from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
 from newrelic.common.object_names import callable_name
+
 
 def framework_details():
     import flask
-    return ('Flask', getattr(flask, '__version__', None))
+
+    return ("Flask", getattr(flask, "__version__", None))
+
 
 def status_code(exc, value, tb):
     from werkzeug.exceptions import HTTPException
@@ -40,6 +45,7 @@ def status_code(exc, value, tb):
     if isinstance(value, HTTPException):
         return value.code
 
+
 @function_wrapper
 def _nr_wrapper_handler_(wrapped, instance, args, kwargs):
     transaction = current_transaction()
@@ -47,7 +53,7 @@ def _nr_wrapper_handler_(wrapped, instance, args, kwargs):
     if transaction is None:
         return wrapped(*args, **kwargs)
 
-    name = getattr(wrapped, '_nr_view_func_name', callable_name(wrapped))
+    name = getattr(wrapped, "_nr_view_func_name", callable_name(wrapped))
 
     # Set priority=2 so this will take precedence over any error
     # handler which will be at priority=1.
@@ -56,6 +62,7 @@ def _nr_wrapper_handler_(wrapped, instance, args, kwargs):
 
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
+
 
 def _nr_wrapper_Flask_add_url_rule_input_(wrapped, instance, args, kwargs):
     def _bind_params(rule, endpoint=None, view_func=None, **options):
@@ -68,10 +75,12 @@ def _nr_wrapper_Flask_add_url_rule_input_(wrapped, instance, args, kwargs):
 
     return wrapped(rule, endpoint, view_func, **options)
 
+
 def _nr_wrapper_Flask_views_View_as_view_(wrapped, instance, args, kwargs):
     view = wrapped(*args, **kwargs)
-    view._nr_view_func_name = '%s:%s' % (view.__module__, view.__name__)
+    view._nr_view_func_name = "%s:%s" % (view.__module__, view.__name__)
     return view
+
 
 @function_wrapper
 def _nr_wrapper_endpoint_(wrapped, instance, args, kwargs):
@@ -82,8 +91,10 @@ def _nr_wrapper_endpoint_(wrapped, instance, args, kwargs):
 
     return wrapped(_nr_wrapper_handler_(f))
 
+
 def _nr_wrapper_Flask_endpoint_(wrapped, instance, args, kwargs):
     return _nr_wrapper_endpoint_(wrapped(*args, **kwargs))
+
 
 def _nr_wrapper_Flask_handle_http_exception_(wrapped, instance, args, kwargs):
     transaction = current_transaction()
@@ -102,6 +113,7 @@ def _nr_wrapper_Flask_handle_http_exception_(wrapped, instance, args, kwargs):
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
 
+
 def _nr_wrapper_Flask_handle_exception_(wrapped, instance, args, kwargs):
     transaction = current_transaction()
 
@@ -118,6 +130,7 @@ def _nr_wrapper_Flask_handle_exception_(wrapped, instance, args, kwargs):
 
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
+
 
 @function_wrapper
 def _nr_wrapper_error_handler_(wrapped, instance, args, kwargs):
@@ -137,6 +150,7 @@ def _nr_wrapper_error_handler_(wrapped, instance, args, kwargs):
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
 
+
 def _nr_wrapper_Flask__register_error_handler_(wrapped, instance, args, kwargs):
     def _bind_params(key, code_or_exception, f):
         return key, code_or_exception, f
@@ -146,6 +160,7 @@ def _nr_wrapper_Flask__register_error_handler_(wrapped, instance, args, kwargs):
     f = _nr_wrapper_error_handler_(f)
 
     return wrapped(key, code_or_exception, f)
+
 
 def _nr_wrapper_Flask_register_error_handler_(wrapped, instance, args, kwargs):
     def _bind_params(code_or_exception, f):
@@ -157,8 +172,10 @@ def _nr_wrapper_Flask_register_error_handler_(wrapped, instance, args, kwargs):
 
     return wrapped(code_or_exception, f)
 
+
 def _nr_wrapper_Flask_try_trigger_before_first_request_functions_(
-        wrapped, instance, args, kwargs):
+    wrapped, instance, args, kwargs
+):
 
     transaction = current_transaction()
 
@@ -178,6 +195,7 @@ def _nr_wrapper_Flask_try_trigger_before_first_request_functions_(
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
 
+
 def _nr_wrapper_Flask_before_first_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
@@ -186,6 +204,7 @@ def _nr_wrapper_Flask_before_first_request_(wrapped, instance, args, kwargs):
     f = FunctionTraceWrapper(f)
 
     return wrapped(f, *_args, **_kwargs)
+
 
 @function_wrapper
 def _nr_wrapper_Flask_before_request_wrapped_(wrapped, instance, args, kwargs):
@@ -201,6 +220,7 @@ def _nr_wrapper_Flask_before_request_wrapped_(wrapped, instance, args, kwargs):
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
 
+
 def _nr_wrapper_Flask_before_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
@@ -209,6 +229,7 @@ def _nr_wrapper_Flask_before_request_(wrapped, instance, args, kwargs):
     f = _nr_wrapper_Flask_before_request_wrapped_(f)
 
     return wrapped(f, *_args, **_kwargs)
+
 
 def _nr_wrapper_Flask_after_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
@@ -219,6 +240,7 @@ def _nr_wrapper_Flask_after_request_(wrapped, instance, args, kwargs):
 
     return wrapped(f, *_args, **_kwargs)
 
+
 def _nr_wrapper_Flask_teardown_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
@@ -227,6 +249,7 @@ def _nr_wrapper_Flask_teardown_request_(wrapped, instance, args, kwargs):
     f = FunctionTraceWrapper(f)
 
     return wrapped(f, *_args, **_kwargs)
+
 
 def _nr_wrapper_Flask_teardown_appcontext_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
@@ -237,79 +260,99 @@ def _nr_wrapper_Flask_teardown_appcontext_(wrapped, instance, args, kwargs):
 
     return wrapped(f, *_args, **_kwargs)
 
+
 def instrument_flask_views(module):
-    wrap_function_wrapper(module, 'View.as_view',
-            _nr_wrapper_Flask_views_View_as_view_)
+    wrap_function_wrapper(module, "View.as_view", _nr_wrapper_Flask_views_View_as_view_)
+
 
 def instrument_flask_app(module):
-    wrap_wsgi_application(module, 'Flask.wsgi_app',
-            framework=framework_details())
+    wrap_wsgi_application(module, "Flask.wsgi_app", framework=framework_details())
 
-    wrap_function_wrapper(module, 'Flask.add_url_rule',
-            _nr_wrapper_Flask_add_url_rule_input_)
+    wrap_function_wrapper(
+        module, "Flask.add_url_rule", _nr_wrapper_Flask_add_url_rule_input_
+    )
 
-    if hasattr(module.Flask, 'endpoint'):
-        wrap_function_wrapper(module, 'Flask.endpoint',
-                _nr_wrapper_Flask_endpoint_)
+    if hasattr(module.Flask, "endpoint"):
+        wrap_function_wrapper(module, "Flask.endpoint", _nr_wrapper_Flask_endpoint_)
 
-    wrap_function_wrapper(module, 'Flask.handle_http_exception',
-            _nr_wrapper_Flask_handle_http_exception_)
+    wrap_function_wrapper(
+        module, "Flask.handle_http_exception", _nr_wrapper_Flask_handle_http_exception_
+    )
 
     # Use the same wrapper for initial user exception processing and
     # fallback for unhandled exceptions.
 
-    if hasattr(module.Flask, 'handle_user_exception'):
-        wrap_function_wrapper(module, 'Flask.handle_user_exception',
-                _nr_wrapper_Flask_handle_exception_)
+    if hasattr(module.Flask, "handle_user_exception"):
+        wrap_function_wrapper(
+            module, "Flask.handle_user_exception", _nr_wrapper_Flask_handle_exception_
+        )
 
-    wrap_function_wrapper(module, 'Flask.handle_exception',
-            _nr_wrapper_Flask_handle_exception_)
+    wrap_function_wrapper(
+        module, "Flask.handle_exception", _nr_wrapper_Flask_handle_exception_
+    )
 
     # The _register_error_handler() method was only introduced in
     # Flask version 0.7.0.
-    if hasattr(module.Flask, '_register_error_handler'):
-        wrap_function_wrapper(module, 'Flask._register_error_handler',
-                _nr_wrapper_Flask__register_error_handler_)
+    if hasattr(module.Flask, "_register_error_handler"):
+        wrap_function_wrapper(
+            module,
+            "Flask._register_error_handler",
+            _nr_wrapper_Flask__register_error_handler_,
+        )
 
     # The method changed name to register_error_handler() in
     # Flask version 2.0.0.
-    elif hasattr(module.Flask, 'register_error_handler'):
-        wrap_function_wrapper(module, 'Flask.register_error_handler',
-                _nr_wrapper_Flask_register_error_handler_)
+    elif hasattr(module.Flask, "register_error_handler"):
+        wrap_function_wrapper(
+            module,
+            "Flask.register_error_handler",
+            _nr_wrapper_Flask_register_error_handler_,
+        )
 
     # Different before/after methods were added in different versions.
     # Check for the presence of everything before patching.
 
-    if hasattr(module.Flask, 'try_trigger_before_first_request_functions'):
-        wrap_function_wrapper(module,
-                'Flask.try_trigger_before_first_request_functions',
-                _nr_wrapper_Flask_try_trigger_before_first_request_functions_)
-        wrap_function_wrapper(module, 'Flask.before_first_request',
-                _nr_wrapper_Flask_before_first_request_)
+    if hasattr(module.Flask, "try_trigger_before_first_request_functions"):
+        wrap_function_wrapper(
+            module,
+            "Flask.try_trigger_before_first_request_functions",
+            _nr_wrapper_Flask_try_trigger_before_first_request_functions_,
+        )
+        wrap_function_wrapper(
+            module,
+            "Flask.before_first_request",
+            _nr_wrapper_Flask_before_first_request_,
+        )
 
-    if hasattr(module.Flask, 'preprocess_request'):
-        wrap_function_trace(module, 'Flask.preprocess_request')
-        wrap_function_wrapper(module, 'Flask.before_request',
-                _nr_wrapper_Flask_before_request_)
+    if hasattr(module.Flask, "preprocess_request"):
+        wrap_function_trace(module, "Flask.preprocess_request")
+        wrap_function_wrapper(
+            module, "Flask.before_request", _nr_wrapper_Flask_before_request_
+        )
 
-    if hasattr(module.Flask, 'process_response'):
-        wrap_function_trace(module, 'Flask.process_response')
-        wrap_function_wrapper(module, 'Flask.after_request',
-                _nr_wrapper_Flask_after_request_)
+    if hasattr(module.Flask, "process_response"):
+        wrap_function_trace(module, "Flask.process_response")
+        wrap_function_wrapper(
+            module, "Flask.after_request", _nr_wrapper_Flask_after_request_
+        )
 
-    if hasattr(module.Flask, 'do_teardown_request'):
-        wrap_function_trace(module, 'Flask.do_teardown_request')
-        wrap_function_wrapper(module, 'Flask.teardown_request',
-                _nr_wrapper_Flask_teardown_request_)
+    if hasattr(module.Flask, "do_teardown_request"):
+        wrap_function_trace(module, "Flask.do_teardown_request")
+        wrap_function_wrapper(
+            module, "Flask.teardown_request", _nr_wrapper_Flask_teardown_request_
+        )
 
-    if hasattr(module.Flask, 'do_teardown_appcontext'):
-        wrap_function_trace(module, 'Flask.do_teardown_appcontext')
-        wrap_function_wrapper(module, 'Flask.teardown_appcontext',
-                _nr_wrapper_Flask_teardown_appcontext_)
+    if hasattr(module.Flask, "do_teardown_appcontext"):
+        wrap_function_trace(module, "Flask.do_teardown_appcontext")
+        wrap_function_wrapper(
+            module, "Flask.teardown_appcontext", _nr_wrapper_Flask_teardown_appcontext_
+        )
+
 
 def instrument_flask_templating(module):
-    wrap_function_trace(module, 'render_template')
-    wrap_function_trace(module, 'render_template_string')
+    wrap_function_trace(module, "render_template")
+    wrap_function_trace(module, "render_template_string")
+
 
 # def instrument_flask_scaffold(module):
 #     # The _register_error_handler() method was moved to the scaffold class
@@ -322,9 +365,9 @@ def instrument_flask_templating(module):
 def _nr_wrapper_Blueprint_endpoint_(wrapped, instance, args, kwargs):
     return _nr_wrapper_endpoint_(wrapped(*args, **kwargs))
 
+
 @function_wrapper
-def _nr_wrapper_Blueprint_before_request_wrapped_(wrapped, instance,
-        args, kwargs):
+def _nr_wrapper_Blueprint_before_request_wrapped_(wrapped, instance, args, kwargs):
 
     transaction = current_transaction()
 
@@ -338,6 +381,7 @@ def _nr_wrapper_Blueprint_before_request_wrapped_(wrapped, instance,
     with FunctionTrace(name):
         return wrapped(*args, **kwargs)
 
+
 def _nr_wrapper_Blueprint_before_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
@@ -347,9 +391,8 @@ def _nr_wrapper_Blueprint_before_request_(wrapped, instance, args, kwargs):
 
     return wrapped(f, *_args, **_kwargs)
 
-def _nr_wrapper_Blueprint_before_app_request_(wrapped, instance,
-        args, kwargs):
 
+def _nr_wrapper_Blueprint_before_app_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
 
@@ -358,9 +401,8 @@ def _nr_wrapper_Blueprint_before_app_request_(wrapped, instance,
 
     return wrapped(f, *_args, **_kwargs)
 
-def _nr_wrapper_Blueprint_before_app_first_request_(wrapped, instance,
-        args, kwargs):
 
+def _nr_wrapper_Blueprint_before_app_first_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
 
@@ -368,6 +410,7 @@ def _nr_wrapper_Blueprint_before_app_first_request_(wrapped, instance,
     f = FunctionTraceWrapper(f)
 
     return wrapped(f, *_args, **_kwargs)
+
 
 def _nr_wrapper_Blueprint_after_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
@@ -378,6 +421,7 @@ def _nr_wrapper_Blueprint_after_request_(wrapped, instance, args, kwargs):
 
     return wrapped(f, *_args, **_kwargs)
 
+
 def _nr_wrapper_Blueprint_after_app_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
@@ -386,6 +430,7 @@ def _nr_wrapper_Blueprint_after_app_request_(wrapped, instance, args, kwargs):
     f = FunctionTraceWrapper(f)
 
     return wrapped(f, *_args, **_kwargs)
+
 
 def _nr_wrapper_Blueprint_teardown_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
@@ -396,9 +441,8 @@ def _nr_wrapper_Blueprint_teardown_request_(wrapped, instance, args, kwargs):
 
     return wrapped(f, *_args, **_kwargs)
 
-def _nr_wrapper_Blueprint_teardown_app_request_(wrapped, instance,
-        args, kwargs):
 
+def _nr_wrapper_Blueprint_teardown_app_request_(wrapped, instance, args, kwargs):
     def _params(f, *args, **kwargs):
         return f, args, kwargs
 
@@ -407,30 +451,47 @@ def _nr_wrapper_Blueprint_teardown_app_request_(wrapped, instance,
 
     return wrapped(f, *_args, **_kwargs)
 
+
 def instrument_flask_blueprints(module):
-    wrap_function_wrapper(module, 'Blueprint.endpoint',
-            _nr_wrapper_Blueprint_endpoint_)
+    wrap_function_wrapper(module, "Blueprint.endpoint", _nr_wrapper_Blueprint_endpoint_)
 
-    if hasattr(module.Blueprint, 'before_request'):
-        wrap_function_wrapper(module, 'Blueprint.before_request',
-                _nr_wrapper_Blueprint_before_request_)
-    if hasattr(module.Blueprint, 'before_app_request'):
-        wrap_function_wrapper(module, 'Blueprint.before_app_request',
-                _nr_wrapper_Blueprint_before_app_request_)
-    if hasattr(module.Blueprint, 'before_app_first_request'):
-        wrap_function_wrapper(module, 'Blueprint.before_app_first_request',
-                _nr_wrapper_Blueprint_before_app_first_request_)
+    if hasattr(module.Blueprint, "before_request"):
+        wrap_function_wrapper(
+            module, "Blueprint.before_request", _nr_wrapper_Blueprint_before_request_
+        )
+    if hasattr(module.Blueprint, "before_app_request"):
+        wrap_function_wrapper(
+            module,
+            "Blueprint.before_app_request",
+            _nr_wrapper_Blueprint_before_app_request_,
+        )
+    if hasattr(module.Blueprint, "before_app_first_request"):
+        wrap_function_wrapper(
+            module,
+            "Blueprint.before_app_first_request",
+            _nr_wrapper_Blueprint_before_app_first_request_,
+        )
 
-    if hasattr(module.Blueprint, 'after_request'):
-        wrap_function_wrapper(module, 'Blueprint.after_request',
-                _nr_wrapper_Blueprint_after_request_)
-    if hasattr(module.Blueprint, 'after_app_request'):
-        wrap_function_wrapper(module, 'Blueprint.after_app_request',
-                _nr_wrapper_Blueprint_after_app_request_)
+    if hasattr(module.Blueprint, "after_request"):
+        wrap_function_wrapper(
+            module, "Blueprint.after_request", _nr_wrapper_Blueprint_after_request_
+        )
+    if hasattr(module.Blueprint, "after_app_request"):
+        wrap_function_wrapper(
+            module,
+            "Blueprint.after_app_request",
+            _nr_wrapper_Blueprint_after_app_request_,
+        )
 
-    if hasattr(module.Blueprint, 'teardown_request'):
-        wrap_function_wrapper(module, 'Blueprint.teardown_request',
-                _nr_wrapper_Blueprint_teardown_request_)
-    if hasattr(module.Blueprint, 'teardown_app_request'):
-        wrap_function_wrapper(module, 'Blueprint.teardown_app_request',
-                _nr_wrapper_Blueprint_teardown_app_request_)
+    if hasattr(module.Blueprint, "teardown_request"):
+        wrap_function_wrapper(
+            module,
+            "Blueprint.teardown_request",
+            _nr_wrapper_Blueprint_teardown_request_,
+        )
+    if hasattr(module.Blueprint, "teardown_app_request"):
+        wrap_function_wrapper(
+            module,
+            "Blueprint.teardown_app_request",
+            _nr_wrapper_Blueprint_teardown_app_request_,
+        )

--- a/tests/framework_flask/test_not_found.py
+++ b/tests/framework_flask/test_not_found.py
@@ -17,16 +17,6 @@ import pytest
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors)
 
-try:
-    # The __version__ attribute was only added in 0.7.0.
-    from flask import __version__ as flask_version
-    is_gt_flask060 = True
-except ImportError:
-    is_gt_flask060 = False
-
-requires_error_handler = pytest.mark.skipif(not is_gt_flask060,
-        reason="The error handler decorator is not supported.")
-
 def target_application():
     # We need to delay Flask application creation because of ordering
     # issues whereby the agent needs to be initialised before Flask is
@@ -47,13 +37,10 @@ _test_error_handler_not_found_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_not_found:page_not_found', 1),
         ('Function/flask.app:Flask.handle_http_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
-if is_gt_flask060:
-    _test_error_handler_not_found_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
 
-@requires_error_handler
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_not_found:page_not_found',
         scoped_metrics=_test_error_handler_not_found_scoped_metrics)

--- a/tests/framework_flask/test_not_found.py
+++ b/tests/framework_flask/test_not_found.py
@@ -57,7 +57,6 @@ if is_gt_flask060:
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_not_found:page_not_found',
         scoped_metrics=_test_error_handler_not_found_scoped_metrics)
-@pytest.mark.xfail(reason="Waiting on exception handling work to be complete")
 def test_error_handler_not_found():
     application = target_application()
     response = application.get('/missing', status=404)

--- a/tests/framework_flask/test_user_exceptions.py
+++ b/tests/framework_flask/test_user_exceptions.py
@@ -17,16 +17,6 @@ import pytest
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors)
 
-try:
-    # The __version__ attribute was only added in 0.7.0.
-    from flask import __version__ as flask_version
-    is_gt_flask060 = True
-except ImportError:
-    is_gt_flask060 = False
-
-requires_error_handler = pytest.mark.skipif(not is_gt_flask060,
-        reason="The error handler decorator is not supported.")
-
 def target_application():
     # We need to delay Flask application creation because of ordering
     # issues whereby the agent needs to be initialised before Flask is
@@ -47,13 +37,11 @@ _test_user_exception_handler_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_user_exceptions:page_not_found', 1),
         ('Function/_test_user_exceptions:error_page', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
-if is_gt_flask060:
-    _test_user_exception_handler_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
 
-@requires_error_handler
+
 @validate_transaction_errors(errors=['_test_user_exceptions:UserException'])
 @validate_transaction_metrics('_test_user_exceptions:error_page',
         scoped_metrics=_test_user_exception_handler_scoped_metrics)

--- a/tests/framework_flask/test_user_exceptions.py
+++ b/tests/framework_flask/test_user_exceptions.py
@@ -57,7 +57,6 @@ if is_gt_flask060:
 @validate_transaction_errors(errors=['_test_user_exceptions:UserException'])
 @validate_transaction_metrics('_test_user_exceptions:error_page',
         scoped_metrics=_test_user_exception_handler_scoped_metrics)
-@pytest.mark.xfail(reason="Waiting on exception handling work to be complete")
 def test_user_exception_handler():
     application = target_application()
     response = application.get('/user_exception', status=500)


### PR DESCRIPTION

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR adds an additional instrumentation point for register_error_handler for compatibility with Flask v2. 

# Related Github Issue
Closes #234 
