### PR TITLE
Flask async view tests

### DIFF
--- a/tests/framework_flask/_test_application.py
+++ b/tests/framework_flask/_test_application.py
@@ -18,6 +18,8 @@ from flask import Flask, render_template_string, render_template, abort
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import Rule
 
+from conftest import is_flask_v2 as async_handler_support
+
 try:
     # The __version__ attribute was only added in 0.7.0.
     from flask import __version__ as flask_version
@@ -38,10 +40,11 @@ if is_gt_flask060:
     def endpoint_page():
         return 'ENDPOINT RESPONSE'
 
-@application.route('/async')
-async def async_page():
-    breakpoint()
-    return 'ASYNC RESPONSE'
+# Async handlers only supported in Flask >2.0.0
+if async_handler_support:
+    @application.route('/async')
+    async def async_page():
+        return 'ASYNC RESPONSE'
 
 @application.route('/error')
 def error_page():

--- a/tests/framework_flask/_test_application.py
+++ b/tests/framework_flask/_test_application.py
@@ -38,6 +38,11 @@ if is_gt_flask060:
     def endpoint_page():
         return 'ENDPOINT RESPONSE'
 
+@application.route('/async')
+async def async_page():
+    breakpoint()
+    return 'ASYNC RESPONSE'
+
 @application.route('/error')
 def error_page():
     raise RuntimeError('RUNTIME ERROR')

--- a/tests/framework_flask/_test_application.py
+++ b/tests/framework_flask/_test_application.py
@@ -20,25 +20,17 @@ from werkzeug.routing import Rule
 
 from conftest import is_flask_v2 as async_handler_support
 
-try:
-    # The __version__ attribute was only added in 0.7.0.
-    from flask import __version__ as flask_version
-    is_gt_flask060 = True
-except ImportError:
-    is_gt_flask060 = False
-
 application = Flask(__name__)
 
 @application.route('/index')
 def index_page():
     return 'INDEX RESPONSE'
 
-if is_gt_flask060:
-    application.url_map.add(Rule('/endpoint', endpoint='endpoint'))
+application.url_map.add(Rule('/endpoint', endpoint='endpoint'))
 
-    @application.endpoint('endpoint')
-    def endpoint_page():
-        return 'ENDPOINT RESPONSE'
+@application.endpoint('endpoint')
+def endpoint_page():
+    return 'ENDPOINT RESPONSE'
 
 # Async handlers only supported in Flask >2.0.0
 if async_handler_support:

--- a/tests/framework_flask/_test_blueprints.py
+++ b/tests/framework_flask/_test_blueprints.py
@@ -18,6 +18,8 @@ from flask import Flask
 from flask import Blueprint
 from werkzeug.routing import Rule
 
+from conftest import is_flask_v2
+
 # Blueprints are only available in 0.7.0 onwards.
 
 blueprint = Blueprint('blueprint', __name__)
@@ -60,9 +62,6 @@ def teardown_request(exc):
 def teardown_app_request(exc):
     pass
 
-
-from flask import __version__ as flask_version
-is_flask_v2 = int(flask_version.split('.')[0]) >= 2
 # Support for nested blueprints was added in Flask 2.0
 if is_flask_v2:
     parent = Blueprint('parent', __name__, url_prefix='/parent')

--- a/tests/framework_flask/_test_views.py
+++ b/tests/framework_flask/_test_views.py
@@ -17,6 +17,8 @@ import webtest
 import flask
 import flask.views
 
+from conftest import is_flask_v2
+
 app = flask.Flask(__name__)
 
 class TestView(flask.views.View):
@@ -36,16 +38,18 @@ class TestAsyncView(flask.views.View):
 
 class TestAsyncMethodView(flask.views.MethodView):
     async def get(self):
-        breakpoint()
         return 'ASYNC METHODVIEW GET RESPONSE'
 
 app.add_url_rule('/view',
         view_func=TestView.as_view('test_view'))
-app.add_url_rule('/async_view',
-        view_func=TestAsyncView.as_view('test_async_view'))
 app.add_url_rule('/methodview',
         view_func=TestMethodView.as_view('test_methodview'))
-app.add_url_rule('/async_methodview',
-        view_func=TestAsyncMethodView.as_view('test_async_methodview'))
+
+# Async view support added in flask v2
+if is_flask_v2:
+        app.add_url_rule('/async_view',
+                view_func=TestAsyncView.as_view('test_async_view'))
+        app.add_url_rule('/async_methodview',
+                view_func=TestAsyncMethodView.as_view('test_async_methodview'))
 
 _test_application = webtest.TestApp(app)

--- a/tests/framework_flask/_test_views.py
+++ b/tests/framework_flask/_test_views.py
@@ -30,9 +30,22 @@ class TestMethodView(flask.views.MethodView):
     def post(self):
         return 'METHODVIEW POST RESPONSE'
 
+class TestAsyncView(flask.views.View):
+    async def dispatch_request(self):
+        return 'ASYNC VIEW RESPONSE'
+
+class TestAsyncMethodView(flask.views.MethodView):
+    async def get(self):
+        breakpoint()
+        return 'ASYNC METHODVIEW GET RESPONSE'
+
 app.add_url_rule('/view',
         view_func=TestView.as_view('test_view'))
+app.add_url_rule('/async_view',
+        view_func=TestAsyncView.as_view('test_async_view'))
 app.add_url_rule('/methodview',
         view_func=TestMethodView.as_view('test_methodview'))
+app.add_url_rule('/async_methodview',
+        view_func=TestAsyncMethodView.as_view('test_async_methodview'))
 
 _test_application = webtest.TestApp(app)

--- a/tests/framework_flask/conftest.py
+++ b/tests/framework_flask/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+from flask import __version__ as flask_version
 
 from testing_support.fixtures import (code_coverage_fixture,
         collector_agent_registration_fixture, collector_available_fixture)
@@ -35,3 +36,8 @@ _default_settings = {
 collector_agent_registration = collector_agent_registration_fixture(
         app_name='Python Agent Test (framework_flask)',
         default_settings=_default_settings)
+
+
+is_flask_v2 = int(flask_version.split('.')[0]) >= 2
+skip_if_flask_1 = pytest.mark.skipif(not is_flask_v2,
+        reason="Not introduced until Flask >2.0.0.")

--- a/tests/framework_flask/test_application.py
+++ b/tests/framework_flask/test_application.py
@@ -22,24 +22,6 @@ from newrelic.packages import six
 
 from conftest import skip_if_flask_1 as async_handler_support
 
-try:
-    # The __version__ attribute was only added in 0.7.0.
-    # Flask team does not use semantic versioning during development.
-    from flask import __version__ as flask_version
-    flask_version = tuple([int(v) for v in flask_version.split('.')])
-    is_gt_flask060 = True
-    is_dev_version = False
-except ValueError:
-    is_gt_flask060 = True
-    is_dev_version = True
-except ImportError:
-    is_gt_flask060 = False
-    is_dev_version = False
-
-requires_endpoint_decorator = pytest.mark.skipif(not is_gt_flask060,
-        reason="The endpoint decorator is not supported.")
-
-
 def target_application():
     # We need to delay Flask application creation because of ordering
     # issues whereby the agent needs to be initialised before Flask is
@@ -69,8 +51,7 @@ _test_application_index_tt_parenting = (
                 ('FunctionNode', []),
                 ('FunctionNode', []),
                 ('FunctionNode', []),
-                # some flask versions have more FunctionNodes here, as appended
-                # below
+                ('FunctionNode', []),
             ]),
         ]),
         ('FunctionNode', []),
@@ -80,14 +61,6 @@ _test_application_index_tt_parenting = (
     ]
 )
 
-if is_dev_version or (is_gt_flask060 and flask_version >= (0, 7)):
-    _test_application_index_tt_parenting[1][0][1][0][1].append(
-        ('FunctionNode', []),
-    )
-if is_dev_version or (is_gt_flask060 and flask_version >= (0, 9)):
-    _test_application_index_tt_parenting[1][0][1][0][1].append(
-        ('FunctionNode', []),
-    )
 
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_application:index_page',
@@ -125,7 +98,6 @@ _test_application_endpoint_scoped_metrics = [
         ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
 
 
-@requires_endpoint_decorator
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_application:endpoint_page',
         scoped_metrics=_test_application_endpoint_scoped_metrics)
@@ -142,11 +114,10 @@ _test_application_error_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_application:error_page', 1),
         ('Function/flask.app:Flask.handle_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
-if is_gt_flask060:
-    _test_application_error_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
 
 if six.PY3:
     _test_application_error_errors = ['builtins:RuntimeError']
@@ -169,11 +140,8 @@ _test_application_abort_404_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_application:abort_404_page', 1),
         ('Function/flask.app:Flask.handle_http_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
-
-if is_gt_flask060:
-    _test_application_abort_404_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
 
 @validate_transaction_errors(errors=[])
@@ -191,11 +159,8 @@ _test_application_exception_404_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_application:exception_404_page', 1),
         ('Function/flask.app:Flask.handle_http_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
-
-if is_gt_flask060:
-    _test_application_exception_404_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
 
 @validate_transaction_errors(errors=[])
@@ -212,11 +177,8 @@ _test_application_not_found_scoped_metrics = [
         ('Python/WSGI/Response', 1),
         ('Python/WSGI/Finalize', 1),
         ('Function/flask.app:Flask.handle_http_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
-
-if is_gt_flask060:
-    _test_application_not_found_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
 
 @validate_transaction_errors(errors=[])
@@ -253,11 +215,8 @@ _test_application_render_template_not_found_scoped_metrics = [
         ('Python/WSGI/Finalize', 1),
         ('Function/_test_application:template_not_found', 1),
         ('Function/flask.app:Flask.handle_exception', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
-
-if is_gt_flask060:
-    _test_application_render_template_not_found_scoped_metrics.extend([
-            ('Function/flask.app:Flask.handle_user_exception', 1)])
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+        ('Function/flask.app:Flask.handle_user_exception', 1)]
 
 
 @validate_transaction_errors(errors=['jinja2.exceptions:TemplateNotFound'])

--- a/tests/framework_flask/test_application.py
+++ b/tests/framework_flask/test_application.py
@@ -20,6 +20,8 @@ from testing_support.fixtures import (validate_transaction_metrics,
 
 from newrelic.packages import six
 
+from conftest import skip_if_flask_1 as async_handler_support
+
 try:
     # The __version__ attribute was only added in 0.7.0.
     # Flask team does not use semantic versioning during development.
@@ -104,6 +106,7 @@ _test_application_async_scoped_metrics = [
         ('Function/_test_application:async_page', 1),
         ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
 
+@async_handler_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_application:async_page',
         scoped_metrics=_test_application_async_scoped_metrics)

--- a/tests/framework_flask/test_application.py
+++ b/tests/framework_flask/test_application.py
@@ -87,7 +87,6 @@ if is_dev_version or (is_gt_flask060 and flask_version >= (0, 9)):
         ('FunctionNode', []),
     )
 
-
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_application:index_page',
         scoped_metrics=_test_application_index_scoped_metrics)
@@ -97,6 +96,22 @@ def test_application_index():
     response = application.get('/index')
     response.mustcontain('INDEX RESPONSE')
 
+_test_application_async_scoped_metrics = [
+        ('Function/flask.app:Flask.wsgi_app', 1),
+        ('Python/WSGI/Application', 1),
+        ('Python/WSGI/Response', 1),
+        ('Python/WSGI/Finalize', 1),
+        ('Function/_test_application:async_page', 1),
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics('_test_application:async_page',
+        scoped_metrics=_test_application_async_scoped_metrics)
+@validate_tt_parenting(_test_application_index_tt_parenting)
+def test_application_async():
+    application = target_application()
+    response = application.get('/async')
+    response.mustcontain('ASYNC RESPONSE')
 
 _test_application_endpoint_scoped_metrics = [
         ('Function/flask.app:Flask.wsgi_app', 1),

--- a/tests/framework_flask/test_blueprints.py
+++ b/tests/framework_flask/test_blueprints.py
@@ -18,14 +18,8 @@ from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors, override_application_settings)
 
 from newrelic.packages import six
+from conftest import skip_if_flask_1 as nested_blueprints_supported
 
-from flask import __version__ as flask_version
-
-is_flask_v2 = int(flask_version.split('.')[0]) >= 2
-
-# Nested blueprints are only supported in v2 of Flask, so we skip the nested test on older versions
-nested_blueprints_supported = pytest.mark.skipif(not is_flask_v2,
-        reason="The nested blueprint mechanism is not supported.")
 
 def target_application():
     # We need to delay Flask application creation because of ordering

--- a/tests/framework_flask/test_middleware.py
+++ b/tests/framework_flask/test_middleware.py
@@ -17,24 +17,6 @@ import pytest
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors, override_application_settings)
 
-try:
-    # The __version__ attribute was only added in 0.7.0.
-    # Flask team does not use semantic versioning during development.
-    from flask import __version__ as flask_version
-    is_gt_flask080 = 'dev' in flask_version or tuple(
-            map(int, flask_version.split('.')))[:2] > (0, 8)
-except ValueError:
-    is_gt_flask080 = True
-except ImportError:
-    is_gt_flask080 = False
-
-# Technically parts of before/after support is available in older
-# versions, but just check with latest versions. The instrumentation
-# always checks for presence of required functions before patching.
-
-requires_before_after = pytest.mark.skipif(not is_gt_flask080,
-    reason="Not all before/after methods are supported.")
-
 def target_application():
     # We need to delay Flask application creation because of ordering
     # issues whereby the agent needs to be initialised before Flask is
@@ -66,7 +48,6 @@ _test_application_app_middleware_scoped_metrics = [
         ('Function/_test_middleware:teardown_appcontext', 1),
         ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
 
-@requires_before_after
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_middleware:index_page',
         scoped_metrics=_test_application_app_middleware_scoped_metrics)

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -17,6 +17,8 @@ import pytest
 from testing_support.fixtures import (validate_transaction_metrics,
     validate_transaction_errors, override_application_settings)
 
+from conftest import skip_if_flask_1 as async_view_support
+
 try:
     import flask.views
     has_view_support = True
@@ -61,7 +63,9 @@ def test_class_based_view():
     response = application.get('/view')
     response.mustcontain('VIEW RESPONSE')
 
+@pytest.mark.xfail(reason="Currently broken in flask.")
 @skip_if_no_view_support
+@async_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_async_view',
         scoped_metrics=scoped_metrics)
@@ -81,18 +85,20 @@ def test_get_method_view():
 
 @skip_if_no_view_support
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views:test_async_methodview',
-        scoped_metrics=scoped_metrics)
-def test_get_method_async_view():
-    application = target_application()
-    response = application.get('/async_methodview')
-    response.mustcontain('ASYNC METHODVIEW GET RESPONSE')
-
-@skip_if_no_view_support
-@validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_methodview',
         scoped_metrics=scoped_metrics)
 def test_post_method_view():
     application = target_application()
     response = application.post('/methodview')
     response.mustcontain('METHODVIEW POST RESPONSE')
+
+@pytest.mark.xfail(reason="Currently broken in flask.")
+@skip_if_no_view_support
+@async_view_support
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics('_test_views:test_async_methodview',
+        scoped_metrics=scoped_metrics)
+def test_get_method_async_view():
+    application = target_application()
+    response = application.get('/async_methodview')
+    response.mustcontain('ASYNC METHODVIEW GET RESPONSE')

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -26,6 +26,19 @@ except ImportError:
 skip_if_no_view_support = pytest.mark.skipif(not has_view_support,
         reason='This flask version does hot support class based views.')
 
+
+scoped_metrics = [
+        ('Function/flask.app:Flask.wsgi_app', 1),
+        ('Python/WSGI/Application', 1),
+        ('Python/WSGI/Response', 1),
+        ('Python/WSGI/Finalize', 1),
+        ('Function/flask.app:Flask.preprocess_request', 1),
+        ('Function/flask.app:Flask.process_response', 1),
+        ('Function/flask.app:Flask.do_teardown_request', 1),
+        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+]
+
+
 def target_application():
     # We need to delay Flask application creation because of ordering
     # issues whereby the agent needs to be initialised before Flask is
@@ -39,61 +52,46 @@ def target_application():
     from _test_views import _test_application
     return _test_application
 
-_test_class_based_view_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
-]
-
 @skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_view',
-        scoped_metrics=_test_class_based_view_scoped_metrics)
+        scoped_metrics=scoped_metrics)
 def test_class_based_view():
     application = target_application()
     response = application.get('/view')
     response.mustcontain('VIEW RESPONSE')
 
-_test_get_method_view_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
-]
+@skip_if_no_view_support
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics('_test_views:test_async_view',
+        scoped_metrics=scoped_metrics)
+def test_class_based_async_view():
+    application = target_application()
+    response = application.get('/async_view')
+    response.mustcontain('ASYNC VIEW RESPONSE')
 
 @skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_methodview',
-        scoped_metrics=_test_get_method_view_scoped_metrics)
+        scoped_metrics=scoped_metrics)
 def test_get_method_view():
     application = target_application()
     response = application.get('/methodview')
     response.mustcontain('METHODVIEW GET RESPONSE')
 
-_test_post_method_view_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
-]
+@skip_if_no_view_support
+@validate_transaction_errors(errors=[])
+@validate_transaction_metrics('_test_views:test_async_methodview',
+        scoped_metrics=scoped_metrics)
+def test_get_method_async_view():
+    application = target_application()
+    response = application.get('/async_methodview')
+    response.mustcontain('ASYNC METHODVIEW GET RESPONSE')
 
 @skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_methodview',
-        scoped_metrics=_test_post_method_view_scoped_metrics)
+        scoped_metrics=scoped_metrics)
 def test_post_method_view():
     application = target_application()
     response = application.post('/methodview')

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -19,15 +19,6 @@ from testing_support.fixtures import (validate_transaction_metrics,
 
 from conftest import skip_if_flask_1 as async_view_support
 
-try:
-    import flask.views
-    has_view_support = True
-except ImportError:
-    has_view_support = False
-
-skip_if_no_view_support = pytest.mark.skipif(not has_view_support,
-        reason='This flask version does hot support class based views.')
-
 
 scoped_metrics = [
         ('Function/flask.app:Flask.wsgi_app', 1),
@@ -54,7 +45,6 @@ def target_application():
     from _test_views import _test_application
     return _test_application
 
-@skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_view',
         scoped_metrics=scoped_metrics)
@@ -64,7 +54,6 @@ def test_class_based_view():
     response.mustcontain('VIEW RESPONSE')
 
 @pytest.mark.xfail(reason="Currently broken in flask.")
-@skip_if_no_view_support
 @async_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_async_view',
@@ -74,7 +63,6 @@ def test_class_based_async_view():
     response = application.get('/async_view')
     response.mustcontain('ASYNC VIEW RESPONSE')
 
-@skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_methodview',
         scoped_metrics=scoped_metrics)
@@ -83,7 +71,6 @@ def test_get_method_view():
     response = application.get('/methodview')
     response.mustcontain('METHODVIEW GET RESPONSE')
 
-@skip_if_no_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_methodview',
         scoped_metrics=scoped_metrics)
@@ -93,7 +80,6 @@ def test_post_method_view():
     response.mustcontain('METHODVIEW POST RESPONSE')
 
 @pytest.mark.xfail(reason="Currently broken in flask.")
-@skip_if_no_view_support
 @async_view_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views:test_async_methodview',

--- a/tox.ini
+++ b/tox.ini
@@ -235,7 +235,7 @@ deps =
     framework_flask-flask0101: flask<1.2
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
-    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip[async]
+    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
     framework_grpc-grpclatest: grpcio

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ envlist =
     python-framework_fastapi-{py36,py37,py38},
     python-framework_flask-{pypy,py27}-flask0012,
     python-framework_flask-{pypy,py27,py36,py37,py38,pypy3}-flask0101,
-    python-framework_flask-{py36,py37,py38,pypy3}-flaskmaster,
+    python-framework_flask-{py36,py37,py38,pypy3}-flask{latest,master},
     grpc-framework_grpc-{py27,py36}-grpc0125,
     grpc-framework_grpc-{py27,py36,py37,py38,py39}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
@@ -233,9 +233,9 @@ deps =
     framework_flask: Flask-Compress
     framework_flask-flask0012: flask<0.13
     framework_flask-flask0101: flask<1.2
-    framework_flask-flasklatest: flask
+    framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
-    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip
+    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip[async]
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
     framework_grpc-grpclatest: grpcio


### PR DESCRIPTION
# Overview
* Add testing for flask async views.
* Centralize logic for flask version skipping.

# Related Github Issue
Closes #233 

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
