### PR TITLE
Fix crash in memory metric calculations

### DIFF
--- a/newrelic/samplers/memory_usage.py
+++ b/newrelic/samplers/memory_usage.py
@@ -27,14 +27,14 @@ PID = os.getpid()
 
 @data_source_generator(name="Memory Usage")
 def memory_usage_data_source():
-    yield ("Memory/Physical", physical_memory_used())
-    yield ("Memory/Physical/%d" % (PID), physical_memory_used())
+    memory = physical_memory_used()
+    total_memory = total_physical_memory()
+    memory_utilization = (
+        (memory / total_memory) if None not in (memory, total_memory) else None
+    )
 
-    yield (
-        "Memory/Physical/Utilization",
-        physical_memory_used() / total_physical_memory(),
-    )
-    yield (
-        "Memory/Physical/Utilization/%d" % (PID),
-        physical_memory_used() / total_physical_memory(),
-    )
+    yield ("Memory/Physical", memory)
+    yield ("Memory/Physical/%d" % (PID), memory)
+
+    yield ("Memory/Physical/Utilization", memory_utilization)
+    yield ("Memory/Physical/Utilization/%d" % (PID), memory_utilization)


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Fixed: On kernels such as BSD memory metrics have values of None, causing a division crash.

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
