### PR TITLE
GraphQL Cleanup

### DIFF
--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -29,9 +29,9 @@ class GraphQLOperationTrace(TimeTrace):
             parent = kwargs['parent']
         super(GraphQLOperationTrace, self).__init__(parent)
 
-        self.operation_name = None
-        self.operation_type = None
-        self.deepest_path = None
+        self.operation_name = "<anonymous>"
+        self.operation_type = "<unknown>"
+        self.deepest_path = "<unknown>"
         self.graphql = None
         self.graphql_format = None
         self.statement = None

--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -44,7 +44,7 @@ class GraphQLOperationTrace(TimeTrace):
         if not self.statement:
             return "<unknown>"
 
-        transaction = current_transaction()
+        transaction = current_transaction(active_only=False)
 
         # Record SQL settings
         settings = transaction.settings

--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -55,9 +55,9 @@ class GraphQLOperationTrace(TimeTrace):
 
     def finalize_data(self, transaction, exc=None, value=None, tb=None):
         # Add attributes
-        self._add_agent_attribute("graphql.operation.type", self.operation_type or "<unknown>")
-        self._add_agent_attribute("graphql.operation.name", self.operation_name or "<anonymous>")
-        self._add_agent_attribute("graphql.operation.deepestPath", self.deepest_path or "<unknown>")
+        self._add_agent_attribute("graphql.operation.type", self.operation_type)
+        self._add_agent_attribute("graphql.operation.name", self.operation_name)
+        self._add_agent_attribute("graphql.operation.deepestPath", self.deepest_path)
 
         # Attach formatted graphql
         limit = transaction.settings.agent_limits.sql_query_length_maximum

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2398,11 +2398,6 @@ def _process_module_builtin_defaults():
         "instrument_graphql_execution_middleware",
     )
     _process_module_definition(
-        "graphql.execution.utils",
-        "newrelic.hooks.framework_graphql",
-        "instrument_graphql_execution_utils",
-    )
-    _process_module_definition(
         "graphql.error.located_error",
         "newrelic.hooks.framework_graphql",
         "instrument_graphql_error_located_error",

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2398,9 +2398,19 @@ def _process_module_builtin_defaults():
         "instrument_graphql_execution_middleware",
     )
     _process_module_definition(
+        "graphql.execution.utils",
+        "newrelic.hooks.framework_graphql",
+        "instrument_graphql_execution_utils",
+    )
+    _process_module_definition(
         "graphql.error.located_error",
         "newrelic.hooks.framework_graphql",
         "instrument_graphql_error_located_error",
+    )
+    _process_module_definition(
+        "graphql.language.parser",
+        "newrelic.hooks.framework_graphql",
+        "instrument_graphql_parser",
     )
     _process_module_definition(
         "graphql.validation.validate",

--- a/newrelic/core/graphql_node.py
+++ b/newrelic/core/graphql_node.py
@@ -96,9 +96,9 @@ class GraphQLResolverNode(_GraphQLResolverNode, GraphQLNodeMixin):
 class GraphQLOperationNode(_GraphQLOperationNode, GraphQLNodeMixin):
     @property
     def name(self):
-        operation_type = self.operation_type or "<unknown>"
-        operation_name = self.operation_name or "<anonymous>"
-        deepest_path = self.deepest_path or "<unknown>"
+        operation_type = self.operation_type
+        operation_name = self.operation_name
+        deepest_path = self.deepest_path
         product = self.product
 
         name = 'GraphQL/operation/%s/%s/%s/%s' % (product, operation_type,
@@ -112,9 +112,9 @@ class GraphQLOperationNode(_GraphQLOperationNode, GraphQLNodeMixin):
 
         """
 
-        operation_type = self.operation_type or "<unknown>"
-        operation_name = self.operation_name or "<anonymous>"
-        deepest_path = self.deepest_path or "<unknown>"
+        operation_type = self.operation_type
+        operation_name = self.operation_name
+        deepest_path = self.deepest_path
         product = self.product
 
         # Determine the scoped metric

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -49,7 +49,7 @@ def ignore_graphql_duplicate_exception(exc, val, tb):
             _, _, fullnames, message = parse_exc_info((None, val.original_error, None))
             fullname = fullnames[0]
             for error in transaction._errors:
-                if error.type == fullname and error.message == message:
+                if error.message == message:
                     return True
 
     return None  # Follow original exception matching rules
@@ -113,7 +113,6 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
 
     result = wrapped(*args, **kwargs)
     transaction_name = "%s/%s/%s" % (operation_type, operation_name, deepest_path)
-    #breakpoint()
     transaction.set_transaction_name(transaction_name, "GraphQL", priority=14)
 
     return result
@@ -218,7 +217,6 @@ def wrap_resolver(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     if transaction is None:
         return wrapped(*args, **kwargs)
-    #breakpoint()
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=13)
     with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
         return wrapped(*args, **kwargs)

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -109,10 +109,12 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
             deepest_path = []
         trace.deepest_path = deepest_path = ".".join(deepest_path) or "<unknown>"
 
-    transaction.set_transaction_name(callable_name(wrapped), priority=11)
+    transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=11)
 
     result = wrapped(*args, **kwargs)
     transaction_name = "%s/%s/%s" % (operation_type, operation_name, deepest_path)
+    #breakpoint()
+    transaction.set_transaction_name(transaction_name, "GraphQL", priority=14)
 
     return result
 
@@ -169,7 +171,7 @@ def wrap_middleware(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = callable_name(wrapped)
-    transaction.set_transaction_name(name, priority=12)
+    transaction.set_transaction_name(name, 'GraphQL', priority=12)
     with FunctionTrace(name):
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             return wrapped(*args, **kwargs)
@@ -217,7 +219,7 @@ def wrap_resolver(wrapped, instance, args, kwargs):
     if transaction is None:
         return wrapped(*args, **kwargs)
 
-    transaction.set_transaction_name(callable_name(wrapped), priority=13)
+    transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=13)
     with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
         return wrapped(*args, **kwargs)
 
@@ -232,7 +234,7 @@ def wrap_validate(wrapped, instance, args, kwargs):
     if transaction is None:
         return wrapped(*args, **kwargs)
 
-    transaction.set_transaction_name(callable_name(wrapped), priority=10)
+    transaction.set_transaction_name(callable_name(wrapped),"GraphQL", priority=10)
 
     # Run and collect errors
     errors = wrapped(*args, **kwargs)
@@ -250,8 +252,8 @@ def wrap_parse(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     if transaction is None:
         return wrapped(*args, **kwargs)
-
-    transaction.set_transaction_name(callable_name(wrapped), priority=10)
+    #breakpoint()
+    transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
         return wrapped(*args, **kwargs)
@@ -328,13 +330,13 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
     if hasattr(query, "body"):
         query = query.body
 
-    transaction.set_transaction_name(callable_name(wrapped), priority=10)
+    transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with GraphQLOperationTrace() as trace:
         trace.statement = graphql_statement(query)
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             result = wrapped(*args, **kwargs)
-            # transaction.set_transaction_name(transaction_name, "GraphQL", priority=14)
+            #transaction.set_transaction_name(transaction_name, "GraphQL", priority=14)
             return result
 
 

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -218,7 +218,7 @@ def wrap_resolver(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     if transaction is None:
         return wrapped(*args, **kwargs)
-
+    #breakpoint()
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=13)
     with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
         return wrapped(*args, **kwargs)
@@ -252,7 +252,6 @@ def wrap_parse(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     if transaction is None:
         return wrapped(*args, **kwargs)
-    #breakpoint()
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with ErrorTrace(ignore=ignore_graphql_duplicate_exception):

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -51,17 +51,6 @@ def ignore_graphql_duplicate_exception(exc, val, tb):
     return None  # Follow original exception matching rules
 
 
-# def wrap_execute(wrapped, instance, args, kwargs):
-#     transaction = current_transaction()
-#     if transaction is None:
-#         return wrapped(*args, **kwargs)
-    
-#     transaction.set_transaction_name(callable_name(wrapped), priority=1)
-#     with GraphQLOperationTrace():
-#         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
-#             return wrapped(*args, **kwargs)
-
-
 def bind_operation_v3(operation, root_value):
     return operation
 
@@ -187,7 +176,7 @@ def wrap_resolve_field(wrapped, instance, args, kwargs):
     field_name = field_asts[0].name.value
 
     with GraphQLResolverTrace(field_name) as trace:
-        with ErrorTrace():
+        with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             trace._add_agent_attribute("graphql.field.parentType", parent_type.name)
             if isinstance(field_path, list):
                 trace._add_agent_attribute("graphql.field.path", field_path[0])
@@ -242,8 +231,6 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
 
 
 def instrument_graphql_execute(module):
-    # if hasattr(module, "execute"):
-    #     wrap_function_wrapper(module, "execute", wrap_execute)
     if hasattr(module, "ExecutionContext"):
         if hasattr(module.ExecutionContext, "resolve_field"):
             wrap_function_wrapper(

--- a/tests/framework_graphql/_target_application.py
+++ b/tests/framework_graphql/_target_application.py
@@ -25,10 +25,11 @@ from graphql import (
 
 libraries = [
     {
+        "id": 1,
         "name": "NYC Public Library",
-        "book": [{"name": "A", "author": "B"}, {"name": "C", "author": "D"}],
+        "book": [{"name": "A", "author": "B", "id": 1}, {"name": "C", "author": "D", "id": 2}],
     },
-    {"name": "Portland Public Library", "book": [{"name": "E", "author": "F"}]},
+    {"id": 2, "name": "Portland Public Library", "book": [{"name": "E", "author": "F", "id": 1}]},
 ]
 
 storage = []
@@ -48,6 +49,7 @@ def resolve_storage(parent, info):
 Book = GraphQLObjectType(
     "Book",
     {
+        "id": GraphQLField(GraphQLInt),
         "name": GraphQLField(GraphQLString),
         "author": GraphQLField(GraphQLString),
     },
@@ -56,6 +58,7 @@ Book = GraphQLObjectType(
 Library = GraphQLObjectType(
     "Library",
     {
+        "id": GraphQLField(GraphQLInt),
         "name": GraphQLField(GraphQLString),
         "book": GraphQLField(GraphQLList(Book)),
     },

--- a/tests/framework_graphql/conftest.py
+++ b/tests/framework_graphql/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import six
 from testing_support.fixtures import (
     code_coverage_fixture,
     collector_agent_registration_fixture,
@@ -44,3 +45,9 @@ def app():
     from _target_application import _target_application
 
     return _target_application
+
+
+if six.PY2:
+    collect_ignore = [
+        'test_application_async.py'
+    ]

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import pytest
 from testing_support.fixtures import (
     dt_enabled,
@@ -43,6 +44,19 @@ def graphql_run():
         from graphql import graphql
 
     return graphql
+
+
+@pytest.fixture(scope="session")
+def graphql_run_async():
+    from graphql import graphql, __version__ as version
+
+    major_version = int(version.split(".")[0])
+    if major_version == 2:
+        def graphql_run(*args, **kwargs):
+            return graphql(*args, return_promise=True, **kwargs)
+        return graphql_run
+    else:
+        return graphql
 
 
 def to_graphql_source(query):
@@ -148,6 +162,77 @@ def test_basic(app, graphql_run):
         assert "storage" in str(response.data)
         assert "abc" in str(response.data)
     _test()
+
+
+@dt_enabled
+def test_basic_async(app, graphql_run_async):
+    from graphql import __version__ as version
+    
+    FRAMEWORK_METRICS = [
+        ('Python/Framework/GraphQL/%s' % version, 1),
+    ]
+    _test_mutation_scoped_metrics = [
+        ("GraphQL/resolve/GraphQL/storage", 1),
+        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
+    ]
+    _test_mutation_unscoped_metrics = [
+        ("OtherTransaction/all", 1),
+        ("GraphQL/all", 2),
+        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/allOther", 2),
+        ("GraphQL/GraphQL/allOther", 2),
+    ] + _test_mutation_scoped_metrics
+
+    _expected_mutation_operation_attributes = {
+        "graphql.operation.type": "mutation",
+        "graphql.operation.name": "<anonymous>",
+        "graphql.operation.deepestPath": "storage_add",
+    }
+    _expected_mutation_resolver_attributes = {
+        "graphql.field.name": "storage_add",
+        "graphql.field.parentType": "Mutation",
+        "graphql.field.path": "storage_add",
+    }
+    _expected_query_operation_attributes = {
+        "graphql.operation.type": "query",
+        "graphql.operation.name": "<anonymous>",
+        "graphql.operation.deepestPath": "storage",
+    }
+    _expected_query_resolver_attributes = {
+        "graphql.field.name": "storage",
+        "graphql.field.parentType": "Query",
+        "graphql.field.path": "storage",
+    }
+    @validate_transaction_metrics(
+        "query/<anonymous>/storage",
+        "GraphQL",
+        scoped_metrics=_test_mutation_scoped_metrics,
+        rollup_metrics=_test_mutation_unscoped_metrics + FRAMEWORK_METRICS,
+        background_task=True,
+    )
+    @validate_span_events(exact_agents=_expected_mutation_operation_attributes)
+    @validate_span_events(exact_agents=_expected_mutation_resolver_attributes)
+    @validate_span_events(exact_agents=_expected_query_operation_attributes)
+    @validate_span_events(exact_agents=_expected_query_resolver_attributes)
+    @background_task()
+    def _test():
+        async def coro():
+            response = await graphql_run_async(app, 'mutation { storage_add(string: "abc") }')
+            assert not response.errors
+            response = await graphql_run_async(app, "query { storage }")
+            assert not response.errors
+
+            # These are separate assertions because pypy stores 'abc' as a unicode string while other Python versions do not
+            assert "storage" in str(response.data)
+            assert "abc" in str(response.data)
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(coro())
+
+    _test()
+
 
 
 @dt_enabled

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -116,7 +116,7 @@ def test_basic(app, graphql_run):
         "graphql.field.path": "storage",
     }
     @validate_transaction_metrics(
-        "query/MyQuery/hello",
+        "query/<anonymous>/storage",
         "GraphQL",
         scoped_metrics=_test_mutation_scoped_metrics,
         rollup_metrics=_test_mutation_unscoped_metrics + FRAMEWORK_METRICS,

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import pytest
 from testing_support.fixtures import (
     dt_enabled,
@@ -44,19 +43,6 @@ def graphql_run():
         from graphql import graphql
 
     return graphql
-
-
-@pytest.fixture(scope="session")
-def graphql_run_async():
-    from graphql import graphql, __version__ as version
-
-    major_version = int(version.split(".")[0])
-    if major_version == 2:
-        def graphql_run(*args, **kwargs):
-            return graphql(*args, return_promise=True, **kwargs)
-        return graphql_run
-    else:
-        return graphql
 
 
 def to_graphql_source(query):
@@ -162,77 +148,6 @@ def test_basic(app, graphql_run):
         assert "storage" in str(response.data)
         assert "abc" in str(response.data)
     _test()
-
-
-@dt_enabled
-def test_basic_async(app, graphql_run_async):
-    from graphql import __version__ as version
-    
-    FRAMEWORK_METRICS = [
-        ('Python/Framework/GraphQL/%s' % version, 1),
-    ]
-    _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
-    ]
-    _test_mutation_unscoped_metrics = [
-        ("OtherTransaction/all", 1),
-        ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
-        ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
-    ] + _test_mutation_scoped_metrics
-
-    _expected_mutation_operation_attributes = {
-        "graphql.operation.type": "mutation",
-        "graphql.operation.name": "<anonymous>",
-        "graphql.operation.deepestPath": "storage_add",
-    }
-    _expected_mutation_resolver_attributes = {
-        "graphql.field.name": "storage_add",
-        "graphql.field.parentType": "Mutation",
-        "graphql.field.path": "storage_add",
-    }
-    _expected_query_operation_attributes = {
-        "graphql.operation.type": "query",
-        "graphql.operation.name": "<anonymous>",
-        "graphql.operation.deepestPath": "storage",
-    }
-    _expected_query_resolver_attributes = {
-        "graphql.field.name": "storage",
-        "graphql.field.parentType": "Query",
-        "graphql.field.path": "storage",
-    }
-    @validate_transaction_metrics(
-        "query/<anonymous>/storage",
-        "GraphQL",
-        scoped_metrics=_test_mutation_scoped_metrics,
-        rollup_metrics=_test_mutation_unscoped_metrics + FRAMEWORK_METRICS,
-        background_task=True,
-    )
-    @validate_span_events(exact_agents=_expected_mutation_operation_attributes)
-    @validate_span_events(exact_agents=_expected_mutation_resolver_attributes)
-    @validate_span_events(exact_agents=_expected_query_operation_attributes)
-    @validate_span_events(exact_agents=_expected_query_resolver_attributes)
-    @background_task()
-    def _test():
-        async def coro():
-            response = await graphql_run_async(app, 'mutation { storage_add(string: "abc") }')
-            assert not response.errors
-            response = await graphql_run_async(app, "query { storage }")
-            assert not response.errors
-
-            # These are separate assertions because pypy stores 'abc' as a unicode string while other Python versions do not
-            assert "storage" in str(response.data)
-            assert "abc" in str(response.data)
-
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(coro())
-
-    _test()
-
 
 
 @dt_enabled

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -274,7 +274,7 @@ def test_exception_in_middleware(app, graphql_run):
     _test_exception_rollup_metrics = [
         ('Errors/all', 1),
         ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/Function/test_application:error_middleware', 1),
+        ('Errors/OtherTransaction/GraphQL/query/MyQuery/%s' % field, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -291,7 +291,8 @@ def test_exception_in_middleware(app, graphql_run):
     }
 
     @validate_transaction_metrics(
-        "test_application:error_middleware",
+        "query/MyQuery/hello",
+        "GraphQL",
         scoped_metrics=_test_exception_scoped_metrics,
         rollup_metrics=_test_exception_rollup_metrics + _graphql_base_rollup_metrics,
         background_task=True,
@@ -320,7 +321,7 @@ def test_exception_in_resolver(app, graphql_run, field):
     _test_exception_rollup_metrics = [
         ('Errors/all', 1),
         ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/Function/_target_application:resolve_error', 1),
+        ('Errors/OtherTransaction/GraphQL/query/MyQuery/%s' % field, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -337,7 +338,8 @@ def test_exception_in_resolver(app, graphql_run, field):
     }
 
     @validate_transaction_metrics(
-        "_target_application:resolve_error",
+        "query/MyQuery/%s" % field,
+        "GraphQL",
         scoped_metrics=_test_exception_scoped_metrics,
         rollup_metrics=_test_exception_rollup_metrics + _graphql_base_rollup_metrics,
         background_task=True,
@@ -373,16 +375,14 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
         exc_class = callable_name(GraphQLError)
 
     # Metrics
-    # _test_exception_scoped_metrics = [
-    #     ('GraphQL/operation/GraphQL/query/MyQuery/missing_field', 1),
-    #     ('GraphQL/resolve/GraphQL/missing_field', 1),
-    # ]
+    # We don't expect field resolver metrics in this case if there was an error validating the query
     _test_exception_scoped_metrics = [
-    ]
+         ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+     ]
     _test_exception_rollup_metrics = [
         ('Errors/all', 1),
         ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/Function/%s' % txn_name, 1),
+        ('Errors/OtherTransaction/GraphQL/%s' % txn_name, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -395,6 +395,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
 
     @validate_transaction_metrics(
         txn_name,
+        "GraphQL",
         scoped_metrics=_test_exception_scoped_metrics,
         rollup_metrics=_test_exception_rollup_metrics + _graphql_base_rollup_metrics,
         background_task=True,

--- a/tests/framework_graphql/test_application_async.py
+++ b/tests/framework_graphql/test_application_async.py
@@ -1,0 +1,90 @@
+import asyncio
+import pytest
+from testing_support.fixtures import (
+    dt_enabled,
+    validate_transaction_errors,
+    validate_transaction_metrics,
+)
+from testing_support.validators.validate_span_events import validate_span_events
+from newrelic.api.background_task import background_task
+
+@pytest.fixture(scope="session")
+def graphql_run_async():
+    from graphql import graphql, __version__ as version
+
+    major_version = int(version.split(".")[0])
+    if major_version == 2:
+        def graphql_run(*args, **kwargs):
+            return graphql(*args, return_promise=True, **kwargs)
+        return graphql_run
+    else:
+        return graphql
+
+@dt_enabled
+def test_basic_async(app, graphql_run_async):
+    from graphql import __version__ as version
+
+    FRAMEWORK_METRICS = [
+        ('Python/Framework/GraphQL/%s' % version, 1),
+    ]
+    _test_mutation_scoped_metrics = [
+        ("GraphQL/resolve/GraphQL/storage", 1),
+        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
+    ]
+    _test_mutation_unscoped_metrics = [
+        ("OtherTransaction/all", 1),
+        ("GraphQL/all", 2),
+        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/allOther", 2),
+        ("GraphQL/GraphQL/allOther", 2),
+    ] + _test_mutation_scoped_metrics
+
+    _expected_mutation_operation_attributes = {
+        "graphql.operation.type": "mutation",
+        "graphql.operation.name": "<anonymous>",
+        "graphql.operation.deepestPath": "storage_add",
+    }
+    _expected_mutation_resolver_attributes = {
+        "graphql.field.name": "storage_add",
+        "graphql.field.parentType": "Mutation",
+        "graphql.field.path": "storage_add",
+    }
+    _expected_query_operation_attributes = {
+        "graphql.operation.type": "query",
+        "graphql.operation.name": "<anonymous>",
+        "graphql.operation.deepestPath": "storage",
+    }
+    _expected_query_resolver_attributes = {
+        "graphql.field.name": "storage",
+        "graphql.field.parentType": "Query",
+        "graphql.field.path": "storage",
+    }
+    @validate_transaction_metrics(
+        "query/<anonymous>/storage",
+        "GraphQL",
+        scoped_metrics=_test_mutation_scoped_metrics,
+        rollup_metrics=_test_mutation_unscoped_metrics + FRAMEWORK_METRICS,
+        background_task=True,
+    )
+    @validate_span_events(exact_agents=_expected_mutation_operation_attributes)
+    @validate_span_events(exact_agents=_expected_mutation_resolver_attributes)
+    @validate_span_events(exact_agents=_expected_query_operation_attributes)
+    @validate_span_events(exact_agents=_expected_query_resolver_attributes)
+    @background_task()
+    def _test():
+        async def coro():
+            response = await graphql_run_async(app, 'mutation { storage_add(string: "abc") }')
+            assert not response.errors
+            response = await graphql_run_async(app, "query { storage }")
+            assert not response.errors
+
+            # These are separate assertions because pypy stores 'abc' as a unicode string while other Python versions do not
+            assert "storage" in str(response.data)
+            assert "abc" in str(response.data)
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(coro())
+
+    _test()

--- a/tox.ini
+++ b/tox.ini
@@ -240,7 +240,6 @@ deps =
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
     framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]
-    framework_graphql: asyncio
     framework_graphql-graphql02: graphql-core<3
     framework_graphql-graphql03: graphql-core<4
     framework_graphql-graphql0201: graphql-core<2.2

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ envlist =
     python-framework_flask-{py37,py38,pypy3}-flask{latest,master},
     python-framework_graphql-{py27,py36,py37,py38,pypy,pypy3}-graphql02,
     python-framework_graphql-{py36,py37,py38,py39,pypy3}-graphql{03,master},
-    python-framework_graphql-py37-graphql{0201,0202,0203,0300,0301,master},
+    python-framework_graphql-py37-graphql{0202,0203,0300,0301,master},
     grpc-framework_grpc-{py27,py36}-grpc0125,
     grpc-framework_grpc-{py27,py36,py37,py38,py39}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,

--- a/tox.ini
+++ b/tox.ini
@@ -242,7 +242,6 @@ deps =
     framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]
     framework_graphql-graphql02: graphql-core<3
     framework_graphql-graphql03: graphql-core<4
-    framework_graphql-graphql0201: graphql-core<2.2
     framework_graphql-graphql0202: graphql-core<2.3
     framework_graphql-graphql0203: graphql-core<2.4
     framework_graphql-graphql0300: graphql-core<3.1

--- a/tox.ini
+++ b/tox.ini
@@ -240,6 +240,7 @@ deps =
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
     framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]
+    framework_graphql: asyncio
     framework_graphql-graphql02: graphql-core<3
     framework_graphql-graphql03: graphql-core<4
     framework_graphql-graphql0201: graphql-core<2.2


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Remove unused instrumentation
* Clean up testing to be more thorough and remove duplicates
* Add ignored and introspection fields to deepest path traversal
* Set transaction name according to spec
* Moves async testing to a separate test file
* Removes graphql 2.1.0 from test matrix based on three year support policy

# Related Github Issue
Closes #280 
Closes #265

