### PR TITLE
GraphQL Fragment Spread Logic

### DIFF
--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -30,6 +30,7 @@ GRAPHQL_INTROSPECTION_FIELDS = frozenset(("__schema", "__type"))
 
 def graphql_version():
     from graphql import __version__ as version
+
     return tuple(int(v) for v in version.split("."))
 
 
@@ -106,15 +107,21 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
                 ignore_transaction()
 
         if graphql_version() <= (3, 0, 0):
-            fragments = args[0].fragments # In v2, args[0] is the ExecutionContext object
+            fragments = args[
+                0
+            ].fragments  # In v2, args[0] is the ExecutionContext object
         else:
-            fragments = instance.fragments # instance is the ExecutionContext object
+            fragments = instance.fragments  # instance is the ExecutionContext object
         deepest_path = traverse_deepest_unique_path(fields, fragments)
         trace.deepest_path = deepest_path = ".".join(deepest_path) or ""
 
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=11)
     result = wrapped(*args, **kwargs)
-    transaction_name = "%s/%s/%s" % (operation_type, operation_name, deepest_path) if deepest_path else "%s/%s" % (operation_type, operation_name)
+    transaction_name = (
+        "%s/%s/%s" % (operation_type, operation_name, deepest_path)
+        if deepest_path
+        else "%s/%s" % (operation_type, operation_name)
+    )
     transaction.set_transaction_name(transaction_name, "GraphQL", priority=14)
 
     return result
@@ -125,6 +132,7 @@ def get_node_value(field, attr, subattr="value"):
     if hasattr(field_name, subattr):
         field_name = getattr(field_name, subattr)
     return field_name
+
 
 def is_fragment_spread_node(field):
     # Resolve version specific imports
@@ -141,7 +149,10 @@ def is_fragment(field):
     try:
         from graphql.language.ast import FragmentSpread, InlineFragment
     except ImportError:
-        from graphql import FragmentSpreadNode as FragmentSpread, InlineFragmentNode as InlineFragment
+        from graphql import (
+            FragmentSpreadNode as FragmentSpread,
+            InlineFragmentNode as InlineFragment,
+        )
 
     _fragment_types = (InlineFragment, FragmentSpread)
 
@@ -155,11 +166,17 @@ def is_named_fragment(field):
     except ImportError:
         from graphql import NamedTypeNode as NamedType
 
-    return is_fragment(field) and getattr(field, "type_condition", None) is not None and isinstance(field.type_condition, NamedType)
+    return (
+        is_fragment(field)
+        and getattr(field, "type_condition", None) is not None
+        and isinstance(field.type_condition, NamedType)
+    )
 
 
 def filter_ignored_fields(fields):
-    filtered_fields = [f for f in fields if get_node_value(f, "name") not in GRAPHQL_IGNORED_FIELDS]
+    filtered_fields = [
+        f for f in fields if get_node_value(f, "name") not in GRAPHQL_IGNORED_FIELDS
+    ]
     return filtered_fields
 
 
@@ -177,16 +194,18 @@ def traverse_deepest_unique_path(fields, fragments):
             name = get_node_value(field.type_condition, "name")
             if name:
                 deepest_path.append("%s<%s>" % (deepest_path.pop(), name))
-        
+
         elif is_fragment(field):
             if len(list(fragments.values())) != 1:
                 return deepest_path
-            
+
             # list(fragments.values())[0] 's index is OK because the previous line
             # ensures that there is only one field in the list
-            full_fragment_selection_set = list(fragments.values())[0].selection_set.selections
+            full_fragment_selection_set = list(fragments.values())[
+                0
+            ].selection_set.selections
             fragment_selection_set = filter_ignored_fields(full_fragment_selection_set)
-            
+
             if len(fragment_selection_set) != 1:
                 return deepest_path
             else:
@@ -197,15 +216,12 @@ def traverse_deepest_unique_path(fields, fragments):
             if field_name:
                 deepest_path.append(field_name)
 
-
         if is_fragment_spread_node(field):
-            field = fragment_selection_set[0]        
+            field = fragment_selection_set[0]
         if field.selection_set is None:
             break
         else:
             fields = field.selection_set.selections
-
-
 
     return deepest_path
 
@@ -216,7 +232,9 @@ def bind_get_middleware_resolvers(middlewares):
 
 def wrap_get_middleware_resolvers(wrapped, instance, args, kwargs):
     middlewares = bind_get_middleware_resolvers(*args, **kwargs)
-    middlewares = [wrap_middleware(m) if not hasattr(m, "_nr_wrapped") else m for m in middlewares]
+    middlewares = [
+        wrap_middleware(m) if not hasattr(m, "_nr_wrapped") else m for m in middlewares
+    ]
     for m in middlewares:
         m._nr_wrapped = True
 
@@ -230,7 +248,7 @@ def wrap_middleware(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     name = callable_name(wrapped)
-    transaction.set_transaction_name(name, 'GraphQL', priority=12)
+    transaction.set_transaction_name(name, "GraphQL", priority=12)
     with FunctionTrace(name):
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             return wrapped(*args, **kwargs)
@@ -293,7 +311,7 @@ def wrap_validate(wrapped, instance, args, kwargs):
     if transaction is None:
         return wrapped(*args, **kwargs)
 
-    transaction.set_transaction_name(callable_name(wrapped),"GraphQL", priority=10)
+    transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     # Run and collect errors
     errors = wrapped(*args, **kwargs)
@@ -322,7 +340,9 @@ def bind_resolve_field_v3(parent_type, source, field_nodes, path):
     return parent_type, field_nodes, path
 
 
-def bind_resolve_field_v2(exe_context, parent_type, source, field_asts, parent_info, field_path):
+def bind_resolve_field_v2(
+    exe_context, parent_type, source, field_asts, parent_info, field_path
+):
     return parent_type, field_asts, field_path
 
 
@@ -364,7 +384,8 @@ def bind_execute_graphql_query(
     operation_name=None,
     middleware=None,
     backend=None,
-    **execute_options):
+    **execute_options
+):
 
     return request_string
 
@@ -376,9 +397,9 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     version = graphql_version()
-    framework_version = '.'.join(map(str, version))
+    framework_version = ".".join(map(str, version))
 
-    transaction.add_framework_info(name='GraphQL', version=framework_version)
+    transaction.add_framework_info(name="GraphQL", version=framework_version)
 
     if graphql_version() <= (3, 0, 0):
         bind_query = bind_execute_graphql_query
@@ -419,9 +440,7 @@ def instrument_graphql_execute(module):
         wrap_function_wrapper(module, "resolve_field", wrap_resolve_field)
 
     if hasattr(module, "execute_operation"):
-        wrap_function_wrapper(
-            module, "execute_operation", wrap_execute_operation
-        )
+        wrap_function_wrapper(module, "execute_operation", wrap_execute_operation)
 
 
 def instrument_graphql_execution_utils(module):

--- a/tests/framework_graphql/_target_application.py
+++ b/tests/framework_graphql/_target_application.py
@@ -42,56 +42,44 @@ authors = [
 books = [
     {
         "id": 1,
-        "name": 'Python Agent: The Book',
-        "isbn": 'a-fake-isbn',
+        "name": "Python Agent: The Book",
+        "isbn": "a-fake-isbn",
         "author": authors[0],
-        "branch": 'riverside'
+        "branch": "riverside",
     },
     {
         "id": 2,
-        "name": 'Ollies for O11y: A Sk8er\'s Guide to Observability',
-        "isbn": 'a-second-fake-isbn',
+        "name": "Ollies for O11y: A Sk8er's Guide to Observability",
+        "isbn": "a-second-fake-isbn",
         "author": authors[1],
-        "branch": 'downtown'
+        "branch": "downtown",
     },
     {
         "id": 3,
-        "name": '[Redacted]',
-        "isbn": 'a-third-fake-isbn',
+        "name": "[Redacted]",
+        "isbn": "a-third-fake-isbn",
         "author": authors[2],
-        "branch": 'riverside'
+        "branch": "riverside",
     },
 ]
 
 magazines = [
-    {
-        "id": 1,
-        "name": 'Reli Updates Weekly',
-        "issue": 1,
-        "branch": 'riverside'
-    },
-    {
-        "id": 2,
-        "name": 'Reli Updates Weekly',
-        "issue": 2,
-        "branch": 'downtown'
-    },
-    {
-        "id": 3,
-        "name": 'Node Weekly',
-        "issue": 1,
-        "branch": 'riverside'
-    },
+    {"id": 1, "name": "Reli Updates Weekly", "issue": 1, "branch": "riverside"},
+    {"id": 2, "name": "Reli Updates Weekly", "issue": 2, "branch": "downtown"},
+    {"id": 3, "name": "Node Weekly", "issue": 1, "branch": "riverside"},
 ]
 
 
-libraries = ['riverside', 'downtown']
-libraries = [{
-    "id": i + 1,
-    "branch": branch,
-    "magazine": [m for m in magazines if m["branch"] == branch],
-    "book": [b for b in books if b["branch"] == branch],
-} for i, branch in enumerate(libraries)]
+libraries = ["riverside", "downtown"]
+libraries = [
+    {
+        "id": i + 1,
+        "branch": branch,
+        "magazine": [m for m in magazines if m["branch"] == branch],
+        "book": [b for b in books if b["branch"] == branch],
+    }
+    for i, branch in enumerate(libraries)
+]
 
 storage = []
 
@@ -99,24 +87,28 @@ storage = []
 def resolve_library(parent, info, index):
     return libraries[index]
 
+
 def resolve_storage_add(parent, info, string):
     storage.append(string)
     return string
 
+
 def resolve_storage(parent, info):
     return storage
+
 
 def resolve_search(parent, info, contains):
     search_books = [b for b in books if contains in b["name"]]
     search_magazines = [m for m in magazines if contains in m["name"]]
     return search_books + search_magazines
 
+
 Author = GraphQLObjectType(
     "Author",
     {
-        "first_name": GraphQLField(GraphQLString), 
+        "first_name": GraphQLField(GraphQLString),
         "last_name": GraphQLField(GraphQLString),
-    }, 
+    },
 )
 
 Book = GraphQLObjectType(
@@ -174,7 +166,9 @@ try:
         args={"index": GraphQLArgument(GraphQLNonNull(GraphQLInt))},
     )
     search_field = GraphQLField(
-        GraphQLList(GraphQLUnionType("Item", (Book, Magazine), resolve_type=resolve_search)),
+        GraphQLList(
+            GraphQLUnionType("Item", (Book, Magazine), resolve_type=resolve_search)
+        ),
         args={"contains": GraphQLArgument(GraphQLNonNull(GraphQLString))},
     )
     echo_field = GraphQLField(
@@ -203,7 +197,9 @@ except TypeError:
         args={"index": GraphQLArgument(GraphQLNonNull(GraphQLInt))},
     )
     search_field = GraphQLField(
-        GraphQLList(GraphQLUnionType("Item", (Book, Magazine), resolve_type=resolve_search)),
+        GraphQLList(
+            GraphQLUnionType("Item", (Book, Magazine), resolve_type=resolve_search)
+        ),
         args={"contains": GraphQLArgument(GraphQLNonNull(GraphQLString))},
     )
     echo_field = GraphQLField(

--- a/tests/framework_graphql/_target_application.py
+++ b/tests/framework_graphql/_target_application.py
@@ -24,27 +24,41 @@ from graphql import (
     GraphQLUnionType,
 )
 
+authors = [
+    {
+        "first_name": "New",
+        "last_name": "Relic",
+    },
+    {
+        "first_name": "Bob",
+        "last_name": "Smith",
+    },
+    {
+        "first_name": "Leslie",
+        "last_name": "Jones",
+    },
+]
 
 books = [
     {
         "id": 1,
         "name": 'Python Agent: The Book',
         "isbn": 'a-fake-isbn',
-        "author": 'Sentient Bits',
+        "author": authors[0],
         "branch": 'riverside'
     },
     {
         "id": 2,
         "name": 'Ollies for O11y: A Sk8er\'s Guide to Observability',
         "isbn": 'a-second-fake-isbn',
-        "author": 'Faux Hawk',
+        "author": authors[1],
         "branch": 'downtown'
     },
     {
         "id": 3,
         "name": '[Redacted]',
         "isbn": 'a-third-fake-isbn',
-        "author": 'Closed Telemetry',
+        "author": authors[2],
         "branch": 'riverside'
     },
 ]
@@ -97,6 +111,13 @@ def resolve_search(parent, info, contains):
     search_magazines = [m for m in magazines if contains in m["name"]]
     return search_books + search_magazines
 
+Author = GraphQLObjectType(
+    "Author",
+    {
+        "first_name": GraphQLField(GraphQLString), 
+        "last_name": GraphQLField(GraphQLString),
+    }, 
+)
 
 Book = GraphQLObjectType(
     "Book",
@@ -104,7 +125,7 @@ Book = GraphQLObjectType(
         "id": GraphQLField(GraphQLInt),
         "name": GraphQLField(GraphQLString),
         "isbn": GraphQLField(GraphQLString),
-        "author": GraphQLField(GraphQLString),
+        "author": GraphQLField(GraphQLList(Author)),
         "branch": GraphQLField(GraphQLString),
     },
 )
@@ -126,7 +147,7 @@ Library = GraphQLObjectType(
         "id": GraphQLField(GraphQLInt),
         "name": GraphQLField(GraphQLString),
         "book": GraphQLField(GraphQLList(Book)),
-        "magazine": GraphQLField(GraphQLList(Book)),
+        "magazine": GraphQLField(GraphQLList(Magazine)),
     },
 )
 

--- a/tests/framework_graphql/conftest.py
+++ b/tests/framework_graphql/conftest.py
@@ -48,6 +48,4 @@ def app():
 
 
 if six.PY2:
-    collect_ignore = [
-        'test_application_async.py'
-    ]
+    collect_ignore = ["test_application_async.py"]

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -417,18 +417,25 @@ _test_queries = [
     ("{ hello }", "/hello"),  # Basic query
     ("{ error }", "/error"),  # Extract deepest path on field error
     ('{ echo(echo: "test") }', "/echo"),  # Fields with arguments
-    ("{ library(index: 0) { name, book { name, author } } }", "/library"),  # Complex Example, 1 level
-    ("{ library(index: 0) { book { name, author } } }", "/library.book"),  # Complex Example, 2 levels
+    ("{ library(index: 0) { name, book { isbn branch } } }", "/library"),  # Complex Example, 1 level
+    ("{ library(index: 0) { book { author { first_name }} } }", "/library.book.author.first_name"),  # Complex Example, 2 levels
     ("{ library(index: 0) { id, book { name } } }", "/library.book.name"),  # Filtering
     ('{ TestEcho: echo(echo: "test") }', "/echo"),  # Aliases
     ('{ search(contains: "A") { __typename ... on Book { name } } }', "/search<Book>.name"),  # InlineFragment
-
-    # Currently incorrect behavior
     ('{ hello echo(echo: "test") }', ""),  # Multiple root selections. (need to decide on final behavior)
-    #(  # FragmentSpread
-    #   '{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { name }',
-    #    "/library.book",  # Should be library.book.name
-    #),
+    # FragmentSpread
+    (
+       '{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { name id }', # Fragment filtering
+        "/library.book.name",
+    ),
+    (
+       '{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { author { first_name } }',
+        "/library.book.author.first_name",
+    ),
+    (
+       '{ library(index: 0) { book { ...MyFragment } magazine { ...MagFragment } } } fragment MyFragment on Book { author { first_name } } fragment MagFragment on Magazine { name }',
+        "/library",
+    ),
 ]
 
 

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -88,9 +88,9 @@ _graphql_base_rollup_metrics = [
 @dt_enabled
 def test_basic(app, graphql_run):
     from graphql import __version__ as version
-    
+
     FRAMEWORK_METRICS = [
-        ('Python/Framework/GraphQL/%s' % version, 1),
+        ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
@@ -124,6 +124,7 @@ def test_basic(app, graphql_run):
         "graphql.field.parentType": "Query",
         "graphql.field.path": "storage",
     }
+
     @validate_transaction_metrics(
         "query/<anonymous>/storage",
         "GraphQL",
@@ -145,6 +146,7 @@ def test_basic(app, graphql_run):
         # These are separate assertions because pypy stores 'abc' as a unicode string while other Python versions do not
         assert "storage" in str(response.data)
         assert "abc" in str(response.data)
+
     _test()
 
 
@@ -178,16 +180,16 @@ def test_middleware(app, graphql_run, is_graphql_2):
 def test_exception_in_middleware(app, graphql_run):
     query = "query MyQuery { hello }"
     field = "hello"
-    
+
     # Metrics
     _test_exception_scoped_metrics = [
-        ('GraphQL/operation/GraphQL/query/MyQuery/%s' % field, 1),
-        ('GraphQL/resolve/GraphQL/%s' % field, 1),
+        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
-        ('Errors/all', 1),
-        ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/GraphQL/query/MyQuery/%s' % field, 1),
+        ("Errors/all", 1),
+        ("Errors/allOther", 1),
+        ("Errors/OtherTransaction/GraphQL/query/MyQuery/%s" % field, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -229,16 +231,16 @@ def test_exception_in_resolver(app, graphql_run, is_graphql_2, field):
         txn_name = "_target_application:resolve_error"
     else:
         txn_name = "query/MyQuery/%s" % field
-    
+
     # Metrics
     _test_exception_scoped_metrics = [
-        ('GraphQL/operation/GraphQL/query/MyQuery/%s' % field, 1),
-        ('GraphQL/resolve/GraphQL/%s' % field, 1),
+        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
-        ('Errors/all', 1),
-        ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/GraphQL/%s' % txn_name, 1),
+        ("Errors/all", 1),
+        ("Errors/allOther", 1),
+        ("Errors/OtherTransaction/GraphQL/%s" % txn_name, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -272,10 +274,13 @@ def test_exception_in_resolver(app, graphql_run, is_graphql_2, field):
 
 
 @dt_enabled
-@pytest.mark.parametrize("query,exc_class", [
-    ("query MyQuery { missing_field }", "GraphQLError"),
-    ("{ syntax_error ", "graphql.error.syntax_error:GraphQLSyntaxError"),
-])
+@pytest.mark.parametrize(
+    "query,exc_class",
+    [
+        ("query MyQuery { missing_field }", "GraphQLError"),
+        ("{ syntax_error ", "graphql.error.syntax_error:GraphQLSyntaxError"),
+    ],
+)
 def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_class):
     if "syntax" in query:
         txn_name = "graphql.language.parser:parse"
@@ -288,15 +293,16 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
     # Import path differs between versions
     if exc_class == "GraphQLError":
         from graphql.error import GraphQLError
+
         exc_class = callable_name(GraphQLError)
 
     _test_exception_scoped_metrics = [
-    #    ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+        #    ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
     ]
     _test_exception_rollup_metrics = [
-        ('Errors/all', 1),
-        ('Errors/allOther', 1),
-        ('Errors/OtherTransaction/GraphQL/%s' % txn_name, 1),
+        ("Errors/all", 1),
+        ("Errors/allOther", 1),
+        ("Errors/OtherTransaction/GraphQL/%s" % txn_name, 1),
     ] + _test_exception_scoped_metrics
 
     # Attributes
@@ -345,7 +351,9 @@ def test_operation_metrics_and_attrs(app, graphql_run):
     @validate_span_events(exact_agents=operation_attrs)
     @background_task()
     def _test():
-        response = graphql_run(app, "query MyQuery { library(index: 0) { name, book { id, name } } }")
+        response = graphql_run(
+            app, "query MyQuery { library(index: 0) { name, book { id, name } } }"
+        )
         assert not response.errors
 
     _test()
@@ -417,23 +425,35 @@ _test_queries = [
     ("{ hello }", "/hello"),  # Basic query
     ("{ error }", "/error"),  # Extract deepest path on field error
     ('{ echo(echo: "test") }', "/echo"),  # Fields with arguments
-    ("{ library(index: 0) { name, book { isbn branch } } }", "/library"),  # Complex Example, 1 level
-    ("{ library(index: 0) { book { author { first_name }} } }", "/library.book.author.first_name"),  # Complex Example, 2 levels
+    (
+        "{ library(index: 0) { name, book { isbn branch } } }",
+        "/library",
+    ),  # Complex Example, 1 level
+    (
+        "{ library(index: 0) { book { author { first_name }} } }",
+        "/library.book.author.first_name",
+    ),  # Complex Example, 2 levels
     ("{ library(index: 0) { id, book { name } } }", "/library.book.name"),  # Filtering
     ('{ TestEcho: echo(echo: "test") }', "/echo"),  # Aliases
-    ('{ search(contains: "A") { __typename ... on Book { name } } }', "/search<Book>.name"),  # InlineFragment
-    ('{ hello echo(echo: "test") }', ""),  # Multiple root selections. (need to decide on final behavior)
+    (
+        '{ search(contains: "A") { __typename ... on Book { name } } }',
+        "/search<Book>.name",
+    ),  # InlineFragment
+    (
+        '{ hello echo(echo: "test") }',
+        "",
+    ),  # Multiple root selections. (need to decide on final behavior)
     # FragmentSpread
     (
-       '{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { name id }', # Fragment filtering
+        "{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { name id }",  # Fragment filtering
         "/library.book.name",
     ),
     (
-       '{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { author { first_name } }',
+        "{ library(index: 0) { book { ...MyFragment } } } fragment MyFragment on Book { author { first_name } }",
         "/library.book.author.first_name",
     ),
     (
-       '{ library(index: 0) { book { ...MyFragment } magazine { ...MagFragment } } } fragment MyFragment on Book { author { first_name } } fragment MagFragment on Magazine { name }',
+        "{ library(index: 0) { book { ...MyFragment } magazine { ...MagFragment } } } fragment MyFragment on Book { author { first_name } } fragment MagFragment on Magazine { name }",
         "/library",
     ),
 ]

--- a/tests/framework_graphql/test_application_async.py
+++ b/tests/framework_graphql/test_application_async.py
@@ -8,24 +8,28 @@ from testing_support.fixtures import (
 from testing_support.validators.validate_span_events import validate_span_events
 from newrelic.api.background_task import background_task
 
+
 @pytest.fixture(scope="session")
 def graphql_run_async():
     from graphql import graphql, __version__ as version
 
     major_version = int(version.split(".")[0])
     if major_version == 2:
+
         def graphql_run(*args, **kwargs):
             return graphql(*args, return_promise=True, **kwargs)
+
         return graphql_run
     else:
         return graphql
+
 
 @dt_enabled
 def test_basic_async(app, graphql_run_async):
     from graphql import __version__ as version
 
     FRAMEWORK_METRICS = [
-        ('Python/Framework/GraphQL/%s' % version, 1),
+        ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
@@ -59,6 +63,7 @@ def test_basic_async(app, graphql_run_async):
         "graphql.field.parentType": "Query",
         "graphql.field.path": "storage",
     }
+
     @validate_transaction_metrics(
         "query/<anonymous>/storage",
         "GraphQL",
@@ -73,7 +78,9 @@ def test_basic_async(app, graphql_run_async):
     @background_task()
     def _test():
         async def coro():
-            response = await graphql_run_async(app, 'mutation { storage_add(string: "abc") }')
+            response = await graphql_run_async(
+                app, 'mutation { storage_add(string: "abc") }'
+            )
             assert not response.errors
             response = await graphql_run_async(app, "query { storage }")
             assert not response.errors


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR adds logic to obtain the selection set(s) for fragment spreads and traverse through them to find the deepest unique path for transaction naming. 

# Related Github Issue
Closes #292
