### PR TITLE
Update stale workflow

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,14 +15,14 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
   - security
   - new instrumentation
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
This PR updates the repo's stale workflow labelling and auto-closing functionality. Auto-closing has been disabled in favor of maintainers verifying and closing issues manually. The `staleLabel` has also been updated from `wontfix` to `stale` as the original label was misleading. 
