### PR TITLE
Update deploy.yml to support arm builds.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ on:
     types:
       - published
 
-
 jobs:
   deploy-linux:
 
@@ -30,28 +29,43 @@ jobs:
       with:
         persist-credentials: false
         fetch-depth: 0
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
         architecture: x64
+
     - name: Install Dependencies
       run: |
         pip install -U pip
         pip install -U wheel setuptools twine
+
     - name: Build Source Package
       run: python setup.py sdist
-    - name: Build Manylinux Wheels (py2)
-      uses: newrelic-forks/python-wheels-manylinux-build@v0.3.4-manylinux2010_x86_64-2021-02-06-3d322a5
-      with:
-        python-versions: 'cp27-cp27m'
+
+    - name: Build Manylinux Wheels (Python 2)
+      uses: pypa/cibuildwheel@v1.12.0
       env:
-        LD_LIBRARY_PATH: /opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
-    - name: Build Manylinux Wheels (py3)
-      uses: RalfG/python-wheels-manylinux-build@f7c9db24751e53d2d3c90edc2b04a9ffaa96cd01
-      with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
+        CIBW_PLATFORM: linux
+        CIBW_BUILD: cp27-manylinux_x86_64
+        CIBW_ARCHS: x86_64
+        CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=/opt/rh/=vtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib"
+        CIBW_TEST_REQUIRES: beautifulsoup4
+        CIBW_TEST_COMMAND: "pip install -r {package}/tests/base_requirements.txt && export PYTHONPATH={package}/tests && NEW_RELIC_APDEX_T=1000 pytest -vx {package}/tests/agent_features/ && pytest -vx {package}/tests/agent_unittests/"
+
+    - name: Build Manylinux Wheels (Python 3)
+      uses: pypa/cibuildwheel@v2.0.1
       env:
-        LD_LIBRARY_PATH: /opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib
+        CIBW_PLATFORM: linux
+        CIBW_BUILD: cp36-manylinux_aarch64 cp37-manylinux_aarch64 cp38-manylinux_aarch64 cp39-manylinux_aarch64 cp36-manylinux_x86_64 cp37-manylinux_x86_64 cp38-manylinux_x86_64 cp39-manylinux_x86_64
+        CIBW_ARCHS: x86_64 aarch64
+        CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib"
+        CIBW_TEST_REQUIRES: beautifulsoup4
+        CIBW_TEST_COMMAND: "pip install -r {package}/tests/base_requirements.txt && export PYTHONPATH={package}/tests && NEW_RELIC_APDEX_T=1000 pytest -vx {package}/tests/agent_features/ && pytest -vx {package}/tests/agent_unittests/"
+
     - name: Upload Package to S3
       run: |
         tarball="$(python setup.py --fullname).tar.gz"
@@ -64,6 +78,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: us-west-2
+
     - name: Upload Package to PyPI
       run: |
         twine upload --non-interactive dist/*.tar.gz dist/*-manylinux*.whl


### PR DESCRIPTION
Co-authored-by: Tim Pansino <tpansino@newrelic.com>
Co-authored-by: Lalleh Rafeei <lrafeei@newrelic.com>

# Overview
This PR updates deploy.yml to use `cibuildwheel` and adds builds for aarch64 for Python 3. 

# Related Github Issue
Closes #295.
