### PR TITLE
Updated DeprecationWarnings about invalid escape sequences

### DIFF
--- a/newrelic/api/html_insertion.py
+++ b/newrelic/api/html_insertion.py
@@ -14,20 +14,20 @@
 
 import re
 
-_head_re = re.compile(b'<head[^>]*>', re.IGNORECASE)
+_head_re = re.compile(r'<head[^>]*>', re.IGNORECASE)
 
-_xua_meta_re = re.compile(b"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
-    b"""x-ua-compatible['"][^>]*>""", re.IGNORECASE)
+_xua_meta_re = re.compile(r"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
+    r"""x-ua-compatible['"][^>]*>""", re.IGNORECASE)
 
-_charset_meta_re = re.compile(b"""<\s*meta[^>]+charset\s*=[^>]*>""",
+_charset_meta_re = re.compile(r"""<\s*meta[^>]+charset\s*=[^>]*>""",
     re.IGNORECASE)
 
-_attachment_meta_re = re.compile(b"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
-    b"""content-disposition['"][^>]*content\s*=\s*(?P<quote>['"])"""
-    b"""\s*attachment(\s*;[^>]*)?(?P=quote)[^>]*>""",
+_attachment_meta_re = re.compile(r"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
+    r"""content-disposition['"][^>]*content\s*=\s*(?P<quote>['"])"""
+    r"""\s*attachment(\s*;[^>]*)?(?P=quote)[^>]*>""",
     re.IGNORECASE)
 
-_body_re = re.compile(b'<body[^>]*>', re.IGNORECASE)
+_body_re = re.compile(r'<body[^>]*>', re.IGNORECASE)
 
 def insert_html_snippet(data, html_to_be_inserted, search_limit=64*1024):
     # First determine if we have a body tag. If we don't we

--- a/newrelic/common/log_file.py
+++ b/newrelic/common/log_file.py
@@ -116,4 +116,4 @@ _urllib3_logger = logging.getLogger(
 _urllib3_logger.addFilter(Urllib3ConnectionFilter())
 
 # Also ignore any urllib3 warning messages
-warnings.filterwarnings("ignore", module='newrelic\.packages\.urllib3')
+warnings.filterwarnings("ignore", module=r"newrelic\.packages\.urllib3")


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Minor issue: when compiling with Python 3.6+, we see `DeprecationWarning`'s for an "invalid escape sequence". To resolve, I updated places in the code where the warning is thrown with raw string notation.

## Background
We use the New Relic Python agent at work and one of our CI jobs recently started failing because it handled the `DeprecationWarning` as a `SyntaxError`. Did some investigating and found this blurb in the Python docs.

> Changed in version 3.6: Unrecognized escape sequences produce a DeprecationWarning. In a future Python version they will be a SyntaxWarning and eventually a SyntaxError.

From: https://docs.python.org/3.9/reference/lexical_analysis.html#string-and-bytes-literals

We updated our CI job to ignore the warning for now, but thought it'd be good to update the package.


## Checking for warnings

```bash
> python3 --version
Python 3.9.6

# Command to run to check for compilation warnings (with latest 'main')
> find . -iname '*.py'  | xargs -P 4 -I{} python3 -Wall -m py_compile {} 
./newrelic/common/log_file.py:119: DeprecationWarning: invalid escape sequence \.
  warnings.filterwarnings("ignore", module='newrelic\.packages\.urllib3')
./newrelic/api/html_insertion.py:19: DeprecationWarning: invalid escape sequence \s
  _xua_meta_re = re.compile(b"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
./newrelic/api/html_insertion.py:22: DeprecationWarning: invalid escape sequence \s
  _charset_meta_re = re.compile(b"""<\s*meta[^>]+charset\s*=[^>]*>""",
./newrelic/api/html_insertion.py:25: DeprecationWarning: invalid escape sequence \s
  _attachment_meta_re = re.compile(b"""<\s*meta[^>]+http-equiv\s*=\s*['"]"""
./newrelic/api/html_insertion.py:26: DeprecationWarning: invalid escape sequence \s
  b"""content-disposition['"][^>]*content\s*=\s*(?P<quote>['"])"""
./newrelic/api/html_insertion.py:27: DeprecationWarning: invalid escape sequence \s
  b"""\s*attachment(\s*;[^>]*)?(?P=quote)[^>]*>""",

# Checking with PR branch
> find . -iname '*.py'  | xargs -P 4 -I{} python3 -Wall -m py_compile {}

```

# Related Github Issue
N/A

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.