### PR TITLE
Pin uvicorn version to v0.14 for py36 testing purposes.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,9 @@ envlist =
     python-adapter_gunicorn-{py36}-aiohttp1-gunicorn{19,latest},
     python-adapter_gunicorn-{py36,py37,py38,py39}-aiohttp3-gunicornlatest,
     python-adapter_uvicorn-{py36,py37}-uvicorn03,
-    python-adapter_uvicorn-{py36,py37,py38,py39}-uvicornlatest,
+    ; Temporarily testing py36 on the uvicorn version preceeding v0.15
+    python-adapter_uvicorn-{py36}-uvicorn014
+    python-adapter_uvicorn-{py37,py38,py39}-uvicornlatest,
     python-agent_features-{py27,py36,py37,py38,py39}-{with,without}_extensions,
     python-agent_features-{pypy,pypy3}-without_extensions,
     python-agent_streaming-{py27,py36,py37,py38,py39}-{with,without}_extensions,
@@ -147,6 +149,7 @@ deps =
     adapter_gunicorn-gunicorn19: gunicorn<20
     adapter_gunicorn-gunicornlatest: gunicorn
     adapter_uvicorn-uvicorn03: uvicorn<0.4
+    adapter_uvicorn-uvicorn014: uvicorn<0.15
     adapter_uvicorn-uvicornlatest: uvicorn
     agent_features: beautifulsoup4
     application_celery: celery<6.0


### PR DESCRIPTION
This PR temporarily disables testing of py36 on the latest uvicorn version by pinning the version to its preceding release (v0.14)