### PR TITLE
Add CAT deprecation warnings

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -876,6 +876,13 @@ def translate_deprecated_settings(settings, cached_settings):
             "attributes.exclude."
         )
 
+    if "cross_application_tracer.enabled" in cached:
+        # CAT Deprecation Warning
+        _logger.info(
+            'Deprecated setting found: cross_application_tracer.enabled. Please replace Cross Application Tracing '
+            '(CAT) with the newer Distributed Tracing by setting ‘distributed_tracing.enabled’ to True in your agent configuration. For further details on distributed tracing, please refer to our documentation: https://docs.newrelic.com/docs/distributed-tracing/concepts/distributed-tracing-planning-guide/#changes.'
+        )
+
     if not settings.ssl:
         settings.ssl = True
         _logger.info(


### PR DESCRIPTION
This PR adds deprecation warnings for CAT when the `cross_application_tracer.enabled` setting is detected in the agent config file. 

Closes #315. 