### PR TITLE
Add develop branch check to GHA test workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ on:
       - main
       - feature/*
       - feature-*
+      - develop-*
 
 jobs:
   python:


### PR DESCRIPTION
This PR adds the develop prefix check to the GHA test workflow to ensure all tests are run when a develop-* branch is set as target.