### PR TITLE
Enable DT in default newrelic.ini

### DIFF
--- a/newrelic/newrelic.ini
+++ b/newrelic/newrelic.ini
@@ -178,11 +178,10 @@ thread_profiler.enabled = true
 # api_key =
 
 # Distributed tracing lets you see the path that a request takes
-# through your distributed system. Enabling distributed tracing
-# changes the behavior of some New Relic features, so carefully
-# consult the transition guide before you enable this feature:
+# through your distributed system. For more information, please
+# consult our distributed tracing planning guide.
 # https://docs.newrelic.com/docs/transition-guide-distributed-tracing
-distributed_tracing.enabled = false
+distributed_tracing.enabled = true
 
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This updates the default newrelic.ini to set distributed_tracing.enabled to True as a part of the DT by default effort.
