### PR TITLE
Add tests for Django 3.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ envlist =
     python-framework_django-{pypy,py27}-Django0103,
     python-framework_django-{pypy,py27,py37}-Django0108,
     python-framework_django-py39-Django{0200,0201,0202,0300,latest},
-    python-framework_django-{py36,py37,py38,py39}-Django0301,
+    python-framework_django-{py36,py37,py38,py39}-Django{0301,0302},
     python-framework_falcon-{py27,py36,py37,py38,py39,pypy,pypy3}-falcon0103,
     python-framework_falcon-{py36,py37,py38,py39,pypy3}-falcon{0200,master},
     python-framework_fastapi-{py36,py37,py38},
@@ -233,6 +233,7 @@ deps =
     framework_django-Django0202: Django<2.3
     framework_django-Django0300: Django<3.1
     framework_django-Django0301: Django<3.2
+    framework_django-Django0302: Django<4.0
     framework_django-Djangolatest: Django
     framework_django-Djangomaster: https://github.com/django/django/archive/main.zip
     framework_falcon-falcon0103: falcon<1.4


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
This PR adds new tox environments to run the tests against latest Django 3.2 and Python from 3.6 to 3.9 (supported Python version for Django 3.2)

# Related Github Issue
https://github.com/newrelic/newrelic-python-agent/issues/343

# Testing
There's no special setup for testing, the CI will run the tests in the new environments with tox.
