### PR TITLE
Add GraphQL Framework Info to Metrics

### DIFF
--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -36,6 +36,7 @@ class GraphQLOperationTrace(TimeTrace):
         self.graphql = None
         self.graphql_format = None
         self.statement = None
+        self.product = "GraphQL"
 
     def __repr__(self):
         return "<%s object at 0x%x %s>" % (
@@ -89,6 +90,7 @@ class GraphQLOperationTrace(TimeTrace):
             operation_type=self.operation_type,
             deepest_path=self.deepest_path,
             graphql=self.graphql,
+            product=self.product,
         )
 
     def set_transaction_name(self, priority=None):

--- a/newrelic/core/graphql_node.py
+++ b/newrelic/core/graphql_node.py
@@ -30,10 +30,6 @@ _GraphQLResolverNode = namedtuple('_GraphQLNode',
     'exclusive', 'guid', 'agent_attributes', 'user_attributes', 'product'])
 
 class GraphQLNodeMixin(GenericNodeMixin):
-    @property
-    def product(self):
-        return self.product
-
     def trace_node(self, stats, root, connections):
         name = root.string_table.cache(self.name)
 

--- a/newrelic/core/graphql_node.py
+++ b/newrelic/core/graphql_node.py
@@ -27,7 +27,7 @@ _GraphQLOperationNode = namedtuple('_GraphQLNode',
 
 _GraphQLResolverNode = namedtuple('_GraphQLNode',
     ['field_name', 'children', 'start_time', 'end_time', 'duration', 
-    'exclusive', 'guid', 'agent_attributes', 'user_attributes'])
+    'exclusive', 'guid', 'agent_attributes', 'user_attributes', 'product'])
 
 class GraphQLNodeMixin(GenericNodeMixin):
     @property
@@ -62,7 +62,7 @@ class GraphQLResolverNode(_GraphQLResolverNode, GraphQLNodeMixin):
     @property
     def name(self):
         field_name = self.field_name or "<unknown>"
-        product = "GraphQL"
+        product = self.product
 
         name = 'GraphQL/resolve/%s/%s' % (product, field_name)
 
@@ -74,7 +74,7 @@ class GraphQLResolverNode(_GraphQLResolverNode, GraphQLNodeMixin):
         """
 
         field_name = self.field_name or "<unknown>"
-        product = "GraphQL"
+        product = self.product
 
         # Determine the scoped metric
 

--- a/newrelic/core/graphql_node.py
+++ b/newrelic/core/graphql_node.py
@@ -23,7 +23,7 @@ from newrelic.core.node_mixin import GenericNodeMixin
 _GraphQLOperationNode = namedtuple('_GraphQLNode',
     ['operation_type', 'operation_name', 'deepest_path', 'graphql', 
     'children', 'start_time', 'end_time', 'duration', 'exclusive', 'guid',
-    'agent_attributes', 'user_attributes'])
+    'agent_attributes', 'user_attributes', 'product'])
 
 _GraphQLResolverNode = namedtuple('_GraphQLNode',
     ['field_name', 'children', 'start_time', 'end_time', 'duration', 
@@ -32,7 +32,7 @@ _GraphQLResolverNode = namedtuple('_GraphQLNode',
 class GraphQLNodeMixin(GenericNodeMixin):
     @property
     def product(self):
-        return "GraphQL"
+        return self.product
 
     def trace_node(self, stats, root, connections):
         name = root.string_table.cache(self.name)
@@ -62,7 +62,7 @@ class GraphQLResolverNode(_GraphQLResolverNode, GraphQLNodeMixin):
     @property
     def name(self):
         field_name = self.field_name or "<unknown>"
-        product = self.product
+        product = "GraphQL"
 
         name = 'GraphQL/resolve/%s/%s' % (product, field_name)
 
@@ -74,7 +74,7 @@ class GraphQLResolverNode(_GraphQLResolverNode, GraphQLNodeMixin):
         """
 
         field_name = self.field_name or "<unknown>"
-        product = self.product
+        product = "GraphQL"
 
         # Determine the scoped metric
 

--- a/newrelic/hooks/framework_ariadne.py
+++ b/newrelic/hooks/framework_ariadne.py
@@ -60,6 +60,7 @@ def wrap_graphql_sync(wrapped, instance, args, kwargs):
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with GraphQLOperationTrace() as trace:
+        trace.product = "Ariadne"
         trace.statement = graphql_statement(query)
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             return wrapped(*args, **kwargs)
@@ -93,6 +94,7 @@ async def wrap_graphql(wrapped, instance, args, kwargs):
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with GraphQLOperationTrace() as trace:
+        trace.product = "Ariadne"
         trace.statement = graphql_statement(query)
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             result = wrapped(*args, **kwargs)

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -362,11 +362,18 @@ def wrap_parse(wrapped, instance, args, kwargs):
 
 
 def bind_resolve_field_v3(parent_type, source, field_nodes, path):
+    breakpoint()
     return parent_type, field_nodes, path
 
 
 def bind_resolve_field_v2(exe_context, parent_type, source, field_asts, parent_info, field_path):
     return parent_type, field_asts, field_path
+
+
+def graphene_framework_details():
+    import graphene
+
+    return ("Graphene", getattr(graphene, "__version__", None))
 
 
 def wrap_resolve_field(wrapped, instance, args, kwargs):
@@ -402,7 +409,7 @@ def wrap_resolve_field(wrapped, instance, args, kwargs):
 
 
 def bind_graphql_impl_query(schema, source, *args, **kwargs):
-    return source
+    return schema, source
 
 
 def bind_execute_graphql_query(
@@ -416,8 +423,7 @@ def bind_execute_graphql_query(
     backend=None,
     **execute_options
 ):
-
-    return request_string
+    return schema, request_string
 
 
 def wrap_graphql_impl(wrapped, instance, args, kwargs):
@@ -433,9 +439,15 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
         bind_query = bind_graphql_impl_query
 
     try:
-        query = bind_query(*args, **kwargs)
+        schema, query = bind_query(*args, **kwargs)
     except TypeError:
         return wrapped(*args, **kwargs)
+
+    is_graphene = "graphene" in str(type(schema))
+
+    if is_graphene:
+        framework = graphene_framework_details()
+        transaction.add_framework_info(name=framework[0], version=framework[1])
 
     if hasattr(query, "body"):
         query = query.body
@@ -444,6 +456,8 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
 
     with GraphQLOperationTrace() as trace:
         trace.statement = graphql_statement(query)
+        if is_graphene: # ex: "<class 'graphene.types.schema.Schema'>"
+            trace.product = "Graphene"
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             result = wrapped(*args, **kwargs)
             return result

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -362,7 +362,6 @@ def wrap_parse(wrapped, instance, args, kwargs):
 
 
 def bind_resolve_field_v3(parent_type, source, field_nodes, path):
-    breakpoint()
     return parent_type, field_nodes, path
 
 

--- a/newrelic/hooks/framework_strawberry.py
+++ b/newrelic/hooks/framework_strawberry.py
@@ -57,6 +57,7 @@ def wrap_execute_sync(wrapped, instance, args, kwargs):
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with GraphQLOperationTrace() as trace:
+        trace.product = "Strawberry"
         trace.statement = graphql_statement(query)
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             return wrapped(*args, **kwargs)
@@ -83,6 +84,7 @@ async def wrap_execute(wrapped, instance, args, kwargs):
     transaction.set_transaction_name(callable_name(wrapped), "GraphQL", priority=10)
 
     with GraphQLOperationTrace() as trace:
+        trace.product = "Strawberry"
         trace.statement = graphql_statement(query)
         with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
             return await wrapped(*args, **kwargs)

--- a/tests/framework_ariadne/test_application.py
+++ b/tests/framework_ariadne/test_application.py
@@ -118,8 +118,8 @@ def test_query_and_mutation(app, graphql_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Ariadne/storage", 1),
+        ("GraphQL/resolve/Ariadne/storage_add", 1),
         ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
         ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
@@ -181,7 +181,7 @@ def test_query_and_mutation(app, graphql_run):
 def test_middleware(app, graphql_run, is_graphql_2):
     _test_middleware_metrics = [
         ("GraphQL/operation/Ariadne/query/<anonymous>/hello", 1),
-        ("GraphQL/resolve/GraphQL/hello", 1),
+        ("GraphQL/resolve/Strawberry/hello", 1),
         ("Function/test_application:example_middleware", 1),
     ]
 
@@ -213,7 +213,7 @@ def test_exception_in_middleware(app, graphql_run):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Ariadne/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/GraphQL/%s" % field, 1),
+        ("GraphQL/resolve/Strawberry/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -263,7 +263,7 @@ def test_exception_in_resolver(app, graphql_run, field):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Ariadne/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/GraphQL/%s" % field, 1),
+        ("GraphQL/resolve/Ariadne/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -326,7 +326,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
         exc_class = callable_name(GraphQLError)
 
     _test_exception_scoped_metrics = [
-            ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+            ('GraphQL/operation/Ariadne/<unknown>/<anonymous>/<unknown>', 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -388,7 +388,7 @@ def test_operation_metrics_and_attrs(app, graphql_run):
 
 @dt_enabled
 def test_field_resolver_metrics_and_attrs(app, graphql_run):
-    field_resolver_metrics = [("GraphQL/resolve/GraphQL/hello", 1)]
+    field_resolver_metrics = [("GraphQL/resolve/Ariadne/hello", 1)]
     graphql_attrs = {
         "graphql.field.name": "hello",
         "graphql.field.parentType": "Query",

--- a/tests/framework_ariadne/test_application.py
+++ b/tests/framework_ariadne/test_application.py
@@ -82,8 +82,8 @@ _graphql_base_rollup_metrics = [
     ("OtherTransaction/all", 1),
     ("GraphQL/all", 1),
     ("GraphQL/allOther", 1),
-    ("GraphQL/GraphQL/all", 1),
-    ("GraphQL/GraphQL/allOther", 1),
+    ("GraphQL/Ariadne/all", 1),
+    ("GraphQL/Ariadne/allOther", 1),
 ]
 
 
@@ -120,15 +120,15 @@ def test_query_and_mutation(app, graphql_run):
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add.string", 1),
+        ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_mutation_unscoped_metrics = [
         ("OtherTransaction/all", 1),
         ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/Ariadne/all", 2),
         ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
+        ("GraphQL/Ariadne/allOther", 2),
     ] + _test_mutation_scoped_metrics
 
     _expected_mutation_operation_attributes = {
@@ -180,7 +180,7 @@ def test_query_and_mutation(app, graphql_run):
 @dt_enabled
 def test_middleware(app, graphql_run, is_graphql_2):
     _test_middleware_metrics = [
-        ("GraphQL/operation/GraphQL/query/<anonymous>/hello", 1),
+        ("GraphQL/operation/Ariadne/query/<anonymous>/hello", 1),
         ("GraphQL/resolve/GraphQL/hello", 1),
         ("Function/test_application:example_middleware", 1),
     ]
@@ -212,7 +212,7 @@ def test_exception_in_middleware(app, graphql_run):
 
     # Metrics
     _test_exception_scoped_metrics = [
-        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/operation/Ariadne/query/MyQuery/%s" % field, 1),
         ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
@@ -262,7 +262,7 @@ def test_exception_in_resolver(app, graphql_run, field):
 
     # Metrics
     _test_exception_scoped_metrics = [
-        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/operation/Ariadne/query/MyQuery/%s" % field, 1),
         ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
@@ -326,7 +326,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
         exc_class = callable_name(GraphQLError)
 
     _test_exception_scoped_metrics = [
-        #    ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+            ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -360,7 +360,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
 
 @dt_enabled
 def test_operation_metrics_and_attrs(app, graphql_run):
-    operation_metrics = [("GraphQL/operation/GraphQL/query/MyQuery/library", 1)]
+    operation_metrics = [("GraphQL/operation/Ariadne/query/MyQuery/library", 1)]
     operation_attrs = {
         "graphql.operation.type": "query",
         "graphql.operation.name": "MyQuery",

--- a/tests/framework_ariadne/test_application.py
+++ b/tests/framework_ariadne/test_application.py
@@ -181,7 +181,7 @@ def test_query_and_mutation(app, graphql_run):
 def test_middleware(app, graphql_run, is_graphql_2):
     _test_middleware_metrics = [
         ("GraphQL/operation/Ariadne/query/<anonymous>/hello", 1),
-        ("GraphQL/resolve/Strawberry/hello", 1),
+        ("GraphQL/resolve/Ariadne/hello", 1),
         ("Function/test_application:example_middleware", 1),
     ]
 
@@ -213,7 +213,7 @@ def test_exception_in_middleware(app, graphql_run):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Ariadne/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/Strawberry/%s" % field, 1),
+        ("GraphQL/resolve/Ariadne/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),

--- a/tests/framework_ariadne/test_application_async.py
+++ b/tests/framework_ariadne/test_application_async.py
@@ -30,15 +30,15 @@ def test_query_and_mutation_async(app, graphql_run_async):
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add.string", 1),
+        ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_mutation_unscoped_metrics = [
         ("OtherTransaction/all", 1),
         ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/Ariadne/all", 2),
         ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
+        ("GraphQL/Ariadne/allOther", 2),
     ] + _test_mutation_scoped_metrics
 
     _expected_mutation_operation_attributes = {

--- a/tests/framework_ariadne/test_application_async.py
+++ b/tests/framework_ariadne/test_application_async.py
@@ -28,8 +28,8 @@ def test_query_and_mutation_async(app, graphql_run_async):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Ariadne/storage", 1),
+        ("GraphQL/resolve/Ariadne/storage_add", 1),
         ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
         ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]

--- a/tests/framework_ariadne/test_asgi.py
+++ b/tests/framework_ariadne/test_asgi.py
@@ -31,18 +31,18 @@ def test_query_and_mutation_asgi(graphql_asgi_run):
     ]
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add.string", 1),
+        ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_query_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [
         ("WebTransaction", 1),
         ("GraphQL/all", 1),
-        ("GraphQL/GraphQL/all", 1),
+        ("GraphQL/Ariadne/all", 1),
         ("GraphQL/allWeb", 1),
-        ("GraphQL/GraphQL/allWeb", 1),
+        ("GraphQL/Ariadne/allWeb", 1),
     ]
     _test_mutation_unscoped_metrics = _test_unscoped_metrics + _test_mutation_scoped_metrics
     _test_query_unscoped_metrics = _test_unscoped_metrics + _test_query_scoped_metrics

--- a/tests/framework_ariadne/test_asgi.py
+++ b/tests/framework_ariadne/test_asgi.py
@@ -30,11 +30,11 @@ def test_query_and_mutation_asgi(graphql_asgi_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Ariadne/storage_add", 1),
         ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_query_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
+        ("GraphQL/resolve/Ariadne/storage", 1),
         ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [

--- a/tests/framework_ariadne/test_wsgi.py
+++ b/tests/framework_ariadne/test_wsgi.py
@@ -26,11 +26,11 @@ def test_query_and_mutation_wsgi(graphql_wsgi_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Ariadne/storage_add", 1),
         ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_query_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
+        ("GraphQL/resolve/Ariadne/storage", 1),
         ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [

--- a/tests/framework_ariadne/test_wsgi.py
+++ b/tests/framework_ariadne/test_wsgi.py
@@ -27,19 +27,19 @@ def test_query_and_mutation_wsgi(graphql_wsgi_run):
     ]
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add.string", 1),
+        ("GraphQL/operation/Ariadne/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_query_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Ariadne/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [
         ("WebTransaction", 1),
         ("Python/WSGI/Response", 1),
         ("GraphQL/all", 1),
-        ("GraphQL/GraphQL/all", 1),
+        ("GraphQL/Ariadne/all", 1),
         ("GraphQL/allWeb", 1),
-        ("GraphQL/GraphQL/allWeb", 1),
+        ("GraphQL/Ariadne/allWeb", 1),
     ]
     _test_mutation_unscoped_metrics = _test_unscoped_metrics + _test_mutation_scoped_metrics
     _test_query_unscoped_metrics = _test_unscoped_metrics + _test_query_scoped_metrics

--- a/tests/framework_graphene/test_application.py
+++ b/tests/framework_graphene/test_application.py
@@ -118,8 +118,8 @@ def test_query_and_mutation(app, graphql_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Graphene/storage", 1),
+        ("GraphQL/resolve/Graphene/storage_add", 1),
         ("GraphQL/operation/Graphene/query/<anonymous>/storage", 1),
         ("GraphQL/operation/Graphene/mutation/<anonymous>/storage_add.string", 1),
     ]
@@ -181,7 +181,7 @@ def test_query_and_mutation(app, graphql_run):
 def test_middleware(app, graphql_run, is_graphql_2):
     _test_middleware_metrics = [
         ("GraphQL/operation/Graphene/query/<anonymous>/hello", 1),
-        ("GraphQL/resolve/GraphQL/hello", 1),
+        ("GraphQL/resolve/Graphene/hello", 1),
         ("Function/test_application:example_middleware", 1),
     ]
 
@@ -211,7 +211,7 @@ def test_exception_in_middleware(app, graphql_run):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Graphene/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/GraphQL/%s" % field, 1),
+        ("GraphQL/resolve/Graphene/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -263,7 +263,7 @@ def test_exception_in_resolver(app, graphql_run, field):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Graphene/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/GraphQL/%s" % field, 1),
+        ("GraphQL/resolve/Graphene/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -388,7 +388,7 @@ def test_operation_metrics_and_attrs(app, graphql_run):
 
 @dt_enabled
 def test_field_resolver_metrics_and_attrs(app, graphql_run):
-    field_resolver_metrics = [("GraphQL/resolve/GraphQL/hello", 1)]
+    field_resolver_metrics = [("GraphQL/resolve/Graphene/hello", 1)]
     graphql_attrs = {
         "graphql.field.name": "hello",
         "graphql.field.parentType": "Query",

--- a/tests/framework_graphene/test_application.py
+++ b/tests/framework_graphene/test_application.py
@@ -81,16 +81,19 @@ _graphql_base_rollup_metrics = [
     ("OtherTransaction/all", 1),
     ("GraphQL/all", 1),
     ("GraphQL/allOther", 1),
-    ("GraphQL/GraphQL/all", 1),
-    ("GraphQL/GraphQL/allOther", 1),
+    ("GraphQL/Graphene/all", 1),
+    ("GraphQL/Graphene/allOther", 1),
 ]
 
 
 def test_basic(app, graphql_run):
     from graphql import __version__ as version
+    from newrelic.hooks.framework_graphql import graphene_framework_details
 
     FRAMEWORK_METRICS = [
+        ("Python/Framework/Graphene/%s" % graphene_framework_details()[1], 1),
         ("Python/Framework/GraphQL/%s" % version, 1),
+
     ]
 
     @validate_transaction_metrics(
@@ -117,15 +120,15 @@ def test_query_and_mutation(app, graphql_run):
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add.string", 1),
+        ("GraphQL/operation/Graphene/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Graphene/mutation/<anonymous>/storage_add.string", 1),
     ]
     _test_mutation_unscoped_metrics = [
         ("OtherTransaction/all", 1),
         ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/Graphene/all", 2),
         ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
+        ("GraphQL/Graphene/allOther", 2),
     ] + _test_mutation_scoped_metrics
 
     _expected_mutation_operation_attributes = {
@@ -177,7 +180,7 @@ def test_query_and_mutation(app, graphql_run):
 @dt_enabled
 def test_middleware(app, graphql_run, is_graphql_2):
     _test_middleware_metrics = [
-        ("GraphQL/operation/GraphQL/query/<anonymous>/hello", 1),
+        ("GraphQL/operation/Graphene/query/<anonymous>/hello", 1),
         ("GraphQL/resolve/GraphQL/hello", 1),
         ("Function/test_application:example_middleware", 1),
     ]
@@ -207,7 +210,7 @@ def test_exception_in_middleware(app, graphql_run):
 
     # Metrics
     _test_exception_scoped_metrics = [
-        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/operation/Graphene/query/MyQuery/%s" % field, 1),
         ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
@@ -259,7 +262,7 @@ def test_exception_in_resolver(app, graphql_run, field):
 
     # Metrics
     _test_exception_scoped_metrics = [
-        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/operation/Graphene/query/MyQuery/%s" % field, 1),
         ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
@@ -323,7 +326,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
         exc_class = callable_name(GraphQLError)
 
     _test_exception_scoped_metrics = [
-        #    ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+            ('GraphQL/operation/Graphene/<unknown>/<anonymous>/<unknown>', 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -357,7 +360,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
 
 @dt_enabled
 def test_operation_metrics_and_attrs(app, graphql_run):
-    operation_metrics = [("GraphQL/operation/GraphQL/query/MyQuery/library", 1)]
+    operation_metrics = [("GraphQL/operation/Graphene/query/MyQuery/library", 1)]
     operation_attrs = {
         "graphql.operation.type": "query",
         "graphql.operation.name": "MyQuery",

--- a/tests/framework_starlette/test_graphql.py
+++ b/tests/framework_starlette/test_graphql.py
@@ -27,19 +27,21 @@ def target_application():
 @pytest.mark.parametrize("endpoint", ("/async", "/sync"))
 def test_graphql_metrics_and_attrs(target_application, endpoint):
     from graphql import __version__ as version
+    from newrelic.hooks.framework_graphql import graphene_framework_details
 
     FRAMEWORK_METRICS = [
+        ("Python/Framework/Graphene/%s" % graphene_framework_details()[1], 1),
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/hello", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/hello", 1),
+        ("GraphQL/resolve/Graphene/hello", 1),
+        ("GraphQL/operation/Graphene/query/<anonymous>/hello", 1),
     ]
     _test_unscoped_metrics = [
         ("GraphQL/all", 1),
-        ("GraphQL/GraphQL/all", 1),
+        ("GraphQL/Graphene/all", 1),
         ("GraphQL/allWeb", 1),
-        ("GraphQL/GraphQL/allWeb", 1),
+        ("GraphQL/Graphene/allWeb", 1),
     ] + _test_scoped_metrics
 
     _expected_query_operation_attributes = {

--- a/tests/framework_strawberry/test_application.py
+++ b/tests/framework_strawberry/test_application.py
@@ -80,8 +80,8 @@ _graphql_base_rollup_metrics = [
     ("OtherTransaction/all", 1),
     ("GraphQL/all", 1),
     ("GraphQL/allOther", 1),
-    ("GraphQL/GraphQL/all", 1),
-    ("GraphQL/GraphQL/allOther", 1),
+    ("GraphQL/Strawberry/all", 1),
+    ("GraphQL/Strawberry/allOther", 1),
 ]
 
 
@@ -122,15 +122,15 @@ def test_query_and_mutation(app, graphql_run):
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
+        ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]
     _test_mutation_unscoped_metrics = [
         ("OtherTransaction/all", 1),
         ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/Strawberry/all", 2),
         ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
+        ("GraphQL/Strawberry/allOther", 2),
     ] + _test_mutation_scoped_metrics
 
     _expected_mutation_operation_attributes = {
@@ -188,7 +188,7 @@ def test_exception_in_resolver(app, graphql_run, field):
 
     # Metrics
     _test_exception_scoped_metrics = [
-        ("GraphQL/operation/GraphQL/query/MyQuery/%s" % field, 1),
+        ("GraphQL/operation/Strawberry/query/MyQuery/%s" % field, 1),
         ("GraphQL/resolve/GraphQL/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
@@ -252,7 +252,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
         exc_class = callable_name(GraphQLError)
 
     _test_exception_scoped_metrics = [
-        #    ('GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>', 1),
+            ('GraphQL/operation/Strawberry/<unknown>/<anonymous>/<unknown>', 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -286,7 +286,7 @@ def test_exception_in_validation(app, graphql_run, is_graphql_2, query, exc_clas
 
 @dt_enabled
 def test_operation_metrics_and_attrs(app, graphql_run):
-    operation_metrics = [("GraphQL/operation/GraphQL/query/MyQuery/library", 1)]
+    operation_metrics = [("GraphQL/operation/Strawberry/query/MyQuery/library", 1)]
     operation_attrs = {
         "graphql.operation.type": "query",
         "graphql.operation.name": "MyQuery",

--- a/tests/framework_strawberry/test_application.py
+++ b/tests/framework_strawberry/test_application.py
@@ -120,8 +120,8 @@ def test_query_and_mutation(app, graphql_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Strawberry/storage", 1),
+        ("GraphQL/resolve/Strawberry/storage_add", 1),
         ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
         ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]
@@ -189,7 +189,7 @@ def test_exception_in_resolver(app, graphql_run, field):
     # Metrics
     _test_exception_scoped_metrics = [
         ("GraphQL/operation/Strawberry/query/MyQuery/%s" % field, 1),
-        ("GraphQL/resolve/GraphQL/%s" % field, 1),
+        ("GraphQL/resolve/Strawberry/%s" % field, 1),
     ]
     _test_exception_rollup_metrics = [
         ("Errors/all", 1),
@@ -314,7 +314,7 @@ def test_operation_metrics_and_attrs(app, graphql_run):
 
 @dt_enabled
 def test_field_resolver_metrics_and_attrs(app, graphql_run):
-    field_resolver_metrics = [("GraphQL/resolve/GraphQL/hello", 1)]
+    field_resolver_metrics = [("GraphQL/resolve/Strawberry/hello", 1)]
     graphql_attrs = {
         "graphql.field.name": "hello",
         "graphql.field.parentType": "Query",

--- a/tests/framework_strawberry/test_application_async.py
+++ b/tests/framework_strawberry/test_application_async.py
@@ -21,15 +21,18 @@ _graphql_base_rollup_metrics = [
     ("OtherTransaction/all", 1),
     ("GraphQL/all", 1),
     ("GraphQL/allOther", 1),
-    ("GraphQL/GraphQL/all", 1),
-    ("GraphQL/GraphQL/allOther", 1),
+    ("GraphQL/Strawberry/all", 1),
+    ("GraphQL/Strawberry/allOther", 1),
 ]
 
 
 def test_basic(app, graphql_run_async):
     from graphql import __version__ as version
 
+    from newrelic.hooks.framework_strawberry import framework_details
+
     FRAMEWORK_METRICS = [
+        ("Python/Framework/Strawberry/%s" % framework_details()[1], 1),
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
 
@@ -64,15 +67,15 @@ def test_query_and_mutation_async(app, graphql_run_async):
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
+        ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]
     _test_mutation_unscoped_metrics = [
         ("OtherTransaction/all", 1),
         ("GraphQL/all", 2),
-        ("GraphQL/GraphQL/all", 2),
+        ("GraphQL/Strawberry/all", 2),
         ("GraphQL/allOther", 2),
-        ("GraphQL/GraphQL/allOther", 2),
+        ("GraphQL/Strawberry/allOther", 2),
     ] + _test_mutation_scoped_metrics
 
     _expected_mutation_operation_attributes = {

--- a/tests/framework_strawberry/test_application_async.py
+++ b/tests/framework_strawberry/test_application_async.py
@@ -65,8 +65,8 @@ def test_query_and_mutation_async(app, graphql_run_async):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Strawberry/storage", 1),
+        ("GraphQL/resolve/Strawberry/storage_add", 1),
         ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
         ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]

--- a/tests/framework_strawberry/test_asgi.py
+++ b/tests/framework_strawberry/test_asgi.py
@@ -35,11 +35,11 @@ def test_query_and_mutation_asgi(graphql_asgi_run):
         ("Python/Framework/GraphQL/%s" % version, 1),
     ]
     _test_mutation_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage_add", 1),
+        ("GraphQL/resolve/Strawberry/storage_add", 1),
         ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]
     _test_query_scoped_metrics = [
-        ("GraphQL/resolve/GraphQL/storage", 1),
+        ("GraphQL/resolve/Strawberry/storage", 1),
         ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [

--- a/tests/framework_strawberry/test_asgi.py
+++ b/tests/framework_strawberry/test_asgi.py
@@ -36,18 +36,18 @@ def test_query_and_mutation_asgi(graphql_asgi_run):
     ]
     _test_mutation_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage_add", 1),
-        ("GraphQL/operation/GraphQL/mutation/<anonymous>/storage_add", 1),
+        ("GraphQL/operation/Strawberry/mutation/<anonymous>/storage_add", 1),
     ]
     _test_query_scoped_metrics = [
         ("GraphQL/resolve/GraphQL/storage", 1),
-        ("GraphQL/operation/GraphQL/query/<anonymous>/storage", 1),
+        ("GraphQL/operation/Strawberry/query/<anonymous>/storage", 1),
     ]
     _test_unscoped_metrics = [
         ("WebTransaction", 1),
         ("GraphQL/all", 1),
-        ("GraphQL/GraphQL/all", 1),
+        ("GraphQL/Strawberry/all", 1),
         ("GraphQL/allWeb", 1),
-        ("GraphQL/GraphQL/allWeb", 1),
+        ("GraphQL/Strawberry/allWeb", 1),
     ]
     _test_mutation_unscoped_metrics = _test_unscoped_metrics + _test_mutation_scoped_metrics
     _test_query_unscoped_metrics = _test_unscoped_metrics + _test_query_scoped_metrics

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,7 @@ deps =
     adapter_uvicorn-uvicorn014: uvicorn<0.15
     adapter_uvicorn-uvicornlatest: uvicorn
     agent_features: beautifulsoup4
-    agent_streaming: protobuf<3.18.0
+    agent_streaming-py27: protobuf<3.18.0
     application_celery: celery<6.0
     application_gearman: gearman<3.0.0
     component_djangorestframework-djangorestframework0300: Django < 1.9

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ envlist =
     python-framework_graphql-{py36,py37,py38,py39,pypy3}-graphql03,
     python-framework_graphql-py37-graphql{0202,0203,0300,0301,master},
     grpc-framework_grpc-{py27,py36}-grpc0125,
-    grpc-framework_grpc-{py27,py36,py37,py38,py39}-grpclatest,
+    grpc-framework_grpc-{py36,py37,py38,py39}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy3,py36,py37,py38,py39}-Pyramid0110-cornice,
     python-framework_pyramid-{pypy3,py36,py37,py38,py39}-Pyramidmaster,
@@ -265,6 +265,7 @@ deps =
     framework_graphql-graphqlmaster: https://github.com/graphql-python/graphql-core/archive/main.zip
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
+    framework_grpc-grpc0125: protobuf<3.18.0
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
     framework_pyramid: routes

--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,7 @@ deps =
     adapter_uvicorn-uvicorn014: uvicorn<0.15
     adapter_uvicorn-uvicornlatest: uvicorn
     agent_features: beautifulsoup4
+    agent_streaming: protobuf<3.18.0
     application_celery: celery<6.0
     application_gearman: gearman<3.0.0
     component_djangorestframework-djangorestframework0300: Django < 1.9


### PR DESCRIPTION
This PR adds logic to store framework information to update metric names to include the specific product in use (ex: Ariadne, Strawberry, Graphene). It also includes the addition of framework metrics for the Graphene library.

# Related Github Issue
Closes #358.
Closes #362.
