### PR TITLE
Drop testing for pymongo<3.0 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ envlist =
     postgres-datastore_psycopg2cffi-py37-psycopg2cffi0208,
     memcached-datastore_pylibmc-{py27,py36,py37},
     memcached-datastore_pymemcache-{py27,py36,py37,py38,py39,pypy,pypy3},
-    mongodb-datastore_pymongo-{py27,py36,py37,py38,py39,pypy}-pymongo{02,03},
+    mongodb-datastore_pymongo-{py27,py36,py37,py38,py39,pypy}-pymongo{03},
     mysql-datastore_pymysql-{py27,py36,py37,py38,py39,pypy,pypy3},
     solr-datastore_pysolr-{py27,py36,py37,py38,py39,pypy,pypy3},
     redis-datastore_redis-{py27,py36,py37,py38,py39,pypy,pypy3},
@@ -186,7 +186,6 @@ deps =
     datastore_pyelasticsearch: pyelasticsearch<2.0
     datastore_pylibmc: pylibmc
     datastore_pymemcache: pymemcache
-    datastore_pymongo-pymongo02: pymongo<3.0
     datastore_pymongo-pymongo03: pymongo<4.0
     datastore_pymysql: PyMySQL<0.11
     datastore_pysolr: pysolr<4.0

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ envlist =
     python-framework_graphql-{py36,py37,py38,py39,pypy3}-graphql03,
     python-framework_graphql-py37-graphql{0202,0203,0300,0301,master},
     grpc-framework_grpc-{py27,py36}-grpc0125,
-    grpc-framework_grpc-{py27,py36,py37,py38,py39}-grpclatest,
+    grpc-framework_grpc-{py36,py37,py38,py39}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy3,py36,py37,py38,py39}-Pyramid0110-cornice,
     python-framework_pyramid-{pypy3,py36,py37,py38,py39}-Pyramidmaster,
@@ -152,6 +152,7 @@ deps =
     adapter_uvicorn-uvicorn014: uvicorn<0.15
     adapter_uvicorn-uvicornlatest: uvicorn
     agent_features: beautifulsoup4
+    agent_streaming-py27: protobuf<3.18.0
     application_celery: celery<6.0
     application_gearman: gearman<3.0.0
     component_djangorestframework-djangorestframework0300: Django < 1.9
@@ -259,6 +260,7 @@ deps =
     framework_graphql-graphqlmaster: https://github.com/graphql-python/graphql-core/archive/main.zip
     framework_grpc-grpc0125: grpcio<1.26
     framework_grpc-grpc0125: grpcio-tools<1.26
+    framework_grpc-grpc0125: protobuf<3.18.0
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
     framework_pyramid: routes


### PR DESCRIPTION
This PR removes testing for pymongo<3.0 due to align with the agent's three year package version support policy.