### PR TITLE
Fix notice_error Rules Matching Settings Handling

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -14,7 +14,6 @@
 
 import json
 from newrelic.common.object_names import parse_exc_info
-import newrelic.packages.six as six
 from logging import Formatter, LogRecord
 from newrelic.api.time_trace import get_linking_metadata
 from newrelic.core.config import is_expected_error
@@ -24,11 +23,16 @@ def format_exc_info(exc_info):
     _, _, fullnames, message = parse_exc_info(exc_info)
     fullname = fullnames[0]
 
-    return {
+    formatted = {
         "error.class": fullname,
         "error.message": message,
-        "error.expected": is_expected_error(exc_info),
     }
+
+    expected = is_expected_error(exc_info)
+    if expected is not None:
+        formatted["error.expected"] = expected
+
+    return formatted
 
 
 class NewRelicContextFormatter(Formatter):

--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import json
-from newrelic.common.object_names import parse_exc_info
 from logging import Formatter, LogRecord
+
 from newrelic.api.time_trace import get_linking_metadata
+from newrelic.common.object_names import parse_exc_info
 from newrelic.core.config import is_expected_error
 
 
@@ -61,7 +62,7 @@ class NewRelicContextFormatter(Formatter):
         if len(record.__dict__) > len(DEFAULT_LOG_RECORD_KEYS):
             for key in record.__dict__:
                 if key not in DEFAULT_LOG_RECORD_KEYS:
-                    output['extra.' + key] = getattr(record, key)
+                    output["extra." + key] = getattr(record, key)
 
         if record.exc_info:
             output.update(format_exc_info(record.exc_info))
@@ -76,4 +77,4 @@ class NewRelicContextFormatter(Formatter):
             except:
                 return "<unprintable %s object>" % type(object).__name__
 
-        return json.dumps(self.log_record_to_dict(record), default=safe_str, separators=(',', ':'))
+        return json.dumps(self.log_record_to_dict(record), default=safe_str, separators=(",", ":"))

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -221,9 +221,9 @@ class TimeTrace(object):
         if not exc_info or None in exc_info:
             exc_info = sys.exc_info()
 
-        # If no exception to report, exit
-        if not exc_info or None in exc_info:
-            return
+            # If no exception to report, exit
+            if not exc_info or None in exc_info:
+                return
 
         exc, value, tb = exc_info
 

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -281,7 +281,7 @@ class TimeTrace(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(exc_info, status_code=status_code)
+            should_ignore = should_ignore_error(exc_info, status_code=status_code, settings=settings)
             if should_ignore:
                 return
 
@@ -304,7 +304,7 @@ class TimeTrace(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(exc_info, status_code=status_code)
+            is_expected = is_expected_error(exc_info, status_code=status_code, settings=settings)
 
         # Record a supportability metric if error attributes are being
         # overiden.

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -390,6 +390,11 @@ class Transaction(object):
         if not self._settings:
             return
 
+        # Record error if one was registered.
+
+        if exc is not None and value is not None and tb is not None:
+            self.root_span.notice_error((exc, value, tb))
+
         self._state = self.STATE_STOPPED
 
         # Force the root span out of the cache if it's there
@@ -417,11 +422,6 @@ class Transaction(object):
                 "occurred during exit. Report this issue to New Relic support."
             )
             return
-
-        # Record error if one was registered.
-
-        if exc is not None and value is not None and tb is not None:
-            root.notice_error((exc, value, tb))
 
         # Record the end time for transaction and then
         # calculate the duration.

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -937,7 +937,7 @@ class Transaction(object):
     def _compute_sampled_and_priority(self):
         if self._priority is None:
             # truncate priority field to 6 digits past the decimal
-            self._priority = float("%.6f" % random.random())
+            self._priority = float("%.6f" % random.random())  # nosec
 
         if self._sampled is None:
             self._sampled = self._application.compute_sampled()

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -41,8 +41,8 @@ except ImportError:
 try:
     import grpc
 
-    from newrelic.core.infinite_tracing_pb2 import (
-        Span as _,  # NOQA # pylint: disable=W0611,C0412
+    from newrelic.core.infinite_tracing_pb2 import (  # pylint: disable=W0611,C0412  # noqa: F401
+        Span,
     )
 except ImportError:
     grpc = None
@@ -1034,13 +1034,12 @@ def apply_server_side_settings(server_side_config=None, settings=_settings):
     apply_config_setting(settings_snapshot, "event_harvest_config.whitelist", frozenset(harvest_limits))
 
     # Override span event harvest config
-    span_event_harvest_config = server_side_config.get('span_event_harvest_config', {})
+    span_event_harvest_config = server_side_config.get("span_event_harvest_config", {})
     span_event_harvest_limit = span_event_harvest_config.get("harvest_limit", None)
     if span_event_harvest_limit is not None:
         apply_config_setting(
-                settings_snapshot,
-                'event_harvest_config.harvest_limits.span_event_data',
-                span_event_harvest_limit)
+            settings_snapshot, "event_harvest_config.harvest_limits.span_event_data", span_event_harvest_limit
+        )
 
     # This will be removed at some future point
     # Special case for account_id which will be sent instead of

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -1157,7 +1157,9 @@ def error_matches_rules(
 
             if not settings:
                 # Unable to find rules to match with
-                _logger.error("Failed to retrieve exception rules: No settings supplied, or found on transaction or trace.")
+                _logger.error(
+                    "Failed to retrieve exception rules: No settings supplied, or found on transaction or trace."
+                )
                 return None
 
     # Retrieve settings based on prefix

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -1106,14 +1106,12 @@ def is_expected_error(
     settings=None,
 ):
     """Check if an error is expected based on rules matching. Default is False when settings lookup fails."""
-    expected = error_matches_rules(
+    return error_matches_rules(
         "expected",
         exc_info,
         status_code=status_code,
         settings=settings,
     )
-
-    return expected if expected is not None else False
 
 
 def should_ignore_error(
@@ -1122,14 +1120,12 @@ def should_ignore_error(
     settings=None,
 ):
     """Check if an error should be ignored based on rules matching. Default is True when settings lookup fails."""
-    ignored = error_matches_rules(
+    return error_matches_rules(
         "ignore",
         exc_info,
         status_code=status_code,
         settings=settings,
     )
-
-    return ignored if ignored is not None else True
 
 
 def error_matches_rules(
@@ -1154,7 +1150,7 @@ def error_matches_rules(
         settings = trace and trace.settings
 
     if not settings:
-        return None  # Default to be filled in by calling methods
+        return None  # Unable to find rules to match with
 
     # Retrieve settings based on prefix
     classes_rules = getattr(settings.error_collector, "%s_classes" % rules_prefix, set())

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -637,7 +637,7 @@ class StatsEngine(object):
 
         # Default rule matching
         if should_ignore is None:
-            should_ignore = should_ignore_error(error, status_code=status_code)
+            should_ignore = should_ignore_error(error, status_code=status_code, settings=settings)
             if should_ignore:
                 return
 
@@ -660,7 +660,7 @@ class StatsEngine(object):
 
         # Default rule matching
         if is_expected is None:
-            is_expected = is_expected_error(error, status_code=status_code)
+            is_expected = is_expected_error(error, status_code=status_code, settings=settings)
 
         # Only add attributes if High Security Mode is off.
 

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -584,9 +584,9 @@ class StatsEngine(object):
         if not error or None in error:
             error = sys.exc_info()
 
-        # If no exception to report, exit
-        if not error or None in error:
-            return
+            # If no exception to report, exit
+            if not error or None in error:
+                return
 
         exc, value, tb = error
 

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -316,7 +316,7 @@ class SampledDataSet(object):
         self.num_seen += 1
 
         if priority is None:
-            priority = random.random()
+            priority = random.random()  # nosec
 
         entry = (priority, self.num_seen, sample)
         if self.num_seen == self.capacity:

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -155,7 +155,7 @@ def test_newrelic_logger_error_inside_transaction(log_buffer):
 
     for k, v in expected.items():
         assert message.pop(k) == v
-    
+
     assert set(message.keys()) == set(expected_extra_txn_keys)
 
 

--- a/tests/agent_features/test_notice_error.py
+++ b/tests/agent_features/test_notice_error.py
@@ -193,7 +193,6 @@ class ErrorOne(Exception):
 _error_one_name = callable_name(ErrorOne)
 
 @override_application_settings(_strip_message_disabled_settings)
-@background_task()
 def test_notice_error_strip_message_disabled_outside_transaction():
     settings = application_settings()
     assert not settings.strip_exception_messages.enabled
@@ -233,7 +232,6 @@ class ErrorTwo(Exception):
 _error_two_name = callable_name(ErrorTwo)
 
 @override_application_settings(_strip_message_enabled_settings)
-@background_task()
 def test_notice_error_strip_message_enabled_outside_transaction():
     settings = application_settings()
     assert settings.strip_exception_messages.enabled
@@ -281,7 +279,6 @@ _strip_message_in_whitelist_settings_outside_transaction = {
 
 @override_application_settings(
         _strip_message_in_whitelist_settings_outside_transaction)
-@background_task()
 def test_notice_error_strip_message_in_whitelist_outside_transaction():
     settings = application_settings()
     assert settings.strip_exception_messages.enabled
@@ -330,7 +327,6 @@ _strip_message_not_in_whitelist_settings_outside_transaction = {
 
 @override_application_settings(
         _strip_message_not_in_whitelist_settings_outside_transaction)
-@background_task()
 def test_notice_error_strip_message_not_in_whitelist_outside_transaction():
     settings = application_settings()
     assert settings.strip_exception_messages.enabled

--- a/tests/agent_features/test_notice_error.py
+++ b/tests/agent_features/test_notice_error.py
@@ -14,139 +14,144 @@
 
 import sys
 
-from newrelic.api.application import (application_settings,
-        application_instance as application)
+from testing_support.fixtures import (
+    core_application_stats_engine_error,
+    error_is_saved,
+    override_application_settings,
+    reset_core_stats_engine,
+    validate_application_error_event_count,
+    validate_application_error_trace_count,
+    validate_application_errors,
+    validate_transaction_error_event_count,
+    validate_transaction_error_trace_count,
+    validate_transaction_errors,
+)
+
+from newrelic.api.application import application_instance as application
+from newrelic.api.application import application_settings
 from newrelic.api.background_task import background_task
 from newrelic.api.settings import STRIP_EXCEPTION_MESSAGE
 from newrelic.api.time_trace import notice_error
-
 from newrelic.common.object_names import callable_name
-
-from testing_support.fixtures import (validate_transaction_errors,
-        override_application_settings, core_application_stats_engine_error,
-        error_is_saved, reset_core_stats_engine, validate_application_errors,
-        validate_transaction_error_trace_count,
-        validate_application_error_trace_count,
-        validate_transaction_error_event_count,
-        validate_application_error_event_count)
-
 
 _runtime_error_name = callable_name(RuntimeError)
 _type_error_name = callable_name(TypeError)
 
 # =============== Test errors during a transaction ===============
 
-_test_notice_error_sys_exc_info = [
-        (_runtime_error_name, 'one')]
+_test_notice_error_sys_exc_info = [(_runtime_error_name, "one")]
+
 
 @validate_transaction_errors(errors=_test_notice_error_sys_exc_info)
 @background_task()
 def test_notice_error_sys_exc_info():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error(sys.exc_info())
 
-_test_notice_error_no_exc_info = [
-        (_runtime_error_name, 'one')]
+
+_test_notice_error_no_exc_info = [(_runtime_error_name, "one")]
+
 
 @validate_transaction_errors(errors=_test_notice_error_no_exc_info)
 @background_task()
 def test_notice_error_no_exc_info():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error()
 
-_test_notice_error_custom_params = [
-        (_runtime_error_name, 'one')]
 
-@validate_transaction_errors(errors=_test_notice_error_custom_params,
-        required_params=[('key', 'value')])
+_test_notice_error_custom_params = [(_runtime_error_name, "one")]
+
+
+@validate_transaction_errors(errors=_test_notice_error_custom_params, required_params=[("key", "value")])
 @background_task()
 def test_notice_error_custom_params():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
-        notice_error(sys.exc_info(), attributes={'key': 'value'})
+        notice_error(sys.exc_info(), attributes={"key": "value"})
 
-_test_notice_error_multiple_different_type = [
-        (_runtime_error_name, 'one'),
-        (_type_error_name, 'two')]
+
+_test_notice_error_multiple_different_type = [(_runtime_error_name, "one"), (_type_error_name, "two")]
+
 
 @validate_transaction_errors(errors=_test_notice_error_multiple_different_type)
 @background_task()
 def test_notice_error_multiple_different_type():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error()
 
     try:
-        raise TypeError('two')
+        raise TypeError("two")
     except TypeError:
         notice_error()
 
-_test_notice_error_multiple_same_type = [
-        (_runtime_error_name, 'one'),
-        (_runtime_error_name, 'two')]
+
+_test_notice_error_multiple_same_type = [(_runtime_error_name, "one"), (_runtime_error_name, "two")]
+
 
 @validate_transaction_errors(errors=_test_notice_error_multiple_same_type)
 @background_task()
 def test_notice_error_multiple_same_type():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error()
 
     try:
-        raise RuntimeError('two')
+        raise RuntimeError("two")
     except RuntimeError:
         notice_error()
 
+
 # =============== Test errors outside a transaction ===============
 
-_test_application_exception = [
-        (_runtime_error_name, 'one')]
+_test_application_exception = [(_runtime_error_name, "one")]
+
 
 @reset_core_stats_engine()
 @validate_application_errors(errors=_test_application_exception)
 def test_application_exception():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         application_instance = application()
         notice_error(application=application_instance)
 
-_test_application_exception_sys_exc_info = [
-        (_runtime_error_name, 'one')]
+
+_test_application_exception_sys_exc_info = [(_runtime_error_name, "one")]
+
 
 @reset_core_stats_engine()
 @validate_application_errors(errors=_test_application_exception_sys_exc_info)
 def test_application_exception_sys_exec_info():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         application_instance = application()
         notice_error(sys.exc_info(), application=application_instance)
 
-_test_application_exception_custom_params = [
-        (_runtime_error_name, 'one')]
+
+_test_application_exception_custom_params = [(_runtime_error_name, "one")]
+
 
 @reset_core_stats_engine()
-@validate_application_errors(errors=_test_application_exception_custom_params,
-        required_params=[('key', 'value')])
+@validate_application_errors(errors=_test_application_exception_custom_params, required_params=[("key", "value")])
 def test_application_exception_custom_params():
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         application_instance = application()
-        notice_error(attributes={'key': 'value'},
-                application=application_instance)
+        notice_error(attributes={"key": "value"}, application=application_instance)
 
-_test_application_exception_multiple = [
-        (_runtime_error_name, 'one'),
-        (_runtime_error_name, 'one')]
+
+_test_application_exception_multiple = [(_runtime_error_name, "one"), (_runtime_error_name, "one")]
+
 
 @reset_core_stats_engine()
 @validate_application_errors(errors=_test_application_exception_multiple)
@@ -157,23 +162,24 @@ def test_application_exception_multiple():
     """
     application_instance = application()
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error(application=application_instance)
 
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error(application=application_instance)
 
+
 # =============== Test exception message stripping/whitelisting ===============
 
-_test_notice_error_strip_message_disabled = [
-        (_runtime_error_name, 'one')]
+_test_notice_error_strip_message_disabled = [(_runtime_error_name, "one")]
 
 _strip_message_disabled_settings = {
-        'strip_exception_messages.enabled': False,
+    "strip_exception_messages.enabled": False,
 }
+
 
 @validate_transaction_errors(errors=_test_notice_error_strip_message_disabled)
 @override_application_settings(_strip_message_disabled_settings)
@@ -183,14 +189,17 @@ def test_notice_error_strip_message_disabled():
     assert not settings.strip_exception_messages.enabled
 
     try:
-        raise RuntimeError('one')
+        raise RuntimeError("one")
     except RuntimeError:
         notice_error()
 
+
 class ErrorOne(Exception):
-    message = 'error one message'
+    message = "error one message"
+
 
 _error_one_name = callable_name(ErrorOne)
+
 
 @override_application_settings(_strip_message_disabled_settings)
 def test_notice_error_strip_message_disabled_outside_transaction():
@@ -207,12 +216,13 @@ def test_notice_error_strip_message_disabled_outside_transaction():
     my_error = core_application_stats_engine_error(_error_one_name)
     assert my_error.message == ErrorOne.message
 
-_test_notice_error_strip_message_enabled = [
-        (_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
+
+_test_notice_error_strip_message_enabled = [(_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
 
 _strip_message_enabled_settings = {
-        'strip_exception_messages.enabled': True,
+    "strip_exception_messages.enabled": True,
 }
+
 
 @validate_transaction_errors(errors=_test_notice_error_strip_message_enabled)
 @override_application_settings(_strip_message_enabled_settings)
@@ -222,14 +232,17 @@ def test_notice_error_strip_message_enabled():
     assert settings.strip_exception_messages.enabled
 
     try:
-        raise RuntimeError('message not displayed')
+        raise RuntimeError("message not displayed")
     except RuntimeError:
         notice_error()
 
+
 class ErrorTwo(Exception):
-    message = 'error two message'
+    message = "error two message"
+
 
 _error_two_name = callable_name(ErrorTwo)
+
 
 @override_application_settings(_strip_message_enabled_settings)
 def test_notice_error_strip_message_enabled_outside_transaction():
@@ -246,13 +259,14 @@ def test_notice_error_strip_message_enabled_outside_transaction():
     my_error = core_application_stats_engine_error(_error_two_name)
     assert my_error.message == STRIP_EXCEPTION_MESSAGE
 
-_test_notice_error_strip_message_in_whitelist = [
-        (_runtime_error_name, 'original error message')]
+
+_test_notice_error_strip_message_in_whitelist = [(_runtime_error_name, "original error message")]
 
 _strip_message_in_whitelist_settings = {
-        'strip_exception_messages.enabled': True,
-        'strip_exception_messages.whitelist': [_runtime_error_name],
+    "strip_exception_messages.enabled": True,
+    "strip_exception_messages.whitelist": [_runtime_error_name],
 }
+
 
 @validate_transaction_errors(errors=_test_notice_error_strip_message_in_whitelist)
 @override_application_settings(_strip_message_in_whitelist_settings)
@@ -263,22 +277,24 @@ def test_notice_error_strip_message_in_whitelist():
     assert _runtime_error_name in settings.strip_exception_messages.whitelist
 
     try:
-        raise RuntimeError('original error message')
+        raise RuntimeError("original error message")
     except RuntimeError:
         notice_error()
 
+
 class ErrorThree(Exception):
-    message = 'error three message'
+    message = "error three message"
+
 
 _error_three_name = callable_name(ErrorThree)
 
 _strip_message_in_whitelist_settings_outside_transaction = {
-        'strip_exception_messages.enabled': True,
-        'strip_exception_messages.whitelist': [_error_three_name],
+    "strip_exception_messages.enabled": True,
+    "strip_exception_messages.whitelist": [_error_three_name],
 }
 
-@override_application_settings(
-        _strip_message_in_whitelist_settings_outside_transaction)
+
+@override_application_settings(_strip_message_in_whitelist_settings_outside_transaction)
 def test_notice_error_strip_message_in_whitelist_outside_transaction():
     settings = application_settings()
     assert settings.strip_exception_messages.enabled
@@ -294,13 +310,14 @@ def test_notice_error_strip_message_in_whitelist_outside_transaction():
     my_error = core_application_stats_engine_error(_error_three_name)
     assert my_error.message == ErrorThree.message
 
-_test_notice_error_strip_message_not_in_whitelist = [
-        (_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
+
+_test_notice_error_strip_message_not_in_whitelist = [(_runtime_error_name, STRIP_EXCEPTION_MESSAGE)]
 
 _strip_message_not_in_whitelist_settings = {
-        'strip_exception_messages.enabled': True,
-        'strip_exception_messages.whitelist': ['FooError', 'BarError'],
+    "strip_exception_messages.enabled": True,
+    "strip_exception_messages.whitelist": ["FooError", "BarError"],
 }
+
 
 @validate_transaction_errors(errors=_test_notice_error_strip_message_not_in_whitelist)
 @override_application_settings(_strip_message_not_in_whitelist_settings)
@@ -311,22 +328,24 @@ def test_notice_error_strip_message_not_in_whitelist():
     assert _runtime_error_name not in settings.strip_exception_messages.whitelist
 
     try:
-        raise RuntimeError('message not displayed')
+        raise RuntimeError("message not displayed")
     except RuntimeError:
         notice_error()
 
+
 class ErrorFour(Exception):
-    message = 'error four message'
+    message = "error four message"
+
 
 _error_four_name = callable_name(ErrorFour)
 
 _strip_message_not_in_whitelist_settings_outside_transaction = {
-        'strip_exception_messages.enabled': True,
-        'strip_exception_messages.whitelist': ['ValueError', 'BarError'],
+    "strip_exception_messages.enabled": True,
+    "strip_exception_messages.whitelist": ["ValueError", "BarError"],
 }
 
-@override_application_settings(
-        _strip_message_not_in_whitelist_settings_outside_transaction)
+
+@override_application_settings(_strip_message_not_in_whitelist_settings_outside_transaction)
 def test_notice_error_strip_message_not_in_whitelist_outside_transaction():
     settings = application_settings()
     assert settings.strip_exception_messages.enabled
@@ -342,14 +361,17 @@ def test_notice_error_strip_message_not_in_whitelist_outside_transaction():
     my_error = core_application_stats_engine_error(_error_four_name)
     assert my_error.message == STRIP_EXCEPTION_MESSAGE
 
+
 # =============== Test exception limits ===============
+
 
 def _raise_errors(num_errors, application=None):
     for i in range(num_errors):
         try:
-            raise RuntimeError('error'+str(i))
+            raise RuntimeError("error" + str(i))
         except RuntimeError:
             notice_error(application=application)
+
 
 _errors_per_transaction_limit = 5
 _num_errors_transaction = 6
@@ -357,42 +379,53 @@ _errors_per_harvest_limit = 20
 _num_errors_app = 26
 _error_event_limit = 25
 
-@override_application_settings(
-        {'agent_limits.errors_per_transaction': _errors_per_transaction_limit})
+
+@override_application_settings({"agent_limits.errors_per_transaction": _errors_per_transaction_limit})
 @validate_transaction_error_trace_count(_errors_per_transaction_limit)
 @background_task()
 def test_transaction_error_trace_limit():
     _raise_errors(_num_errors_transaction)
 
-@override_application_settings(
-        {'agent_limits.errors_per_harvest': _errors_per_harvest_limit})
+
+@override_application_settings({"agent_limits.errors_per_harvest": _errors_per_harvest_limit})
 @reset_core_stats_engine()
 @validate_application_error_trace_count(_errors_per_harvest_limit)
 def test_application_error_trace_limit():
     _raise_errors(_num_errors_app, application())
 
+
 # The limit for errors on transactions is shared for traces and errors
 
-@override_application_settings({
-        'agent_limits.errors_per_transaction': _errors_per_transaction_limit,
-        'error_collector.max_event_samples_stored': _error_event_limit})
+
+@override_application_settings(
+    {
+        "agent_limits.errors_per_transaction": _errors_per_transaction_limit,
+        "error_collector.max_event_samples_stored": _error_event_limit,
+    }
+)
 @validate_transaction_error_event_count(_errors_per_transaction_limit)
 @background_task()
 def test_transaction_error_event_limit():
     _raise_errors(_num_errors_transaction)
 
+
 # The harvest limit for error traces doesn't affect events
 
-@override_application_settings({
-        'agent_limits.errors_per_harvest': _errors_per_harvest_limit,
-        'event_harvest_config.harvest_limits.error_event_data':
-            _error_event_limit})
+
+@override_application_settings(
+    {
+        "agent_limits.errors_per_harvest": _errors_per_harvest_limit,
+        "event_harvest_config.harvest_limits.error_event_data": _error_event_limit,
+    }
+)
 @reset_core_stats_engine()
 @validate_application_error_event_count(_error_event_limit)
 def test_application_error_event_limit():
     _raise_errors(_num_errors_app, application())
 
+
 # =============== Test params is not a dict ===============
+
 
 @reset_core_stats_engine()
 @validate_transaction_error_trace_count(num_errors=1)
@@ -401,7 +434,8 @@ def test_transaction_notice_error_params_not_a_dict():
     try:
         raise RuntimeError()
     except RuntimeError:
-        notice_error(sys.exc_info(), attributes=[1,2,3])
+        notice_error(sys.exc_info(), attributes=[1, 2, 3])
+
 
 @reset_core_stats_engine()
 @validate_application_error_trace_count(num_errors=1)
@@ -409,5 +443,4 @@ def test_application_notice_error_params_not_a_dict():
     try:
         raise RuntimeError()
     except RuntimeError:
-        notice_error(sys.exc_info(), attributes=[1,2,3],
-                application=application())
+        notice_error(sys.exc_info(), attributes=[1, 2, 3], application=application())


### PR DESCRIPTION
# Overview
* Fix handling of settings in `error_matches_rules` to use the same settings as the call to `notice_error`, to be sure application settings are properly observed.
* Reorder `complete_root` and `notice_error` calls in `Transaction.__exit__` to fix missing settings issues.
* Remove `error.expected` attribute from logs in context IF there is no active transaction, as there is no reliable way to retrieve an application from within the context formatter otherwise.

# Related Github Issue
Closes #378

# Testing
* Modified existing tests to ensure they failed when these changes were not present.
* Added new tests for logs in context to capture inside/outside transaction behavior of errors
