### PR TITLE
Remove Smart Quotes

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -789,7 +789,9 @@ def translate_deprecated_settings(settings, cached_settings):
         # CAT Deprecation Warning
         _logger.info(
             "Deprecated setting found: cross_application_tracer.enabled. Please replace Cross Application Tracing "
-            "(CAT) with the newer Distributed Tracing by setting ‘distributed_tracing.enabled’ to True in your agent configuration. For further details on distributed tracing, please refer to our documentation: https://docs.newrelic.com/docs/distributed-tracing/concepts/distributed-tracing-planning-guide/#changes."
+            "(CAT) with the newer Distributed Tracing by setting 'distributed_tracing.enabled' to True in your agent "
+            "configuration. For further details on distributed tracing, please refer to our documentation: "
+            "https://docs.newrelic.com/docs/distributed-tracing/concepts/distributed-tracing-planning-guide/#changes."
         )
 
     if not settings.ssl:


### PR DESCRIPTION
# Overview
* Remove smart quotes from deprecation warning that caused python 2.7 import issues.

# Related Github Issue
N/A

