### PR TITLE
Fix FastAPI Context Propagation

### DIFF
--- a/newrelic/core/context.py
+++ b/newrelic/core/context.py
@@ -43,7 +43,8 @@ class ContextOf(object):
             self.trace = self.trace_cache._cache.get(trace_cache_id, None)
             if self.trace is None:
                 _logger.error(
-                    "Runtime instrumentation error. Request context propagation failed. No trace with id %s. Report this issue to New Relic support.", trace_cache_id
+                    "Runtime instrumentation error. Request context propagation failed. No trace with id %s. Report this issue to New Relic support.",
+                    trace_cache_id,
                 )
         elif hasattr(request, "_nr_trace") and request._nr_trace is not None:
             # Unpack traces from objects patched with them
@@ -56,7 +57,7 @@ class ContextOf(object):
     def __enter__(self):
         if self.trace:
             self.thread_id = self.trace_cache.current_thread_id()
-            
+
             # Save previous cache contents
             self.restore = self.trace_cache._cache.get(self.thread_id, None)
             self.should_restore = True

--- a/newrelic/core/context.py
+++ b/newrelic/core/context.py
@@ -17,7 +17,6 @@ This module implements utilities for context propagation for tracing across thre
 """
 
 import logging
-from newrelic.api.time_trace import current_trace
 
 from newrelic.common.object_wrapper import function_wrapper
 from newrelic.core.trace_cache import trace_cache
@@ -40,13 +39,12 @@ class ContextOf(object):
         elif trace is not None:
             self.trace = trace
         elif hasattr(request, "_nr_trace") and request._nr_trace is not None:
-                # Unpack traces from objects patched with them
-                self.trace = request._nr_trace
+            # Unpack traces from objects patched with them
+            self.trace = request._nr_trace
         else:
             _logger.error(
                 "Runtime instrumentation error. Request context propagation failed. No context attached to request. Report this issue to New Relic support.\n",
             )
-
 
     def __enter__(self):
         if self.trace:

--- a/newrelic/core/context.py
+++ b/newrelic/core/context.py
@@ -16,37 +16,67 @@
 This module implements utilities for context propagation for tracing across threads.
 """
 
+import logging
+from newrelic.api.time_trace import current_trace
+
 from newrelic.common.object_wrapper import function_wrapper
 from newrelic.core.trace_cache import trace_cache
 
+_logger = logging.getLogger(__name__)
+
+
 class ContextOf(object):
-    def __init__(self, trace_cache_id):
+    def __init__(self, trace=None, request=None):
+        self.trace = None
         self.trace_cache = trace_cache()
-        self.trace = self.trace_cache._cache.get(trace_cache_id)
         self.thread_id = None
-        self.restore = None
+        self.restore = False
+
+        # Extract trace if possible, else leave as None for safety
+        if trace is None and request is None:
+            _logger.error(
+                "Runtime instrumentation error. Request context propagation failed. No trace or request provided. Report this issue to New Relic support.\n",
+            )
+        elif trace is not None:
+            self.trace = trace
+        elif hasattr(request, "_nr_trace") and request._nr_trace is not None:
+                # Unpack traces from objects patched with them
+                self.trace = request._nr_trace
+        else:
+            _logger.error(
+                "Runtime instrumentation error. Request context propagation failed. No context attached to request. Report this issue to New Relic support.\n",
+            )
+
 
     def __enter__(self):
         if self.trace:
             self.thread_id = self.trace_cache.current_thread_id()
-            self.restore = self.trace_cache._cache.get(self.thread_id)
-            self.trace_cache._cache[self.thread_id] = self.trace
+
+            if self.thread_id not in self.trace_cache._cache:
+                # No active trace for current thread: continue
+                self.restore = True
+                self.trace_cache._cache[self.thread_id] = self.trace
+            elif self.trace_cache._cache[self.thread_id] is self.trace:
+                # Trace already active for this thread: ignore
+                pass
+            else:
+                _logger.error(
+                    "Runtime instrumentation error. An active trace already exists in the cache on thread_id %s. Report this issue to New Relic support.\n",
+                    current_thread_id,
+                )
+                return None
+
         return self
 
     def __exit__(self, exc, value, tb):
         if self.restore:
-            self.trace_cache._cache[self.thread_id] = self.restore
+            self.trace_cache._cache.pop(self.thread_id)
 
 
-async def context_wrapper_async(awaitable, trace_cache_id):
-    with ContextOf(trace_cache_id):
-        return await awaitable
-
-
-def context_wrapper(func, trace_cache_id):
+def context_wrapper(func, trace=None, request=None):
     @function_wrapper
     def _context_wrapper(wrapped, instance, args, kwargs):
-        with ContextOf(trace_cache_id):
+        with ContextOf(trace=trace, request=request):
             return wrapped(*args, **kwargs)
 
     return _context_wrapper(func)

--- a/newrelic/core/trace_cache.py
+++ b/newrelic/core/trace_cache.py
@@ -275,25 +275,6 @@ class TraceCache(object):
                     task = current_task(self.asyncio)
                     trace._task = task
 
-    def thread_start(self, trace):
-        current_thread_id = self.current_thread_id()
-        if current_thread_id not in self._cache:
-            self._cache[current_thread_id] = trace
-        else:
-            _logger.error(
-                "Runtime instrumentation error. An active "
-                "trace already exists in the cache on thread_id %s. Report "
-                "this issue to New Relic support.\n ",
-                current_thread_id,
-            )
-            return None
-
-        return current_thread_id
-
-    def thread_stop(self, thread_id):
-        if thread_id:
-            self._cache.pop(thread_id, None)
-
     def pop_current(self, trace):
         """Restore the trace's parent under the thread ID of the current
         executing thread."""

--- a/newrelic/hooks/adapter_asgiref.py
+++ b/newrelic/hooks/adapter_asgiref.py
@@ -1,6 +1,6 @@
 from newrelic.api.time_trace import current_trace
 from newrelic.common.object_wrapper import wrap_function_wrapper
-from newrelic.core.context import ContextOf, context_wrapper
+from newrelic.core.context import ContextOf, context_wrapper_async
 
 
 def _bind_thread_handler(loop, source_task, *args, **kwargs):
@@ -9,13 +9,13 @@ def _bind_thread_handler(loop, source_task, *args, **kwargs):
 
 def thread_handler_wrapper(wrapped, instance, args, kwargs):
     task = _bind_thread_handler(*args, **kwargs)
-    with ContextOf(id(task)):
+    with ContextOf(trace_cache_id=id(task)):
         return wrapped(*args, **kwargs)
 
 
 def main_wrap_wrapper(wrapped, instance, args, kwargs):
     awaitable = wrapped(*args, **kwargs)
-    return context_wrapper(awaitable, current_trace())
+    return context_wrapper_async(awaitable, current_trace())
 
 
 def instrument_asgiref_sync(module):

--- a/newrelic/hooks/adapter_asgiref.py
+++ b/newrelic/hooks/adapter_asgiref.py
@@ -1,6 +1,6 @@
 from newrelic.common.object_wrapper import wrap_function_wrapper
-from newrelic.core.trace_cache import trace_cache
-from newrelic.core.context import context_wrapper_async, ContextOf
+from newrelic.core.context import context_wrapper, ContextOf
+from newrelic.api.time_trace import current_trace
 
 
 def _bind_thread_handler(loop, source_task, *args, **kwargs):
@@ -15,7 +15,7 @@ def thread_handler_wrapper(wrapped, instance, args, kwargs):
 
 def main_wrap_wrapper(wrapped, instance, args, kwargs):
     awaitable = wrapped(*args, **kwargs)
-    return context_wrapper_async(awaitable, trace_cache().current_thread_id())
+    return context_wrapper(awaitable, current_trace())
 
 
 def instrument_asgiref_sync(module):

--- a/newrelic/hooks/adapter_asgiref.py
+++ b/newrelic/hooks/adapter_asgiref.py
@@ -1,6 +1,6 @@
-from newrelic.common.object_wrapper import wrap_function_wrapper
-from newrelic.core.context import context_wrapper, ContextOf
 from newrelic.api.time_trace import current_trace
+from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.core.context import ContextOf, context_wrapper
 
 
 def _bind_thread_handler(loop, source_task, *args, **kwargs):
@@ -19,7 +19,5 @@ def main_wrap_wrapper(wrapped, instance, args, kwargs):
 
 
 def instrument_asgiref_sync(module):
-    wrap_function_wrapper(module, 'SyncToAsync.thread_handler',
-        thread_handler_wrapper)
-    wrap_function_wrapper(module, 'AsyncToSync.main_wrap',
-        main_wrap_wrapper)
+    wrap_function_wrapper(module, "SyncToAsync.thread_handler", thread_handler_wrapper)
+    wrap_function_wrapper(module, "AsyncToSync.main_wrap", main_wrap_wrapper)

--- a/newrelic/hooks/framework_fastapi.py
+++ b/newrelic/hooks/framework_fastapi.py
@@ -15,23 +15,8 @@
 from copy import copy
 from newrelic.api.time_trace import current_trace
 from newrelic.api.function_trace import FunctionTraceWrapper
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import wrap_function_wrapper
 from newrelic.common.object_names import callable_name
-from newrelic.core.trace_cache import trace_cache
-
-
-def use_context(trace):
-
-    @function_wrapper
-    def context_wrapper(wrapped, instance, args, kwargs):
-        cache = trace_cache()
-        thread_id = cache.thread_start(trace)
-        try:
-            return wrapped(*args, **kwargs)
-        finally:
-            cache.thread_stop(thread_id)
-
-    return context_wrapper
 
 
 def wrap_run_endpoint_function(wrapped, instance, args, kwargs):
@@ -41,12 +26,9 @@ def wrap_run_endpoint_function(wrapped, instance, args, kwargs):
         name = callable_name(dependant.call)
         trace.transaction.set_transaction_name(name)
 
-        if not kwargs["is_coroutine"]:
-            dependant = kwargs["dependant"] = copy(dependant)
-            dependant.call = use_context(trace)(FunctionTraceWrapper(dependant.call))
-            return wrapped(*args, **kwargs)
-        else:
-            return FunctionTraceWrapper(wrapped, name=name)(*args, **kwargs)
+        dependant = kwargs["dependant"] = copy(dependant)
+        dependant.call = FunctionTraceWrapper(dependant.call)
+        return wrapped(*args, **kwargs)
 
     return wrapped(*args, **kwargs)
 

--- a/newrelic/hooks/framework_fastapi.py
+++ b/newrelic/hooks/framework_fastapi.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from copy import copy
-from newrelic.api.time_trace import current_trace
+
 from newrelic.api.function_trace import FunctionTraceWrapper
-from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.api.time_trace import current_trace
 from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import wrap_function_wrapper
 
 
 def wrap_run_endpoint_function(wrapped, instance, args, kwargs):

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ kwargs = dict(
             "git_describe_command": "git describe --dirty --tags --long --match *.*.*.*",
             "write_to": "newrelic/version.txt",
         },
-        setup_requires=["setuptools_scm>=3.2,<4"],
+        setup_requires=["setuptools_scm>=3.2,<7"],
         description = "New Relic Python Agent",
         long_description = open(readme_file).read(),
         url = "https://newrelic.com/docs/python/new-relic-for-python",

--- a/setup.py
+++ b/setup.py
@@ -14,26 +14,28 @@
 
 from __future__ import print_function
 
-import sys
 import os
+import sys
 
 python_version = sys.version_info[:2]
 
-assert python_version in ((2, 7),) or python_version >= (3, 6), \
-        'The New Relic Python agent only supports Python 2.7 and 3.6+.'
+assert python_version in ((2, 7),) or python_version >= (
+    3,
+    6,
+), "The New Relic Python agent only supports Python 2.7 and 3.6+."
 
 with_setuptools = False
 
 try:
     from setuptools import setup
+
     with_setuptools = True
 except ImportError:
     from distutils.core import setup
 
-from distutils.core import Extension
-from distutils.command.build_ext import build_ext
-from distutils.errors import (CCompilerError, DistutilsExecError,
-        DistutilsPlatformError)
+from distutils.command.build_ext import build_ext  # noqa
+from distutils.core import Extension  # noqa
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError  # noqa
 
 
 def newrelic_agent_guess_next_version(tag_version):
@@ -53,26 +55,24 @@ def newrelic_agent_next_version(version):
     if version.exact:
         return version.format_with("{tag}")
     else:
-        return version.format_next_version(
-            newrelic_agent_guess_next_version, fmt="{guessed}"
-        )
+        return version.format_next_version(newrelic_agent_guess_next_version, fmt="{guessed}")
 
 
 script_directory = os.path.dirname(__file__)
 if not script_directory:
     script_directory = os.getcwd()
 
-readme_file = os.path.join(script_directory, 'README.rst')
+readme_file = os.path.join(script_directory, "README.rst")
 
-if sys.platform == 'win32' and python_version > (2, 6):
-    build_ext_errors = (CCompilerError, DistutilsExecError,
-            DistutilsPlatformError, IOError)
+if sys.platform == "win32" and python_version > (2, 6):
+    build_ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError, IOError)
 else:
-    build_ext_errors = (CCompilerError, DistutilsExecError,
-            DistutilsPlatformError)
+    build_ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+
 
 class BuildExtFailed(Exception):
     pass
+
 
 class optional_build_ext(build_ext):
     def run(self):
@@ -87,87 +87,89 @@ class optional_build_ext(build_ext):
         except build_ext_errors:
             raise BuildExtFailed()
 
+
 packages = [
-        "newrelic",
-        "newrelic.admin",
-        "newrelic.api",
-        "newrelic.bootstrap",
-        "newrelic.common",
-        "newrelic.core",
-        "newrelic.extras",
-        "newrelic.extras.framework_django",
-        "newrelic.extras.framework_django.templatetags",
-        "newrelic.hooks",
-        "newrelic.network",
-        "newrelic/packages",
-        "newrelic/packages/urllib3",
-        "newrelic/packages/urllib3/util",
-        "newrelic/packages/urllib3/contrib",
-        "newrelic/packages/urllib3/contrib/_securetransport",
-        "newrelic/packages/urllib3/packages",
-        "newrelic/packages/urllib3/packages/backports",
-        "newrelic/packages/urllib3/packages/ssl_match_hostname",
-        "newrelic/packages/wrapt",
-        "newrelic.samplers",
+    "newrelic",
+    "newrelic.admin",
+    "newrelic.api",
+    "newrelic.bootstrap",
+    "newrelic.common",
+    "newrelic.core",
+    "newrelic.extras",
+    "newrelic.extras.framework_django",
+    "newrelic.extras.framework_django.templatetags",
+    "newrelic.hooks",
+    "newrelic.network",
+    "newrelic/packages",
+    "newrelic/packages/urllib3",
+    "newrelic/packages/urllib3/util",
+    "newrelic/packages/urllib3/contrib",
+    "newrelic/packages/urllib3/contrib/_securetransport",
+    "newrelic/packages/urllib3/packages",
+    "newrelic/packages/urllib3/packages/backports",
+    "newrelic/packages/urllib3/packages/ssl_match_hostname",
+    "newrelic/packages/wrapt",
+    "newrelic.samplers",
 ]
 
 classifiers = [
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: System :: Monitoring",
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: System :: Monitoring",
 ]
 
 kwargs = dict(
-        name = "newrelic",
-        use_scm_version={
-            "version_scheme": newrelic_agent_next_version,
-            "local_scheme": "no-local-version",
-            "git_describe_command": "git describe --dirty --tags --long --match *.*.*.*",
-            "write_to": "newrelic/version.txt",
-        },
-        setup_requires=["setuptools_scm>=3.2,<7"],
-        description = "New Relic Python Agent",
-        long_description = open(readme_file).read(),
-        url = "https://newrelic.com/docs/python/new-relic-for-python",
-        project_urls = {"Source": "https://github.com/newrelic/newrelic-python-agent"},
-        author = "New Relic",
-        author_email = "support@newrelic.com",
-        maintainer = 'New Relic',
-        maintainer_email = 'support@newrelic.com',
-        license = 'Apache-2.0',
-        zip_safe = False,
-        classifiers = classifiers,
-        packages = packages,
-        python_requires = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
-        package_data = {'newrelic': ['newrelic.ini',
-                                     'version.txt',
-                                     'packages/urllib3/LICENSE.txt',
-                                     'common/cacert.pem'],
-        },
-        scripts = [ 'scripts/newrelic-admin' ],
-        extras_require = {'infinite-tracing': ['grpcio<2', 'protobuf<4']},
+    name="newrelic",
+    use_scm_version={
+        "version_scheme": newrelic_agent_next_version,
+        "local_scheme": "no-local-version",
+        "git_describe_command": "git describe --dirty --tags --long --match *.*.*.*",
+        "write_to": "newrelic/version.txt",
+    },
+    setup_requires=["setuptools_scm>=3.2,<7"],
+    description="New Relic Python Agent",
+    long_description=open(readme_file).read(),
+    url="https://newrelic.com/docs/python/new-relic-for-python",
+    project_urls={"Source": "https://github.com/newrelic/newrelic-python-agent"},
+    author="New Relic",
+    author_email="support@newrelic.com",
+    maintainer="New Relic",
+    maintainer_email="support@newrelic.com",
+    license="Apache-2.0",
+    zip_safe=False,
+    classifiers=classifiers,
+    packages=packages,
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
+    package_data={
+        "newrelic": ["newrelic.ini", "version.txt", "packages/urllib3/LICENSE.txt", "common/cacert.pem"],
+    },
+    scripts=["scripts/newrelic-admin"],
+    extras_require={"infinite-tracing": ["grpcio<2", "protobuf<4"]},
 )
 
 if with_setuptools:
-    kwargs['entry_points'] = {
-            'console_scripts': ['newrelic-admin = newrelic.admin:main'],
-            }
+    kwargs["entry_points"] = {
+        "console_scripts": ["newrelic-admin = newrelic.admin:main"],
+    }
+
 
 def with_librt():
     try:
-        if sys.platform.startswith('linux'):
+        if sys.platform.startswith("linux"):
             import ctypes.util
-            return ctypes.util.find_library('rt')
+
+            return ctypes.util.find_library("rt")
     except Exception:
         pass
+
 
 def run_setup(with_extensions):
     def _run_setup():
@@ -180,34 +182,33 @@ def run_setup(with_extensions):
         if with_extensions:
             monotonic_libraries = []
             if with_librt():
-                monotonic_libraries = ['rt']
+                monotonic_libraries = ["rt"]
 
-            kwargs_tmp['ext_modules'] = [
-                    Extension("newrelic.packages.wrapt._wrappers",
-                        ["newrelic/packages/wrapt/_wrappers.c"]),
-                    Extension("newrelic.common._monotonic",
-                        ["newrelic/common/_monotonic.c"],
-                        libraries=monotonic_libraries),
-                    Extension("newrelic.core._thread_utilization",
-                        ["newrelic/core/_thread_utilization.c"]),
-                    ]
-            kwargs_tmp['cmdclass'] = dict(build_ext=optional_build_ext)
+            kwargs_tmp["ext_modules"] = [
+                Extension("newrelic.packages.wrapt._wrappers", ["newrelic/packages/wrapt/_wrappers.c"]),
+                Extension(
+                    "newrelic.common._monotonic", ["newrelic/common/_monotonic.c"], libraries=monotonic_libraries
+                ),
+                Extension("newrelic.core._thread_utilization", ["newrelic/core/_thread_utilization.c"]),
+            ]
+            kwargs_tmp["cmdclass"] = dict(build_ext=optional_build_ext)
 
         setup(**kwargs_tmp)
 
-    if os.environ.get('TDDIUM') is not None:
+    if os.environ.get("TDDIUM") is not None:
         try:
-            print('INFO: Running under tddium. Use lock.')
+            print("INFO: Running under tddium. Use lock.")
             from lock_file import LockFile
         except ImportError:
-            print('ERROR: Cannot import locking mechanism.')
+            print("ERROR: Cannot import locking mechanism.")
             _run_setup()
         else:
-            print('INFO: Attempting to create lock file.')
-            with LockFile('setup.lock', wait=True):
+            print("INFO: Attempting to create lock file.")
+            with LockFile("setup.lock", wait=True):
                 _run_setup()
     else:
         _run_setup()
+
 
 WARNING = """
 WARNING: The optional C extension components of the Python agent could
@@ -221,16 +222,16 @@ Pure Python versions of code supporting some features, rather than the
 optimised C versions, will also be used resulting in additional overheads.
 """
 
-with_extensions = os.environ.get('NEW_RELIC_EXTENSIONS', None)
+with_extensions = os.environ.get("NEW_RELIC_EXTENSIONS", None)
 if with_extensions:
-    if with_extensions.lower() == 'true':
+    if with_extensions.lower() == "true":
         with_extensions = True
-    elif with_extensions.lower() == 'false':
+    elif with_extensions.lower() == "false":
         with_extensions = False
     else:
         with_extensions = None
 
-if hasattr(sys, 'pypy_version_info'):
+if hasattr(sys, "pypy_version_info"):
     with_extensions = False
 
 if with_extensions is not None:
@@ -242,20 +243,20 @@ else:
 
     except BuildExtFailed:
 
-        print(75 * '*')
+        print(75 * "*")
 
         print(WARNING)
         print("INFO: Trying to build without extensions.")
 
         print()
-        print(75 * '*')
+        print(75 * "*")
 
         run_setup(with_extensions=False)
 
-        print(75 * '*')
+        print(75 * "*")
 
         print(WARNING)
         print("INFO: Only pure Python agent was installed.")
 
         print()
-        print(75 * '*')
+        print(75 * "*")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,11 @@ except ImportError:
 
 from distutils.command.build_ext import build_ext  # noqa
 from distutils.core import Extension  # noqa
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError  # noqa
+from distutils.errors import (  # noqa
+    CCompilerError,
+    DistutilsExecError,
+    DistutilsPlatformError,
+)
 
 
 def newrelic_agent_guess_next_version(tag_version):

--- a/tests/framework_fastapi/conftest.py
+++ b/tests/framework_fastapi/conftest.py
@@ -13,28 +13,33 @@
 # limitations under the License.
 
 import pytest
-
-from testing_support.fixtures import (code_coverage_fixture,
-        collector_agent_registration_fixture, collector_available_fixture)
+from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+    code_coverage_fixture,
+    collector_agent_registration_fixture,
+    collector_available_fixture,
+)
+from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+    newrelic_caplog as caplog,
+)
 
 _coverage_source = [
-    'newrelic.hooks.framework_fastapi',
+    "newrelic.hooks.framework_fastapi",
 ]
 
 code_coverage = code_coverage_fixture(source=_coverage_source)
 
 _default_settings = {
-    'transaction_tracer.explain_threshold': 0.0,
-    'transaction_tracer.transaction_threshold': 0.0,
-    'transaction_tracer.stack_trace_threshold': 0.0,
-    'debug.log_data_collector_payloads': True,
-    'debug.record_transaction_failure': True,
-    'debug.log_autorum_middleware': True,
+    "transaction_tracer.explain_threshold": 0.0,
+    "transaction_tracer.transaction_threshold": 0.0,
+    "transaction_tracer.stack_trace_threshold": 0.0,
+    "debug.log_data_collector_payloads": True,
+    "debug.record_transaction_failure": True,
+    "debug.log_autorum_middleware": True,
 }
 
 collector_agent_registration = collector_agent_registration_fixture(
-        app_name='Python Agent Test (framework_fastapi)',
-        default_settings=_default_settings)
+    app_name="Python Agent Test (framework_fastapi)", default_settings=_default_settings
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/framework_fastapi/test_application.py
+++ b/tests/framework_fastapi/test_application.py
@@ -12,19 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import pytest
+
 from testing_support.fixtures import validate_transaction_metrics
+from testing_support.fixtures import newrelic_caplog as caplog  # noqa: F401; pylint: disable=W0611
 
 
 @pytest.mark.parametrize("endpoint,transaction_name", (
     ("/sync", "_target_application:sync"),
     ("/async", "_target_application:non_sync"),
 ))
-def test_application(app, endpoint, transaction_name):
+def test_application(caplog, app, endpoint, transaction_name):
+    caplog.set_level(logging.ERROR)
     @validate_transaction_metrics(transaction_name,
         scoped_metrics=[("Function/" + transaction_name, 1)])
     def _test():
         response = app.get(endpoint)
         assert response.status == 200
+
+        # Catch context propagation error messages
+        assert not caplog.records
 
     _test()

--- a/tests/framework_fastapi/test_application.py
+++ b/tests/framework_fastapi/test_application.py
@@ -13,20 +13,22 @@
 # limitations under the License.
 
 import logging
+
 import pytest
-
 from testing_support.fixtures import validate_transaction_metrics
-from testing_support.fixtures import newrelic_caplog as caplog  # noqa: F401; pylint: disable=W0611
 
 
-@pytest.mark.parametrize("endpoint,transaction_name", (
-    ("/sync", "_target_application:sync"),
-    ("/async", "_target_application:non_sync"),
-))
+@pytest.mark.parametrize(
+    "endpoint,transaction_name",
+    (
+        ("/sync", "_target_application:sync"),
+        ("/async", "_target_application:non_sync"),
+    ),
+)
 def test_application(caplog, app, endpoint, transaction_name):
     caplog.set_level(logging.ERROR)
-    @validate_transaction_metrics(transaction_name,
-        scoped_metrics=[("Function/" + transaction_name, 1)])
+
+    @validate_transaction_metrics(transaction_name, scoped_metrics=[("Function/" + transaction_name, 1)])
     def _test():
         response = app.get(endpoint)
         assert response.status == 200

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from conftest import async_handler_support, skip_if_not_async_handler_support  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    async_handler_support,
+    skip_if_not_async_handler_support,
+)
 from testing_support.fixtures import (
     validate_transaction_errors,
     validate_transaction_metrics,

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -56,7 +56,6 @@ def test_class_based_view():
     response = application.get('/view')
     response.mustcontain('VIEW RESPONSE')
 
-@pytest.mark.xfail(reason="Currently broken in flask.")
 @skip_if_not_async_handler_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views_async:test_async_view',
@@ -82,7 +81,6 @@ def test_post_method_view():
     response = application.post('/methodview')
     response.mustcontain('METHODVIEW POST RESPONSE')
 
-@pytest.mark.xfail(reason="Currently broken in flask.")
 @skip_if_not_async_handler_support
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_views_async:test_async_methodview',

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -12,23 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-from testing_support.fixtures import (validate_transaction_metrics,
-    validate_transaction_errors, override_application_settings)
-
-from conftest import async_handler_support, skip_if_not_async_handler_support
-
+from conftest import async_handler_support, skip_if_not_async_handler_support  # pylint: disable=E0611
+from testing_support.fixtures import (
+    validate_transaction_errors,
+    validate_transaction_metrics,
+)
 
 scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/flask.app:Flask.preprocess_request", 1),
+    ("Function/flask.app:Flask.process_response", 1),
+    ("Function/flask.app:Flask.do_teardown_request", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
 ]
 
 
@@ -48,44 +46,44 @@ def target_application():
         from _test_views_async import _test_application
     return _test_application
 
+
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views:test_view',
-        scoped_metrics=scoped_metrics)
+@validate_transaction_metrics("_test_views:test_view", scoped_metrics=scoped_metrics)
 def test_class_based_view():
     application = target_application()
-    response = application.get('/view')
-    response.mustcontain('VIEW RESPONSE')
+    response = application.get("/view")
+    response.mustcontain("VIEW RESPONSE")
+
 
 @skip_if_not_async_handler_support
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views_async:test_async_view',
-        scoped_metrics=scoped_metrics)
+@validate_transaction_metrics("_test_views_async:test_async_view", scoped_metrics=scoped_metrics)
 def test_class_based_async_view():
     application = target_application()
-    response = application.get('/async_view')
-    response.mustcontain('ASYNC VIEW RESPONSE')
+    response = application.get("/async_view")
+    response.mustcontain("ASYNC VIEW RESPONSE")
+
 
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views:test_methodview',
-        scoped_metrics=scoped_metrics)
+@validate_transaction_metrics("_test_views:test_methodview", scoped_metrics=scoped_metrics)
 def test_get_method_view():
     application = target_application()
-    response = application.get('/methodview')
-    response.mustcontain('METHODVIEW GET RESPONSE')
+    response = application.get("/methodview")
+    response.mustcontain("METHODVIEW GET RESPONSE")
+
 
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views:test_methodview',
-        scoped_metrics=scoped_metrics)
+@validate_transaction_metrics("_test_views:test_methodview", scoped_metrics=scoped_metrics)
 def test_post_method_view():
     application = target_application()
-    response = application.post('/methodview')
-    response.mustcontain('METHODVIEW POST RESPONSE')
+    response = application.post("/methodview")
+    response.mustcontain("METHODVIEW POST RESPONSE")
+
 
 @skip_if_not_async_handler_support
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_views_async:test_async_methodview',
-        scoped_metrics=scoped_metrics)
+@validate_transaction_metrics("_test_views_async:test_async_methodview", scoped_metrics=scoped_metrics)
 def test_get_method_async_view():
     application = target_application()
-    response = application.get('/async_methodview')
-    response.mustcontain('ASYNC METHODVIEW GET RESPONSE')
+    response = application.get("/async_methodview")
+    response.mustcontain("ASYNC METHODVIEW GET RESPONSE")


### PR DESCRIPTION
# Overview
* A bug in context propagation resulting from instrumentation of Starlette's `run_in_threadpool` caused redundant instrumentation to issue `Runtime instrumentation error`s. This has been corrected.
* Refactor of existing context propagation to use centralized context manager API.

# Related Github Issue
Closes #419

# Testing
Negative testing done, `caplog` should be sufficient to catch regressions.
