### PR TITLE
Add service.version agent attribute.

### DIFF
--- a/newrelic/api/profile_trace.py
+++ b/newrelic/api/profile_trace.py
@@ -121,6 +121,7 @@ class ProfileTrace(object):
             try:
                 if func:
                     function_trace.add_source_code_context(func)
+                    function_trace.add_service_version()
             except Exception:
                 pass
 

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -14,6 +14,7 @@
 
 import inspect
 import logging
+import os
 import random
 import sys
 import time
@@ -54,6 +55,8 @@ class TimeTrace(object):
 
         if source is not None:
             self.add_code(source)
+
+        self.add_service_version()
 
     @property
     def transaction(self):
@@ -197,6 +200,11 @@ class TimeTrace(object):
 
         self.user_attributes[key] = value
 
+    def add_service_version(self):
+        service_version = os.environ.get("SERVICE_VERSION", None)
+        if service_version is not None:
+            self._add_agent_attribute("service.version", service_version)
+
     def add_code(self, func):
         """Extract source code context from a callable and add appropriate attributes."""
         # Fully unwrap object
@@ -229,7 +237,6 @@ class TimeTrace(object):
                 line_number = inspect.getsourcelines(func)[1]
             except TypeError:
                 pass
-
         # Add filepath attributes
         if line_number is not None:
             self._add_agent_attribute("code.lineno", line_number)

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -83,6 +83,7 @@ _TRANSACTION_EVENT_DEFAULT_ATTRIBUTES = set((
         "code.function",
         "code.lineno",
         "code.namespace",
+        "service.version",
 ))
 
 MAX_NUM_USER_ATTRIBUTES = 128

--- a/tests/agent_features/test_source_code_context.py
+++ b/tests/agent_features/test_source_code_context.py
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 import newrelic.packages.six as six
+import os
 import pytest
 
 from testing_support.validators.validate_span_events import validate_span_events
+from testing_support.fixtures import override_application_settings
+
 
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTraceWrapper
 
 from _test_source_code_context import exercise_function, CLASS_INSTANCE, exercise_lambda, ExerciseClass, __file__ as FILE_PATH
 
-
+os.environ['SERVICE_VERSION'] = '1.2.3'
 NAMESPACE = "_test_source_code_context"
 CLASS_NAMESPACE = ".".join((NAMESPACE, "ExerciseClass"))
 FUZZY_NAMESPACE = CLASS_NAMESPACE if six.PY3 else NAMESPACE
@@ -39,6 +42,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "exercise_function",
                 "code.lineno": 14,
                 "code.namespace": NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
         (  # Method
@@ -48,6 +52,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "exercise_method",
                 "code.lineno": 19,
                 "code.namespace": CLASS_NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
         (  # Static Method
@@ -57,6 +62,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "exercise_static_method",
                 "code.lineno": 22,
                 "code.namespace": FUZZY_NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
         (  # Class Method
@@ -66,6 +72,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "exercise_class_method",
                 "code.lineno": 26,
                 "code.namespace": CLASS_NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
         (  # Callable object
@@ -75,6 +82,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "__call__",
                 "code.lineno": 30,
                 "code.namespace": CLASS_NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
         (  # Lambda
@@ -84,6 +92,7 @@ if FILE_PATH.endswith(".pyc"):
                 "code.function": "<lambda>",
                 "code.lineno": 36,
                 "code.namespace": NAMESPACE,
+                "service.version": '1.2.3',
             },
         ),
     ),


### PR DESCRIPTION
This PR adds a new method (`add_service_version`) to TimeTrace that reads from a user defined `SERVICE_VERSION` env variable and sets it as an agent attribute. 

# Related Github Issue
Closes #417.
