### PR TITLE
Pin gRPC<1.40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ kwargs = dict(
         "newrelic": ["newrelic.ini", "version.txt", "packages/urllib3/LICENSE.txt", "common/cacert.pem"],
     },
     scripts=["scripts/newrelic-admin"],
-    extras_require={"infinite-tracing": ["grpcio<2", "protobuf<4"]},
+    extras_require={"infinite-tracing": ["grpcio<1.40", "protobuf<4"]},
 )
 
 if with_setuptools:


### PR DESCRIPTION
# Overview
* Due to retries becoming enabled by default, gRPC will be pinned to an earlier version until compatibility can be ensured without causing retry storms.
