### PR TITLE
Update moto version used in botocore tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -217,7 +217,7 @@ deps =
     external_boto3-boto01: moto<2.0
     external_boto3-py27: rsa<4.7.1
     external_botocore: botocore
-    external_botocore: moto[awslambda,ec2,iam]<2.0
+    external_botocore: moto[awslambda,ec2,iam]<3.0
     external_botocore-py27: rsa<4.7.1
     external_feedparser-feedparser05: feedparser<6
     external_feedparser-feedparser06: feedparser<7

--- a/tox.ini
+++ b/tox.ini
@@ -217,8 +217,9 @@ deps =
     external_boto3-boto01: moto<2.0
     external_boto3-py27: rsa<4.7.1
     external_botocore: botocore
-    external_botocore: moto[awslambda,ec2,iam]<3.0
+    external_botocore-{py36,py37,py38,py39,py310}: moto[awslambda,ec2,iam]<3.0
     external_botocore-py27: rsa<4.7.1
+    external_botocore-py27: moto[awslambda,ec2,iam]<2.0
     external_feedparser-feedparser05: feedparser<6
     external_feedparser-feedparser06: feedparser<7
     external_httplib2: httplib2<1.0


### PR DESCRIPTION
A new zone (ap-southeast-3) was [added](https://github.com/spulec/moto/commit/cf2461a14e2d9d996f093372a244a800c5670cd9 ) to moto in v2.2.19. This PR updates the version of moto installed in the botocore tests to account for this change and alleviate a `KeyError`.