### PR TITLE
Update Django tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,9 @@ envlist =
     python-framework_cherrypy-pypy3-CherryPy0303,
     python-framework_django-{pypy,py27}-Django0103,
     python-framework_django-{pypy,py27,py37}-Django0108,
-    python-framework_django-{py39}-Django{0200,0201,0202,0300,0301,latest},
+    ;temporarily disabling Django latest tests until v4 support is added to agent
+    ; python-framework_django-{py39}-Django{0200,0201,0202,0300,0301,latest},
+    python-framework_django-{py39}-Django{0200,0201,0202,0300,0301},
     python-framework_django-{py36,py37,py38,py39,py310}-Django0302,
     python-framework_falcon-{py27,py36,py37,py38,py39,pypy,pypy3}-falcon0103,
     python-framework_falcon-{py36,py37,py38,py39,py310,pypy3}-falcon{0200,master},


### PR DESCRIPTION
This PR temporarily disables testing on the latest version of Django until v4 support is added to agent.