### PR TITLE
Drop py36 testing for Tornado.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,7 @@ envlist =
     python-framework_starlette-{py36,py37,py38,py39,py310,pypy3}-starlette{latest},
     python-framework_strawberry-{py37,py38,py39,py310}-strawberrylatest,
     libcurl-framework_tornado-{py36,py37,py38,py39,py310,pypy3}-tornado0600,
-    libcurl-framework_tornado-{py36,py37,py38,py39,py310,pypy3}-tornadomaster,
+    libcurl-framework_tornado-{py37,py38,py39,py310,pypy3}-tornadomaster,
     rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,pypy,pypy3}-pika0.13,
     rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,py310,pypy,pypy3}-pikalatest,
     python-template_mako-{py27,py36,py37,py38,py39,py310}

--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,7 @@ envlist =
     python-framework_starlette-{py36,py37,py38,py39,py310,pypy3}-starlette{latest},
     python-framework_strawberry-{py37,py38,py39,py310}-strawberrylatest,
     libcurl-framework_tornado-{py36,py37,py38,py39,py310,pypy3}-tornado0600,
-    libcurl-framework_tornado-{py37,py38,py39,py310,pypy3}-tornadomaster,
+    libcurl-framework_tornado-{py37,py38,py39,py310}-tornadomaster,
     rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,pypy,pypy3}-pika0.13,
     rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,py310,pypy,pypy3}-pikalatest,
     python-template_mako-{py27,py36,py37,py38,py39,py310}


### PR DESCRIPTION
This PR drops Python 3.6 testing for Tornado. 
See: https://github.com/tornadoweb/tornado/commit/1f8aab8ba7340c7d2b146d989cfcc4e3482b0a6b