### PR TITLE
Fix Strawberry Testing Versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -301,7 +301,8 @@ deps =
     framework_starlette-starlette0014: starlette<0.15
     framework_starlette-starlette0015: starlette<0.16
     framework_starlette-starlettelatest: starlette
-    framework_strawberry: starlette
+    ; Strawberry 0.95.0 is incompatible with Starlette 0.18.0, downgrade until future release
+    framework_strawberry: starlette<0.18.0
     framework_strawberry-strawberrylatest: strawberry-graphql
     framework_tornado: pycurl
     framework_tornado-tornado0600: tornado<6.1


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Strawberry v0.95.0 is incompatible with Starlette 0.18.0.