### PR TITLE
Drop Python 3.6 testing for Pyramid master. 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,7 +129,8 @@ envlist =
     grpc-framework_grpc-{py36,py37,py38,py39,py310}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy3,py36,py37,py38,py39,py310}-Pyramid0110-cornice,
-    python-framework_pyramid-{pypy3,py37,py38,py39,py310}-Pyramidmaster,
+    ;temporarily disabling pypy3 on pyramid master
+    python-framework_pyramid-{py37,py38,py39,py310}-Pyramidmaster,
     python-framework_sanic-{py38,pypy3}-sanic{190301,1906,1812,1912,200904,210300},
     python-framework_sanic-{py36,py37,py38,py310,pypy3}-saniclatest,
     python-framework_starlette-{py36,py310,pypy3}-starlette{0014,0015},

--- a/tox.ini
+++ b/tox.ini
@@ -129,7 +129,7 @@ envlist =
     grpc-framework_grpc-{py36,py37,py38,py39,py310}-grpclatest,
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy3,py36,py37,py38,py39,py310}-Pyramid0110-cornice,
-    python-framework_pyramid-{pypy3,py36,py37,py38,py39,py310}-Pyramidmaster,
+    python-framework_pyramid-{pypy3,py37,py38,py39,py310}-Pyramidmaster,
     python-framework_sanic-{py38,pypy3}-sanic{190301,1906,1812,1912,200904,210300},
     python-framework_sanic-{py36,py37,py38,py310,pypy3}-saniclatest,
     python-framework_starlette-{py36,py310,pypy3}-starlette{0014,0015},


### PR DESCRIPTION
Pyramid has dropped support for Python 3.6 on their master branch for upcoming release as seen [here](https://github.com/Pylons/pyramid/commit/c7250ee947d2804a54a272373758150cce9db539#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7). This PR updates the Pyramid testing matrix to reflect this change. 