### PR TITLE
Fix Lost Data in gRPC (Infinite Tracing)

### DIFF
--- a/newrelic/common/streaming_utils.py
+++ b/newrelic/common/streaming_utils.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 import collections
+import logging
 import threading
 
 try:
     from newrelic.core.infinite_tracing_pb2 import AttributeValue
 except:
     AttributeValue = None
+
+_logger = logging.getLogger(__name__)
 
 
 class StreamBuffer(object):
@@ -64,18 +67,46 @@ class StreamBuffer(object):
 
         return seen, dropped
 
+    def __iter__(self):
+        return StreamBufferIterator(self)
+
+class StreamBufferIterator(object):
+
+    def __init__(self, stream_buffer):
+        self.stream_buffer = stream_buffer
+        self._notify = self.stream_buffer._notify
+        self._shutdown = False
+        self._stream = None
+
+    def shutdown(self):
+        with self._notify:
+            self._shutdown = True
+            self._notify.notify_all()
+
+    def stream_closed(self):
+        return self._shutdown or self.stream_buffer._shutdown or (self._stream and self._stream.done())
+
     def __next__(self):
-        while True:
-            if self._shutdown:
-                raise StopIteration
+        with self._notify:
+            while True:
+                # When a gRPC stream receives a server side disconnect (usually in the form of an OK code)
+                # the item it is waiting to consume from the iterator will not be sent, and will inevitably 
+                # be lost. To prevent this, StopIteration is raised by shutting down the iterator and 
+                # notifying to allow the thread to exit. Iterators cannot be reused or race conditions may
+                # occur between iterator shutdown and restart, so a new iterator must be created from the
+                # streaming buffer.
+                if self.stream_closed():
+                    _logger.debug("gRPC stream is closed. Shutting down and refusing to iterate.")
+                    if not self._shutdown:
+                        self.shutdown()
+                    raise StopIteration
 
-            try:
-                return self._queue.popleft()
-            except IndexError:
-                pass
+                try:
+                    return self.stream_buffer._queue.popleft()
+                except IndexError:
+                    pass
 
-            with self._notify:
-                if not self._shutdown and not self._queue:
+                if not self.stream_closed() and not self.stream_buffer._queue:
                     self._notify.wait()
 
     next = __next__

--- a/newrelic/common/streaming_utils.py
+++ b/newrelic/common/streaming_utils.py
@@ -25,7 +25,6 @@ _logger = logging.getLogger(__name__)
 
 
 class StreamBuffer(object):
-
     def __init__(self, maxlen):
         self._queue = collections.deque(maxlen=maxlen)
         self._notify = self.condition()
@@ -70,8 +69,8 @@ class StreamBuffer(object):
     def __iter__(self):
         return StreamBufferIterator(self)
 
-class StreamBufferIterator(object):
 
+class StreamBufferIterator(object):
     def __init__(self, stream_buffer):
         self.stream_buffer = stream_buffer
         self._notify = self.stream_buffer._notify
@@ -90,8 +89,8 @@ class StreamBufferIterator(object):
         with self._notify:
             while True:
                 # When a gRPC stream receives a server side disconnect (usually in the form of an OK code)
-                # the item it is waiting to consume from the iterator will not be sent, and will inevitably 
-                # be lost. To prevent this, StopIteration is raised by shutting down the iterator and 
+                # the item it is waiting to consume from the iterator will not be sent, and will inevitably
+                # be lost. To prevent this, StopIteration is raised by shutting down the iterator and
                 # notifying to allow the thread to exit. Iterators cannot be reused or race conditions may
                 # occur between iterator shutdown and restart, so a new iterator must be created from the
                 # streaming buffer.
@@ -121,10 +120,8 @@ class SpanProtoAttrs(dict):
         if args:
             arg = args[0]
             if len(args) > 1:
-                raise TypeError(
-                        "SpanProtoAttrs expected at most 1 argument, got %d",
-                        len(args))
-            elif hasattr(arg, 'keys'):
+                raise TypeError("SpanProtoAttrs expected at most 1 argument, got %d", len(args))
+            elif hasattr(arg, "keys"):
                 for k in arg:
                     self[k] = arg[k]
             else:
@@ -135,8 +132,7 @@ class SpanProtoAttrs(dict):
             self[k] = kwargs[k]
 
     def __setitem__(self, key, value):
-        super(SpanProtoAttrs, self).__setitem__(key,
-                SpanProtoAttrs.get_attribute_value(value))
+        super(SpanProtoAttrs, self).__setitem__(key, SpanProtoAttrs.get_attribute_value(value))
 
     def copy(self):
         copy = SpanProtoAttrs()

--- a/newrelic/core/agent_streaming.py
+++ b/newrelic/core/agent_streaming.py
@@ -48,7 +48,8 @@ class StreamingRpc(object):
         self._endpoint = endpoint
         self._ssl = ssl
         self.metadata = metadata
-        self.request_iterator = stream_buffer
+        self.stream_buffer = stream_buffer
+        self.request_iterator = iter(stream_buffer)
         self.response_processing_thread = threading.Thread(
             target=self.process_responses, name="NR-StreamingRpc-process-responses"
         )
@@ -67,6 +68,12 @@ class StreamingRpc(object):
             self.channel = grpc.insecure_channel(self._endpoint, options=self.OPTIONS)
 
         self.rpc = self.channel.stream_stream(self.PATH, Span.SerializeToString, RecordStatus.FromString)
+
+    def create_response_iterator(self):
+        with self.stream_buffer._notify:
+            self.request_iterator = iter(self.stream_buffer)
+            self.request_iterator._stream = reponse_iterator = self.rpc(self.request_iterator, metadata=self.metadata)
+            return reponse_iterator
 
     @staticmethod
     def condition(*args, **kwargs):
@@ -114,6 +121,12 @@ class StreamingRpc(object):
                             "response code. The agent will attempt "
                             "to reestablish the stream immediately."
                         )
+
+                        # Reconnect channel for load balancing
+                        self.request_iterator.shutdown()
+                        self.channel.close()
+                        self.create_channel()
+
                     else:
                         self.record_metric(
                             "Supportability/InfiniteTracing/Span/Response/Error",
@@ -153,6 +166,7 @@ class StreamingRpc(object):
                             )
 
                         # Reconnect channel with backoff
+                        self.request_iterator.shutdown()
                         self.channel.close()
                         self.notify.wait(retry_time)
                         if self.closed:
@@ -164,7 +178,8 @@ class StreamingRpc(object):
                 if self.closed:
                     break
 
-                response_iterator = self.rpc(self.request_iterator, metadata=self.metadata)
+                response_iterator = self.create_response_iterator()
+
                 _logger.info("Streaming RPC connect completed.")
 
             try:


### PR DESCRIPTION
Co-authored-by: Lalleh Rafeei <lrafeei@users.noreply.github.com>
Co-authored-by: Uma Annamalai <umaannamalai@users.noreply.github.com>
Co-authored-by: Michael Goin <michaelgoin@users.noreply.github.com>

# Overview
* Data loss with gRPC has been occurring when the data collectors issues a restart. This has been mostly mitigated with proper locking and safeguarding the stream buffer.

# Related Github Issue
N/A

# Testing
N/A