### PR TITLE
Fix GraphQL Impl Coros

### DIFF
--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -59,6 +59,7 @@ if six.PY3:
         nr_coro_execute_name_wrapper,
         nr_coro_resolver_error_wrapper,
         nr_coro_resolver_wrapper,
+        nr_coro_graphql_impl_wrapper,
     )
 
 _logger = logging.getLogger(__name__)
@@ -564,10 +565,10 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
     # Otherwise subsequent instrumentation will not be able to find an operation trace and will have issues.
     trace.__enter__()
     try:
-        result = wrapped(*args, **kwargs)
+        with ErrorTrace(ignore=ignore_graphql_duplicate_exception):
+            result = wrapped(*args, **kwargs)
     except Exception as e:
         # Execution finished synchronously, exit immediately.
-        notice_error(ignore=ignore_graphql_duplicate_exception)
         trace.__exit__(*sys.exc_info())
         raise
     else:
@@ -583,6 +584,10 @@ def wrap_graphql_impl(wrapped, instance, args, kwargs):
                 return e
 
             return result.then(on_resolve, on_reject)
+        elif isawaitable(result) and not is_promise(result):
+            # Asynchronous implementations
+            # Return a coroutine that handles closing the operation trace
+            return nr_coro_graphql_impl_wrapper(wrapped, trace, ignore_graphql_duplicate_exception, result)
         else:
             # Execution finished synchronously, exit immediately.
             trace.__exit__(None, None, None)

--- a/newrelic/hooks/framework_graphql_py3.py
+++ b/newrelic/hooks/framework_graphql_py3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
+import sys
 
 from newrelic.api.error_trace import ErrorTrace
 from newrelic.api.function_trace import FunctionTrace
@@ -49,3 +50,19 @@ def nr_coro_resolver_wrapper(wrapped, trace, ignore, result):
                 return await result
 
     return _nr_coro_resolver_wrapper()
+
+def nr_coro_graphql_impl_wrapper(wrapped, trace, ignore, result):
+    @functools.wraps(wrapped)
+    async def _nr_coro_graphql_impl_wrapper():
+        try:
+            with ErrorTrace(ignore=ignore):
+                result_ = await result
+        except:
+            trace.__exit__(*sys.exc_info())
+            raise
+        else:
+            trace.__exit__(None, None, None)
+            return result_
+
+
+    return _nr_coro_graphql_impl_wrapper()


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* The functions `graphql_impl` or `graphql` can in fact return coroutines in frameworks like Graphene. This patch correctly closes the trace after the coro executes.

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
