### PR TITLE
Fix crash in route wrappers for Starlette 0.19.1

### DIFF
--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -61,7 +61,19 @@ def bind_add_exception_handler(exc_class_or_status_code, handler, *args, **kwarg
 
 def wrap_route(wrapped, instance, args, kwargs):
     path, endpoint, args, kwargs = bind_endpoint(*args, **kwargs)
-    endpoint = route_naming_wrapper(FunctionTraceWrapper(endpoint))
+    endpoint = FunctionTraceWrapper(endpoint)
+
+    # Starlette name detection gets a bit confused with our wrappers
+    # so the get_name function should be called and the result should
+    # be cached on the wrapper.
+    try:
+        if not hasattr(endpoint, "__name__"):
+            from starlette.routing import get_name
+            endpoint.__name__ = get_name(endpoint.__wrapped__)
+    except Exception:
+        pass
+
+    endpoint = route_naming_wrapper(endpoint)
     return wrapped(path, endpoint, *args, **kwargs)
 
 


### PR DESCRIPTION
Co-authored-by: Lalleh Rafeei <lrafeei@users.noreply.github.com>
Co-authored-by: Uma Annamalai <umaannamalai@users.noreply.github.com>

_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* A crash in Starlette appeared after a change to the get_name logic for routes got confused by our wrappers. The problem should now be fixed.

# Related Github Issue

Closes #526 

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
