### PR TITLE
Pin protobuf version to < 4 (for now)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -210,6 +210,7 @@ deps =
     datastore_memcache-memcached01: python-memcached<2
     datastore_mysql-mysqllatest: mysql-connector-python
     datastore_mysql-mysql080023: mysql-connector-python<8.0.24
+    datastore_mysql: protobuf<4
     datastore_postgresql: py-postgresql<1.3
     datastore_psycopg2-psycopg20208: psycopg2-binary<2.9
     datastore_psycopg2cffi-psycopg2cffi0207: psycopg2cffi<2.8


### PR DESCRIPTION
This PR pins the protobuf version used in mysql to less than 4.  This is a temporary fix since protobuf 4.21 was released then pulled.