### PR TITLE
Fix gRPC / Protobuf incompatibilities

### DIFF
--- a/newrelic/core/agent_streaming.py
+++ b/newrelic/core/agent_streaming.py
@@ -19,8 +19,8 @@ try:
     import grpc
 
     from newrelic.core.infinite_tracing_pb2 import RecordStatus, Span
-except ImportError:
-    grpc = None
+except Exception:
+    grpc, RecordStatus, Span = None, None, None
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -38,6 +38,15 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
+try:
+    import grpc
+
+    from newrelic.core.infinite_tracing_pb2 import (  # pylint: disable=W0611,C0412  # noqa: F401
+        Span,
+    )
+except Exception:
+    grpc = None
+
 
 # By default, Transaction Events and Custom Events have the same size
 # reservoir. Error Events have a different default size.

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -38,15 +38,6 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
-try:
-    import grpc
-
-    from newrelic.core.infinite_tracing_pb2 import (  # pylint: disable=W0611,C0412  # noqa: F401
-        Span,
-    )
-except ImportError:
-    grpc = None
-
 
 # By default, Transaction Events and Custom Events have the same size
 # reservoir. Error Events have a different default size.


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
* Protobuf v4 causes issues when importing agent_streaming, even when infinite tracing is disabled and the agent is not using gRPC. 
  * Fix this issue by suppressing errors from the pb2 file at import time.
  * When v4 is stable and released, will need additional work to ensure full compatibility.

# Related Github Issue
Closes #545
