### PR TITLE
Replace deprecated threading.currentThread with threading.current_thread

### DIFF
--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -376,10 +376,7 @@ class Transaction(object):
         # actual thread and not a greenlet.
 
         if not hasattr(sys, "_current_frames") or self.thread_id in sys._current_frames():
-            try:
-                thread_instance = threading.current_thread()
-            except TypeError:
-                thread_instance = threading.currentThread()
+            thread_instance = threading.current_thread()
 
             self._utilization_tracker = utilization_tracker(self.application.name)
             if self._utilization_tracker:


### PR DESCRIPTION

# Overview

`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).


# Related GitHub Issue

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174
