### PR TITLE
ARedis Concurrency Bug Regression Test

### DIFF
--- a/tests/datastore_aredis/test_multiple_dbs.py
+++ b/tests/datastore_aredis/test_multiple_dbs.py
@@ -37,20 +37,34 @@ _disable_instance_settings = {
 # Metrics
 
 _base_scoped_metrics = (
-        ('Datastore/operation/Redis/get', 1),
-        ('Datastore/operation/Redis/set', 1),
-        ('Datastore/operation/Redis/client_list', 1),
+    ('Datastore/operation/Redis/get', 1),
+    ('Datastore/operation/Redis/set', 1),
+    ('Datastore/operation/Redis/client_list', 1),
 )
 
 _base_rollup_metrics = (
-        ('Datastore/all', 3),
-        ('Datastore/allOther', 3),
-        ('Datastore/Redis/all', 3),
-        ('Datastore/Redis/allOther', 3),
-        ('Datastore/operation/Redis/get', 1),
-        ('Datastore/operation/Redis/get', 1),
-        ('Datastore/operation/Redis/client_list', 1),
+    ('Datastore/all', 3),
+    ('Datastore/allOther', 3),
+    ('Datastore/Redis/all', 3),
+    ('Datastore/Redis/allOther', 3),
+    ('Datastore/operation/Redis/get', 1),
+    ('Datastore/operation/Redis/get', 1),
+    ('Datastore/operation/Redis/client_list', 1),
 )
+
+_concurrent_scoped_metrics = [
+    ('Datastore/operation/Redis/get', 2),
+    ('Datastore/operation/Redis/set', 2),
+]
+
+_concurrent_rollup_metrics = [
+    ('Datastore/all', 4),
+    ('Datastore/allOther', 4),
+    ('Datastore/Redis/all', 4),
+    ('Datastore/Redis/allOther', 4),
+    ('Datastore/operation/Redis/set', 2),
+    ('Datastore/operation/Redis/get', 2),
+]
 
 _disable_scoped_metrics = list(_base_scoped_metrics)
 _disable_rollup_metrics = list(_base_rollup_metrics)
@@ -81,6 +95,12 @@ if len(DB_MULTIPLE_SETTINGS) > 1:
             (instance_metric_name_2, None),
     ])
 
+    _concurrent_rollup_metrics.extend([
+            (instance_metric_name_1, 2),
+            (instance_metric_name_2, 2),
+    ])
+
+
 async def exercise_redis(client_1, client_2):
     await client_1.set('key', 'value')
     await client_1.get('key')
@@ -88,12 +108,12 @@ async def exercise_redis(client_1, client_2):
     await client_2.execute_command('CLIENT', 'LIST', parse='LIST')
 
 @pytest.mark.skipif(len(DB_MULTIPLE_SETTINGS) < 2,
-        reason='Test environment not configured with multiple databases.')
+    reason='Test environment not configured with multiple databases.')
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics('test_multiple_dbs:test_multiple_datastores_enabled',
-        scoped_metrics=_enable_scoped_metrics,
-        rollup_metrics=_enable_rollup_metrics,
-        background_task=True)
+    scoped_metrics=_enable_scoped_metrics,
+    rollup_metrics=_enable_rollup_metrics,
+    background_task=True)
 @background_task()
 def test_multiple_datastores_enabled(loop):
     redis1 = DB_MULTIPLE_SETTINGS[0]
@@ -103,13 +123,14 @@ def test_multiple_datastores_enabled(loop):
     client_2 = aredis.StrictRedis(host=redis2['host'], port=redis2['port'], db=1)
     loop.run_until_complete(exercise_redis(client_1, client_2))
 
+
 @pytest.mark.skipif(len(DB_MULTIPLE_SETTINGS) < 2,
-        reason='Test environment not configured with multiple databases.')
+    reason='Test environment not configured with multiple databases.')
 @override_application_settings(_disable_instance_settings)
 @validate_transaction_metrics('test_multiple_dbs:test_multiple_datastores_disabled',
-        scoped_metrics=_disable_scoped_metrics,
-        rollup_metrics=_disable_rollup_metrics,
-        background_task=True)
+    scoped_metrics=_disable_scoped_metrics,
+    rollup_metrics=_disable_rollup_metrics,
+    background_task=True)
 @background_task()
 def test_multiple_datastores_disabled(loop):
     redis1 = DB_MULTIPLE_SETTINGS[0]
@@ -118,3 +139,33 @@ def test_multiple_datastores_disabled(loop):
     client_1 = aredis.StrictRedis(host=redis1['host'], port=redis1['port'], db=0)
     client_2 = aredis.StrictRedis(host=redis2['host'], port=redis2['port'], db=1)
     loop.run_until_complete(exercise_redis(client_1, client_2))
+
+
+@pytest.mark.skipif(len(DB_MULTIPLE_SETTINGS) < 2,
+    reason='Test environment not configured with multiple databases.')
+@pytest.mark.xfail(reason="Demonstrates concurrency bug in async redis instrumentation.")
+@validate_transaction_metrics('test_multiple_dbs:test_concurrent_calls',
+    scoped_metrics=_concurrent_scoped_metrics,
+    rollup_metrics=_concurrent_rollup_metrics,
+    background_task=True)
+@override_application_settings(_enable_instance_settings)
+@background_task()
+def test_concurrent_calls(loop):
+    # Concurrent calls made with original instrumenation taken from synchonous Redis
+    # instrumentation had a bug where datastore info on concurrent calls to multiple instances
+    # would result in all instances reporting as the host/port of the final call made.
+
+    import asyncio
+
+    redis1 = DB_MULTIPLE_SETTINGS[0]
+    redis2 = DB_MULTIPLE_SETTINGS[1]
+
+    client_1 = aredis.StrictRedis(host=redis1['host'], port=redis1['port'], db=0)
+    client_2 = aredis.StrictRedis(host=redis2['host'], port=redis2['port'], db=1)
+    clients = (client_1, client_2)
+
+    async def exercise_concurrent():
+        await asyncio.gather(*(client.set("key-%d" % i, i) for i, client in enumerate(clients)))
+        await asyncio.gather(*(client.get("key-%d" % i) for i, client in enumerate(clients)))
+
+    loop.run_until_complete(exercise_concurrent())


### PR DESCRIPTION
# Overview
* Add a regression test that reproduces probably concurrency bugs in async redis instance reporting.

# Related Github Issue
N/A

# Testing
* This test is marked XFail to prove the existence of the bug and demonstrate a working regression test. The fix will come in a separate PR which removes the XFail marker.