### PR TITLE
Update pika tox matrix.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,7 @@ envlist =
     python-framework_sanic-{py38,pypy36}-sanic{190301,1906,1812,1912,200904,210300},
     python-framework_sanic-{py36,py37,py38,py310,pypy36}-saniclatest,
     python-framework_starlette-{py36,py310,pypy36}-starlette{0014,0015,0019},
-    python-framework_starlette-{py36,py37,py38,py39,py310,pypy36}-starlette{latest},
+    python-framework_starlette-{py36,py37,py38,py39,py310,pypy36}-starlettelatest,
     python-framework_strawberry-{py37,py38,py39,py310}-strawberrylatest,
     python-logger_logging-{py27,py36,py37,py38,py39,py310,pypy,pypy36},
     python-logger_loguru-{py36,py37,py38,py39,py310,pypy36}-logurulatest,
@@ -146,7 +146,7 @@ envlist =
     libcurl-framework_tornado-{py36,py37,py38,py39,py310,pypy36}-tornado0600,
     libcurl-framework_tornado-{py37,py38,py39,py310}-tornadomaster,
     rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,pypy,pypy36}-pika0.13,
-    rabbitmq-messagebroker_pika-{py27,py36,py37,py38,py39,py310,pypy,pypy36}-pikalatest,
+    rabbitmq-messagebroker_pika-{py36,py37,py38,py39,py310,pypy36}-pikalatest,
     python-template_mako-{py27,py36,py37,py38,py39,py310}
 
 [pytest]


### PR DESCRIPTION
Versions of pika > 1.1.0 no longer support Python 2.7. This PR updates the tox matrix to reflect these changes.
