### PR TITLE
Enable log forwarding by default.

### DIFF
--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -812,7 +812,7 @@ _settings.code_level_metrics.enabled = True
 
 _settings.application_logging.enabled = _environ_as_bool("NEW_RELIC_APPLICATION_LOGGING_ENABLED", default=True)
 _settings.application_logging.forwarding.enabled = _environ_as_bool(
-    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED", default=False
+    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED", default=True
 )
 _settings.application_logging.metrics.enabled = _environ_as_bool(
     "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED", default=True

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -2625,8 +2625,8 @@ def validate_analytics_catmap_data(name, expected_attributes=(), non_expected_at
         _new_wrapped = _capture_samples(wrapped)
 
         result = _new_wrapped(*args, **kwargs)
-
-        _samples = [s for s in samples if s[0]["type"] == "Transaction"]
+        # Check type of s[0] because it returns an integer if s is a LogEventNode
+        _samples = [s for s in samples if (type(s[0]) is not int and s[0]["type"] == "Transaction")]
         assert _samples, "No Transaction events captured."
         for sample in _samples:
             assert isinstance(sample, list)

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -2626,7 +2626,7 @@ def validate_analytics_catmap_data(name, expected_attributes=(), non_expected_at
 
         result = _new_wrapped(*args, **kwargs)
         # Check type of s[0] because it returns an integer if s is a LogEventNode
-        _samples = [s for s in samples if (type(s[0]) is not int and s[0]["type"] == "Transaction")]
+        _samples = [s for s in samples if not isinstance(s[0], int) and s[0]["type"] == "Transaction"]
         assert _samples, "No Transaction events captured."
         for sample in _samples:
             assert isinstance(sample, list)


### PR DESCRIPTION
This PR flips the switch on `application_logging.forwarding.enabled` to turn it on by default. 