### PR TITLE
Enable log forwarding by default. 

### DIFF
--- a/newrelic/common/agent_http.py
+++ b/newrelic/common/agent_http.py
@@ -524,24 +524,32 @@ class SupportabilityMixin(object):
         # *********
         # Used only for supportability metrics. Do not use to drive business
         # logic!
+        # payload: uncompressed
+        # body: compressed
         agent_method = params and params.get("method")
         # *********
 
-        if agent_method and body:
+        if agent_method and payload:
             # Compression was applied
             if compression_time is not None:
                 internal_metric(
-                    "Supportability/Python/Collector/ZLIB/Bytes/%s" % agent_method,
-                    len(payload),
+                    "Supportability/Python/Collector/%s/ZLIB/Bytes" % agent_method,
+                    len(body),
                 )
                 internal_metric(
-                    "Supportability/Python/Collector/ZLIB/Compress/%s" % agent_method,
+                    "Supportability/Python/Collector/ZLIB/Bytes", len(body)
+                )
+                internal_metric(
+                    "Supportability/Python/Collector/%s/ZLIB/Compress" % agent_method,
                     compression_time,
                 )
-
             internal_metric(
-                "Supportability/Python/Collector/Output/Bytes/%s" % agent_method,
-                len(body),
+                "Supportability/Python/Collector/%s/Output/Bytes" % agent_method,
+                len(payload),
+            )
+            # Top level metric to aggregate overall bytes being sent
+            internal_metric(
+                "Supportability/Python/Collector/Output/Bytes", len(payload)
             )
 
     @staticmethod

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -812,7 +812,7 @@ _settings.code_level_metrics.enabled = True
 
 _settings.application_logging.enabled = _environ_as_bool("NEW_RELIC_APPLICATION_LOGGING_ENABLED", default=True)
 _settings.application_logging.forwarding.enabled = _environ_as_bool(
-    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED", default=False
+    "NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED", default=True
 )
 _settings.application_logging.metrics.enabled = _environ_as_bool(
     "NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED", default=True

--- a/tests/agent_unittests/test_harvest_loop.py
+++ b/tests/agent_unittests/test_harvest_loop.py
@@ -896,7 +896,7 @@ def test_default_events_harvested(allowlist_event):
     num_seen = 0 if (allowlist_event != "span_event_data") else 1
     assert app._stats_engine.span_events.num_seen == num_seen
 
-    assert app._stats_engine.metrics_count() == 1
+    assert app._stats_engine.metrics_count() == 4
 
 
 @failing_endpoint("analytic_event_data")

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -2625,8 +2625,8 @@ def validate_analytics_catmap_data(name, expected_attributes=(), non_expected_at
         _new_wrapped = _capture_samples(wrapped)
 
         result = _new_wrapped(*args, **kwargs)
-
-        _samples = [s for s in samples if s[0]["type"] == "Transaction"]
+        # Check type of s[0] because it returns an integer if s is a LogEventNode
+        _samples = [s for s in samples if not isinstance(s[0], int) and s[0]["type"] == "Transaction"]
         assert _samples, "No Transaction events captured."
         for sample in _samples:
             assert isinstance(sample, list)


### PR DESCRIPTION
This PR enables log forwarding by default and corrects the Python agent data usage supportability metric naming scheme. It also addresses a bug related to compressed byte calculation. 