### PR TITLE
Capture module versions

### DIFF
--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -190,7 +190,7 @@ def environment_settings():
         get_version = sys.modules["importlib"].metadata.version
     elif "pkg_resources" in sys.modules:
 
-        def get_version(name):
+        def get_version(name):  # pylint: disable=function-redefined
             return sys.modules["pkg_resources"].get_distribution(name).version
 
     # Using any iterable to create a snapshot of sys.modules can occassionally

--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -191,7 +191,7 @@ def environment_settings():
     for name, module in sys.modules.copy().items():
         # If the module isn't actually loaded (such as failed relative imports
         # in Python 2.7), the module will be None and should not be reported.
-        if module is None:
+        if not module:
             continue
 
         if name.startswith("newrelic.hooks."):

--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -189,15 +189,15 @@ def environment_settings():
     # list
 
     for name, module in sys.modules.copy().items():
+        # Exclude lib.sub_paths as independent modules except for newrelic.hooks.
+        if "." in name and not name.startswith("newrelic.hooks."):
+            continue
         # If the module isn't actually loaded (such as failed relative imports
         # in Python 2.7), the module will be None and should not be reported.
         if not module:
             continue
 
-        if name.startswith("newrelic.hooks."):
-            plugins.append(name)
-
-        elif "." not in name and hasattr(module, "__file__"):
+        elif hasattr(module, "__file__"):
             # XXX This is disabled as it can cause notable overhead in
             # pathalogical cases. Will be replaced with a new system
             # where have a allowlist of packages we really want version

--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -197,7 +197,7 @@ def environment_settings():
         if name.startswith("newrelic.hooks."):
             plugins.append(name)
 
-        elif name.find(".") == -1 and hasattr(module, "__file__"):
+        elif "." not in name and hasattr(module, "__file__"):
             # XXX This is disabled as it can cause notable overhead in
             # pathalogical cases. Will be replaced with a new system
             # where have a allowlist of packages we really want version

--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -217,11 +217,6 @@ def environment_settings():
             or not module.__file__.startswith(platlib)
         ):
             continue
-        # pkg_resources is installed with setuptools and does not work on itself so
-        # skip it. importlib is part of the standard library so it is already skipped
-        # above.
-        if name.startswith("pkg_resources"):
-            continue
 
         try:
             version = get_version(name)

--- a/tests/agent_unittests/test_environment.py
+++ b/tests/agent_unittests/test_environment.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import sys
+
+import pytest
+
 from newrelic.core.environment import environment_settings
 
 
@@ -29,7 +31,7 @@ def module(version):
 
 def test_plugin_list():
     # Let's pretend we fired an import hook
-    import newrelic.hooks.adapter_gunicorn
+    import newrelic.hooks.adapter_gunicorn  # noqa: F401
 
     environment_info = environment_settings()
 
@@ -41,6 +43,8 @@ def test_plugin_list():
 
     # Check that bogus plugins don't get reported
     assert "newrelic.hooks.newrelic" not in plugin_list
+    # Check that plugin that should get reported has version info.
+    assert "pytest (%s)" % (pytest.__version__) in plugin_list
 
 
 class NoIteratorDict(object):
@@ -62,7 +66,7 @@ class NoIteratorDict(object):
 
 def test_plugin_list_uses_no_sys_modules_iterator(monkeypatch):
     modules = NoIteratorDict(sys.modules)
-    monkeypatch.setattr(sys, 'modules', modules)
+    monkeypatch.setattr(sys, "modules", modules)
 
     # If environment_settings iterates over sys.modules, an attribute error will be generated
     environment_info = environment_settings()
@@ -113,9 +117,7 @@ def test_plugin_list_uses_no_sys_modules_iterator(monkeypatch):
         ),
     ),
 )
-def test_uvicorn_dispatcher(
-    monkeypatch, loaded_modules, dispatcher, dispatcher_version, worker_version
-):
+def test_uvicorn_dispatcher(monkeypatch, loaded_modules, dispatcher, dispatcher_version, worker_version):
     # Let's pretend we load some modules
     for name, module in loaded_modules.items():
         monkeypatch.setitem(sys.modules, name, module)


### PR DESCRIPTION
# Overview
Capture third party modules and their version.

# Related Github Issue
* [Add python app modules version information to the data published to agent_lifecycle_event](https://issues.newrelic.com/browse/NR-35286)
* https://github.com/newrelic/newrelic-python-agent/issues/542
