### PR TITLE
Upgrade MegaLinter to v6

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,6 +1,6 @@
 ---
 # Mega-Linter GitHub Action configuration file
-# More info at https://megalinter.github.io
+# More info at https://oxsecurity.github.io/megalinter
 name: Mega-Linter
 
 on:
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -34,11 +34,11 @@ jobs:
       - name: Mega-Linter
         id: ml
         # You can override Mega-Linter flavor used to have faster performances
-        # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter/flavors/python@v5
+        # More info at https://oxsecurity.github.io/megalinter/flavors/
+        uses: oxsecurity/megalinter/flavors/python@v6
         env:
           # All available variables are described in documentation
-          # https://megalinter.github.io/configuration/
+          # https://oxsecurity.github.io/megalinter/configuration/
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Set 'true' if you always want to lint all sources
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
         with:
           name: Mega-Linter reports
           path: |
-            report
+            megalinter-reports
             mega-linter.log
 
       # Create pull request if applicable (for now works only on PR from same repository, not from forks)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -123,7 +123,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -178,7 +178,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -203,7 +203,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -258,7 +258,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -283,7 +283,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -359,7 +359,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -384,7 +384,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -457,7 +457,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -482,7 +482,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -550,7 +550,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -575,7 +575,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -645,7 +645,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -670,7 +670,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -738,7 +738,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -763,7 +763,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -832,7 +832,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -857,7 +857,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -925,7 +925,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -950,7 +950,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -1020,7 +1020,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -1045,7 +1045,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -1115,7 +1115,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -1140,7 +1140,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"
@@ -1207,7 +1207,7 @@ jobs:
         with:
           python-version: "pypy-2.7"
           architecture: x64
-    
+
       - uses: actions/setup-python@v3
         with:
           python-version: "3.6"
@@ -1232,7 +1232,7 @@ jobs:
         with:
           python-version: "3.10"
           architecture: x64
-          
+
       - uses: actions/setup-python@v3
         with:
           python-version: "2.7"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -240,7 +240,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -341,7 +341,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -439,7 +439,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -532,7 +532,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -627,7 +627,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -720,7 +720,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -814,7 +814,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -907,7 +907,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -1002,7 +1002,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -1097,7 +1097,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases
@@ -1189,7 +1189,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Set up all versions of python
       # Setup PyPy2 and Python 2.7 after Python 3 to prevent overwriting aliases

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Linter
-report/
+megalinter-reports/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,5 +1,5 @@
 # Configuration file for Mega-Linter
-# See all available variables at https://megalinter.github.io/configuration/ and in linters documentation
+# See all available variables at https://oxsecurity.github.io/megalinter/configuration/ and in linters documentation
 
 APPLY_FIXES: none # all, none, or list of linter keys
 DEFAULT_BRANCH: main # Usually master or main


### PR DESCRIPTION
# Overview
* Upgrade MegaLinter to v6 using automated upgrader
* Also happened to upgrade all calls to actions/checkout to v3, leaving that in as well.
