### PR TITLE
Fix django version for tastypie

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -196,9 +196,9 @@ deps =
     component_graphqlserver: jinja2<3.1
     component_tastypie-tastypie0143: django-tastypie<0.14.4
     component_tastypie-{py27,pypy}-tastypie0143: django<1.12
-    component_tastypie-{py36,py37,py38,py39,pypy36}-tastypie0143: django<3.0.1
+    component_tastypie-{py36,py37,py38,py39,py310,pypy36,pypy37}-tastypie0143: django<3.0.1
     component_tastypie-tastypielatest: django-tastypie
-    component_tastypie-tastypielatest: django
+    component_tastypie-tastypielatest: django<4.1
     coroutines_asyncio: uvloop
     cross_agent: mock==1.0.1
     cross_agent: requests


### PR DESCRIPTION
# Overview
* Django released a new version incompatible with the current TastyPie. Pinning old version.

# Testing
All tastypie tests (except PyPy3.6 which can't be installed on latest MacOS version) pass locally, probably not possible to get the GHA checks to pass right now.