### PR TITLE
Fix PyPy coroutines testing to exclude uvloop

### DIFF
--- a/tests/coroutines_asyncio/test_context_propagation.py
+++ b/tests/coroutines_asyncio/test_context_propagation.py
@@ -15,7 +15,7 @@
 import sys
 
 import pytest
-import uvloop
+
 from testing_support.fixtures import (
     function_not_called,
     override_generic_settings,
@@ -33,6 +33,14 @@ from newrelic.api.message_trace import message_trace
 from newrelic.api.time_trace import current_trace
 from newrelic.core.config import global_settings
 from newrelic.core.trace_cache import trace_cache
+
+
+# uvloop is not available on PyPy.
+try:
+    import uvloop
+    loop_policies = (None, uvloop.EventLoopPolicy())
+except ImportError:
+    loop_policies = (None,)
 
 
 @function_trace("waiter3")
@@ -88,7 +96,7 @@ async def _test(asyncio, schedule, nr_enabled=True):
     return trace
 
 
-@pytest.mark.parametrize("loop_policy", (None, uvloop.EventLoopPolicy()))
+@pytest.mark.parametrize("loop_policy", loop_policies)
 @pytest.mark.parametrize(
     "schedule",
     (

--- a/tests/coroutines_asyncio/test_context_propagation.py
+++ b/tests/coroutines_asyncio/test_context_propagation.py
@@ -15,7 +15,6 @@
 import sys
 
 import pytest
-
 from testing_support.fixtures import (
     function_not_called,
     override_generic_settings,
@@ -34,10 +33,10 @@ from newrelic.api.time_trace import current_trace
 from newrelic.core.config import global_settings
 from newrelic.core.trace_cache import trace_cache
 
-
 # uvloop is not available on PyPy.
 try:
     import uvloop
+
     loop_policies = (None, uvloop.EventLoopPolicy())
 except ImportError:
     loop_policies = (None,)

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ envlist =
     python-component_graphqlserver-{py36,py37,py38,py39,py310},
     python-component_tastypie-{py27,pypy}-tastypie0143,
     python-component_tastypie-{py36,py37,py38,py39,pypy36}-tastypie{0143,latest},
-    python-coroutines_asyncio-{py36,py37,py38,py39,py310,pypy36},
+    python-coroutines_asyncio-{py36,py37,py38,py39,py310,pypy37},
     python-cross_agent-{py27,py36,py37,py38,py39,py310}-{with,without}_extensions,
     python-cross_agent-pypy-without_extensions,
     postgres-datastore_asyncpg-{py36,py37,py38,py39,py310},
@@ -200,7 +200,7 @@ deps =
     component_tastypie-{py36,py37,py38,py39,py310,pypy36,pypy37}-tastypie0143: django<3.0.1
     component_tastypie-tastypielatest: django-tastypie
     component_tastypie-tastypielatest: django<4.1
-    coroutines_asyncio: uvloop
+    coroutines_asyncio-{py36,py37,py38,py39,py310}: uvloop
     cross_agent: mock==1.0.1
     cross_agent: requests
     datastore_asyncpg: asyncpg


### PR DESCRIPTION
# Overview
* Removes uvloop from PyPy testing for `coroutines_asyncio` as uvloop is not listed as compatible with PyPy and cannot be installed on PyPy3.7+.

# Related Github Issue
Blocks #590