### PR TITLE
Fix loguru detection of module/function name

### DIFF
--- a/newrelic/hooks/logger_loguru.py
+++ b/newrelic/hooks/logger_loguru.py
@@ -71,6 +71,10 @@ def wrap_log(wrapped, instance, args, kwargs):
     try:
         level_id, static_level_no, from_decorator, options, message, subargs, subkwargs = bind_log(*args, **kwargs)
         options[-2] = nr_log_patcher(options[-2])
+        # Loguru looks into the stack trace to find the caller's module and function names.
+        # options[1] tells loguru how far up to look in the stack trace to find the caller.
+        # Because wrap_log is an extra call in the stack trace, loguru needs to look 1 level higher.
+        options[1] += 1
     except Exception as e:
         _logger.debug("Exception in loguru handling: %s" % str(e))
         return wrapped(*args, **kwargs)

--- a/tests/logger_loguru/test_stack_inspection.py
+++ b/tests/logger_loguru/test_stack_inspection.py
@@ -1,0 +1,56 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from conftest import CaplogHandler
+
+from newrelic.api.background_task import background_task
+from testing_support.fixtures import reset_core_stats_engine
+from testing_support.validators.validate_log_event_count import validate_log_event_count
+from testing_support.validators.validate_log_events import validate_log_events
+from testing_support.fixtures import override_application_settings
+
+
+
+@pytest.fixture(scope="function")
+def filepath_logger():
+    import loguru
+    _logger = loguru.logger
+    caplog = CaplogHandler()
+    handler_id = _logger.add(caplog, level="WARNING", format="{file}:{function} - {message}")
+    _logger.caplog = caplog
+    yield _logger
+    del caplog.records[:]
+    _logger.remove(handler_id)
+
+
+@override_application_settings({
+    "application_logging.local_decorating.enabled": False,
+})
+@reset_core_stats_engine()
+def test_filepath_inspection(filepath_logger):
+    # Test for regression in stack inspection that caused log messages.
+    # See https://github.com/newrelic/newrelic-python-agent/issues/603
+
+    @validate_log_events([{"message": "A", "level": "ERROR"}])
+    @validate_log_event_count(1)
+    @background_task()
+    def test():
+        filepath_logger.error("A")
+        assert len(filepath_logger.caplog.records) == 1
+        record = filepath_logger.caplog.records[0]
+        assert record == "test_stack_inspection.py:test - A", record
+
+    test()


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Loguru looks at the stack trace to determine the caller's module and function name for logging. In the example below, we are calling `logger.info("initialized")` from inside module `__main__` in function `my_function`:
```
2022-08-04 17:28:30.883 | INFO     | __main__:my_function:7 - initialized
```
Loguru looks two levels up (`_log` <- `info` <- `my_function`) in the stacktrace. Newrelic's `loguru._logger` hook breaks this by adding one call in between (`_log` <- `wrap_log` <- `info` <- `my_function`), which causes loguru to log instead:
```
2022-08-04 17:28:30.883 | INFO     | loguru._logger:info:1977 - initialized
```
This PR fixes it by asking Loguru to look one level higher.

# Related Github Issue
https://github.com/newrelic/newrelic-python-agent/issues/603

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
