### PR TITLE
Fix PID in Memory Sampler

### DIFF
--- a/newrelic/samplers/memory_usage.py
+++ b/newrelic/samplers/memory_usage.py
@@ -21,19 +21,18 @@ import os
 from newrelic.common.system_info import physical_memory_used, total_physical_memory
 from newrelic.samplers.decorators import data_source_generator
 
-PID = os.getpid()
-
 
 @data_source_generator(name="Memory Usage")
 def memory_usage_data_source():
     memory = physical_memory_used()
     total_memory = total_physical_memory()
+    pid = os.getpid()
 
     # Calculate memory utilization without 0 division errors
     memory_utilization = (memory / total_memory) if total_memory != 0 else 0
 
     yield ("Memory/Physical", memory)
-    yield ("Memory/Physical/%d" % (PID), memory)
+    yield ("Memory/Physical/%d" % (pid), memory)
 
     yield ("Memory/Physical/Utilization", memory_utilization)
-    yield ("Memory/Physical/Utilization/%d" % (PID), memory_utilization)
+    yield ("Memory/Physical/Utilization/%d" % (pid), memory_utilization)


### PR DESCRIPTION
# Overview
* PID used in memory sampler for metric naming is incorrect in forked processes. Fixed by always getting the PID again.

# Related Github Issue
#566 
