### PR TITLE
Add support for Sanic.TouchUp metaclass

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2544,6 +2544,9 @@ def _process_module_builtin_defaults():
 
     _process_module_definition("sanic.app", "newrelic.hooks.framework_sanic", "instrument_sanic_app")
     _process_module_definition("sanic.response", "newrelic.hooks.framework_sanic", "instrument_sanic_response")
+    _process_module_definition(
+        "sanic.touchup.service", "newrelic.hooks.framework_sanic", "instrument_sanic_touchup_service"
+    )
 
     _process_module_definition("aiohttp.wsgi", "newrelic.hooks.framework_aiohttp", "instrument_aiohttp_wsgi")
     _process_module_definition("aiohttp.web", "newrelic.hooks.framework_aiohttp", "instrument_aiohttp_web")

--- a/newrelic/hooks/framework_sanic.py
+++ b/newrelic/hooks/framework_sanic.py
@@ -186,7 +186,7 @@ async def _nr_sanic_response_send(wrapped, instance, args, kwargs):
         await result
 
     if transaction is None:
-        return wrapped(*args, **kwargs)
+        return result
 
     # instance is the response object
     cat_headers = transaction.process_response(str(instance.status), instance.headers.items())

--- a/tests/framework_sanic/_target_application.py
+++ b/tests/framework_sanic/_target_application.py
@@ -93,7 +93,7 @@ except TypeError:
     error_handler = CustomErrorHandler()
 
 router = CustomRouter()
-app = Sanic(name="test app", error_handler=error_handler, router=router)
+app = Sanic(name="test-app", error_handler=error_handler, router=router)
 router.app = app
 blueprint = Blueprint("test_bp")
 

--- a/tests/framework_sanic/_target_application.py
+++ b/tests/framework_sanic/_target_application.py
@@ -209,8 +209,6 @@ async def blueprint_route(request):
 app.blueprint(blueprint)
 app.add_route(MethodView.as_view(), "/method_view")
 
-if not getattr(router, "finalized", True):
-    router.finalize()
 
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=8000)

--- a/tests/framework_sanic/_target_application.py
+++ b/tests/framework_sanic/_target_application.py
@@ -15,9 +15,16 @@
 from sanic import Blueprint, Sanic
 from sanic.exceptions import NotFound, SanicException, ServerError
 from sanic.handlers import ErrorHandler
-from sanic.response import json, stream
+from sanic.response import json
 from sanic.router import Router
 from sanic.views import HTTPMethodView
+
+
+try:
+    # Old style response streaming
+    from sanic.response import stream
+except ImportError:
+    stream = None
 
 
 class MethodView(HTTPMethodView):
@@ -139,13 +146,25 @@ async def blueprint_middleware(request):
 app.register_middleware(request_middleware)
 
 
+async def do_streaming(request):
+    if stream is not None:
+        # Old style response streaming
+        async def streaming_fn(response):
+            response.write("foo")
+            response.write("bar")
+
+        return stream(streaming_fn)
+    else:
+        # New style response streaming
+        response = await request.respond(content_type="text/plain")
+        await response.send("foo")
+        await response.send("bar")
+        await response.eof()
+
+
 @app.route("/streaming")
 async def streaming(request):
-    async def streaming_fn(response):
-        response.write("foo")
-        response.write("bar")
-
-    return stream(streaming_fn)
+    return await do_streaming(request)
 
 
 # Fake websocket endpoint to enable websockets on the server
@@ -200,11 +219,7 @@ async def async_error(request):
 
 @blueprint.route("/blueprint")
 async def blueprint_route(request):
-    async def streaming_fn(response):
-        response.write("foo")
-
-    return stream(streaming_fn)
-
+    return await do_streaming(request)
 
 app.blueprint(blueprint)
 app.add_route(MethodView.as_view(), "/method_view")

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -80,7 +80,10 @@ def create_request_class(app, method, url, headers=None, loop=None):
         proto = MockProtocol(loop=loop, app=app)
         proto.recv_buffer = bytearray()
         http = Http(proto)
-        http.init_for_request()
+        
+        if hasattr(http, "init_for_request"):
+            http.init_for_request()
+
         http.stage = Stage.HANDLER
         http.response_func = http.http1_response_header
         _request.stream = http
@@ -127,7 +130,10 @@ def request(app, method, url, headers=None):
         # Handle startup if the router hasn't been finalized.
         # Older versions don't have this requirement or variable so
         # the default should be True.
-        loop.run_until_complete(app._startup())
+        if hasattr(app, "_startup"):
+            loop.run_until_complete(app._startup())
+        else:
+            app.router.finalize()
 
     coro = create_request_coroutine(app, method, url, headers, loop)
     loop.run_until_complete(coro)

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ envlist =
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy37,py37,py38,py39,py310}-Pyramid0110-cornice,
     python-framework_pyramid-{py37,py38,py39,py310,pypy37}-Pyramidmaster,
-    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300},
+    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300,2109,2112,2203},
     python-framework_sanic-{py37,py38,py310,pypy37}-saniclatest,
     python-framework_starlette-{py310,pypy37}-starlette{0014,0015,0019},
     python-framework_starlette-{py37,py38,py39,py310,pypy37}-starlettelatest,
@@ -319,8 +319,10 @@ deps =
     framework_sanic-sanic1912: sanic<19.13
     framework_sanic-sanic200904: sanic<20.9.5
     framework_sanic-sanic210300: sanic<21.3.1
-    ; Temporarily test older sanic version until issues are resolved
-    framework_sanic-saniclatest: sanic<21.9.0
+    framework_sanic-sanic2109: sanic<21.10
+    framework_sanic-sanic2112: sanic<21.13
+    framework_sanic-sanic2203: sanic<22.4
+    framework_sanic-saniclatest: sanic
     framework_sanic-sanic{1812,190301,1906}: aiohttp
     framework_starlette: graphene<3
     framework_starlette-starlette0014: starlette<0.15

--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,7 @@ envlist =
     python-framework_pyramid-{pypy,py27,pypy37,py37,py38,py39,py310}-Pyramid0110-cornice,
     python-framework_pyramid-{py37,py38,py39,py310,pypy37}-Pyramidmaster,
     python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300,2109,2112,2203},
-    python-framework_sanic-{py37,py38,py310,pypy37}-saniclatest,
+    python-framework_sanic-{py37,py38,py39,py310,pypy37}-saniclatest,
     python-framework_starlette-{py310,pypy37}-starlette{0014,0015,0019},
     python-framework_starlette-{py37,py38,py39,py310,pypy37}-starlettelatest,
     python-framework_strawberry-{py37,py38,py39,py310}-strawberrylatest,


### PR DESCRIPTION
# Overview
Starting in [Sanic version 21.9.0](https://sanic.readthedocs.io/en/stable/sanic/changelog.html#version-21-9-0), Sanic added a TouchUp metaclass that rewrites methods on the Sanic class effectively undoing our instrumentation wrapping on startup of the server. This adds back our instrumentation wrapping after it is undone by wrapping the TouchUp metaclass.

# Related Github Issue
This fixes [To support instrumentation on Sanic 21.9 / 21.12](https://issues.newrelic.com/browse/NR-40216)

Fixes #608
