### PR TITLE
Pin protobuf to compatible version for grpc tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -320,6 +320,7 @@ deps =
     framework_grpc-grpc0125: protobuf<3.18.0
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
+    framework_grpc-grpclatest: protobuf<4
     framework_pyramid: routes
     framework_pyramid-cornice: cornice!=5.0.0
     framework_pyramid-Pyramid0104: Pyramid<1.5


### PR DESCRIPTION
# Overview
* Pin protobuf<4 to ignore compatibility issues with grpc.
