### PR TITLE
Fix app id fetch in newrelic-admin record-deploy

### DIFF
--- a/newrelic/admin/record_deploy.py
+++ b/newrelic/admin/record_deploy.py
@@ -39,7 +39,7 @@ def fetch_app_id(app_name, client, headers):
         return
 
     for application in response_json["applications"]:
-        if application["name"] == app_name:
+        if application["name"].lower() == app_name.lower():
             return application["id"]
 
 


### PR DESCRIPTION
# Overview
Newrelic treats application names as case-insensitive server-side, but `newrelic-admin record-deploy` uses case-sensitive comparison. This PR fixes that

# Related Github Issue
\-

# Testing
Manual test