### PR TITLE
Update aiohttp tests for v3.8.3.

### DIFF
--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -174,8 +174,8 @@ def multi_fetch_handler(request):
     return web.Response(text=responses, content_type='text/html')
 
 
-def make_app(middlewares=None, loop=None):
-    app = web.Application(middlewares=middlewares, loop=loop)
+def make_app(middlewares=None):
+    app = web.Application(middlewares=middlewares)
     app.router.add_route('*', '/coro', index)
     app.router.add_route('*', '/class', HelloWorldView)
     app.router.add_route('*', '/error', error)

--- a/tests/framework_aiohttp/conftest.py
+++ b/tests/framework_aiohttp/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import asyncio
 from collections import namedtuple
 
@@ -62,10 +63,17 @@ class SimpleAiohttpApp(AioHTTPTestCase):
 
     def setUp(self):
         super(SimpleAiohttpApp, self).setUp()
+        if hasattr(self, "asyncSetUp"):
+            asyncio.get_event_loop().run_until_complete(self.asyncSetUp())
         asyncio.set_event_loop(self.loop)
 
     def get_app(self, *args, **kwargs):
-        return make_app(self.middleware, loop=self.loop)
+        return make_app(self.middleware)
+
+    def tearDown(self):
+        super(SimpleAiohttpApp, self).tearDown()
+        if hasattr(self, "asyncTearDown"):
+            asyncio.get_event_loop().run_until_complete(self.asyncTearDown())
 
     @asyncio.coroutine
     def _get_client(self, app_or_server):
@@ -79,10 +87,7 @@ class SimpleAiohttpApp(AioHTTPTestCase):
             test_server = self.server_cls(app_or_server, scheme=scheme, host=host, **server_kwargs)
             client_constructor_arg = test_server
 
-        try:
-            return _TestClient(client_constructor_arg, loop=self.loop)
-        except TypeError:
-            return _TestClient(client_constructor_arg)
+        return _TestClient(client_constructor_arg)
 
     get_client = _get_client
 

--- a/tox.ini
+++ b/tox.ini
@@ -265,7 +265,7 @@ deps =
     external_requests: requests
     external_urllib3-urllib30109: urllib3<1.10
     external_urllib3-urllib3latest: urllib3
-    framework_aiohttp-aiohttp03: aiohttp==3.8.1
+    framework_aiohttp-aiohttp03: aiohttp
     framework_ariadne-ariadnelatest: ariadne
     framework_ariadne-ariadne0011: ariadne<0.12
     framework_ariadne-ariadne0012: ariadne<0.13


### PR DESCRIPTION
v3.8.3 of aiohttp includes changes to `TestClient` and `AioHTTPTestCase` in test_utils.py (both of which are utilized in our agent tests). This PR modifies the setup and teardown logic in `SimpleAiohttpApp` to be compatible with the newest aiohttp release. 
It also modifies the tox.ini to test the latest version of aiohttp instead of aiohttp<4 so we are alerted when v4 drops.