### PR TITLE
Fix celery py37 tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -193,6 +193,7 @@ deps =
     adapter_uvicorn-uvicornlatest: uvicorn
     agent_features: beautifulsoup4
     application_celery: celery<6.0
+    application_celery-py37: importlib-metadata<5.0
     application_gearman: gearman<3.0.0
     component_djangorestframework-djangorestframework0300: Django < 1.9
     component_djangorestframework-djangorestframework0300: djangorestframework < 3.1


### PR DESCRIPTION
This PR temporarily pins the `importlib-metadata` version installed for celery in Python 3.7 to resolve an import error. 

Related issue in celery repo: https://github.com/celery/celery/issues/7783