### PR TITLE
Fix instumentation for sanic 22.0.9

### DIFF
--- a/newrelic/hooks/framework_sanic.py
+++ b/newrelic/hooks/framework_sanic.py
@@ -243,7 +243,12 @@ def _nr_sanic_register_middleware_(wrapped, instance, args, kwargs):
 
     # Cache the callable_name on the middleware object
     callable_name(middleware)
-    wrapped_middleware = _nr_wrapper_middleware_(attach_to)(middleware)
+    middleware_func = middleware
+    if hasattr(middleware, "func"):
+        name = callable_name(middleware.func)
+        middleware_func = middleware.func
+
+    wrapped_middleware = _nr_wrapper_middleware_(attach_to)(middleware_func)
     wrapped(wrapped_middleware, attach_to)
     return middleware
 

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -15,13 +15,15 @@
 import asyncio
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401
+from testing_support.fixtures import (  # noqa: F401 pylint: disable=W0611
     code_coverage_fixture,
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
 
-from newrelic.common.object_wrapper import transient_function_wrapper  # noqa: F401
+from newrelic.common.object_wrapper import (  # noqa: F401 pylint: disable=W0611
+    transient_function_wrapper,
+)
 
 _coverage_source = [
     "newrelic.hooks.framework_sanic",
@@ -74,7 +76,7 @@ def create_request_class(app, method, url, headers=None, loop=None):
         from sanic.server import HttpProtocol
 
         class MockProtocol(HttpProtocol):
-            async def send(*args, **kwargs):
+            async def send(*args, **kwargs):  # pylint: disable=E0211
                 return
 
         proto = MockProtocol(loop=loop, app=app)

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -15,13 +15,13 @@
 import asyncio
 
 import pytest
-from testing_support.fixtures import (
+from testing_support.fixtures import (  # noqa: F401
     code_coverage_fixture,
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
 
-from newrelic.common.object_wrapper import transient_function_wrapper
+from newrelic.common.object_wrapper import transient_function_wrapper  # noqa: F401
 
 _coverage_source = [
     "newrelic.hooks.framework_sanic",
@@ -80,7 +80,7 @@ def create_request_class(app, method, url, headers=None, loop=None):
         proto = MockProtocol(loop=loop, app=app)
         proto.recv_buffer = bytearray()
         http = Http(proto)
-        
+
         if hasattr(http, "init_for_request"):
             http.init_for_request()
 
@@ -134,6 +134,12 @@ def request(app, method, url, headers=None):
             loop.run_until_complete(app._startup())
         else:
             app.router.finalize()
+    # Starting in 22.9.0 sanic introduced an API to control middleware ordering.
+    # This included a new method called finalize_middleware that sets the middleware
+    # to be used on the request.route during the app._startup. In order to register
+    # new middleware the finalize_middleware must be called.
+    elif hasattr(app, "finalize_middleware"):
+        app.finalize_middleware()
 
     coro = create_request_coroutine(app, method, url, headers, loop)
     loop.run_until_complete(coro)

--- a/tests/framework_sanic/test_application.py
+++ b/tests/framework_sanic/test_application.py
@@ -12,104 +12,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-import sanic
-
-from newrelic.core.config import global_settings
 from collections import deque
 
-from newrelic.api.application import application_instance
-from newrelic.api.transaction import Transaction
-from newrelic.api.external_trace import ExternalTrace
-
-from testing_support.fixtures import (validate_transaction_metrics,
-    override_application_settings, validate_transaction_errors,
+import pytest
+import sanic
+from testing_support.fixtures import (
+    function_not_called,
+    override_application_settings,
+    override_generic_settings,
+    override_ignore_status_codes,
+    validate_transaction_errors,
     validate_transaction_event_attributes,
-    override_ignore_status_codes, override_generic_settings,
-    function_not_called)
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+    validate_transaction_metrics,
+)
+from testing_support.validators.validate_code_level_metrics import (
+    validate_code_level_metrics,
+)
 
+from newrelic.api.application import application_instance
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import Transaction
+from newrelic.core.config import global_settings
 
 BASE_METRICS = [
-    ('Function/_target_application:index', 1),
-    ('Function/_target_application:request_middleware', 1 if int(sanic.__version__.split('.', 1)[0]) > 18 else 2),
+    ("Function/_target_application:index", 1),
+    ("Function/_target_application:request_middleware", 1 if int(sanic.__version__.split(".", 1)[0]) > 18 else 2),
 ]
 FRAMEWORK_METRICS = [
-    ('Python/Framework/Sanic/%s' % sanic.__version__, 1),
+    ("Python/Framework/Sanic/%s" % sanic.__version__, 1),
 ]
-BASE_ATTRS = ['response.status', 'response.headers.contentType',
-        'response.headers.contentLength']
+BASE_ATTRS = ["response.status", "response.headers.contentType", "response.headers.contentLength"]
 
 validate_base_transaction_event_attr = validate_transaction_event_attributes(
-    required_params={'agent': BASE_ATTRS, 'user': [], 'intrinsic': []},
+    required_params={"agent": BASE_ATTRS, "user": [], "intrinsic": []},
 )
 
 
 @validate_code_level_metrics("_target_application", "index")
 @validate_transaction_metrics(
-    '_target_application:index',
+    "_target_application:index",
     scoped_metrics=BASE_METRICS,
     rollup_metrics=BASE_METRICS + FRAMEWORK_METRICS,
 )
 @validate_base_transaction_event_attr
 def test_simple_request(app):
-    response = app.fetch('get', '/')
+    response = app.fetch("get", "/")
     assert response.status == 200
 
 
-@function_not_called('newrelic.core.stats_engine',
-        'StatsEngine.record_transaction')
+@function_not_called("newrelic.core.stats_engine", "StatsEngine.record_transaction")
 def test_websocket(app):
-    headers = {'upgrade': 'WebSocket'}
-    response = app.fetch('get', '/', headers=headers)
+    headers = {"upgrade": "WebSocket"}
+    response = app.fetch("get", "/", headers=headers)
     assert response.status == 200
 
 
-@pytest.mark.parametrize('method', (
-    'get',
-    'post',
-    'put',
-    'patch',
-    'delete',
-))
+@pytest.mark.parametrize(
+    "method",
+    (
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete",
+    ),
+)
 def test_method_view(app, method):
-    metric_name = 'Function/_target_application:MethodView.' + method
+    metric_name = "Function/_target_application:MethodView." + method
 
     @validate_code_level_metrics("_target_application.MethodView", method)
     @validate_transaction_metrics(
-        '_target_application:MethodView.' + method,
+        "_target_application:MethodView." + method,
         scoped_metrics=[(metric_name, 1)],
         rollup_metrics=[(metric_name, 1)],
     )
     @validate_base_transaction_event_attr
     def _test():
-        response = app.fetch(method, '/method_view')
+        response = app.fetch(method, "/method_view")
         assert response.status == 200
 
     _test()
 
 
 DT_METRICS = [
-    ('Supportability/DistributedTrace/AcceptPayload/Success', None),
-    ('Supportability/TraceContext/TraceParent/Accept/Success', 1),
+    ("Supportability/DistributedTrace/AcceptPayload/Success", None),
+    ("Supportability/TraceContext/TraceParent/Accept/Success", 1),
 ]
 
 
 @validate_transaction_metrics(
-    '_target_application:index',
+    "_target_application:index",
     scoped_metrics=BASE_METRICS,
     rollup_metrics=BASE_METRICS + DT_METRICS + FRAMEWORK_METRICS,
 )
 @validate_base_transaction_event_attr
-@override_application_settings({
-    'distributed_tracing.enabled': True,
-})
+@override_application_settings(
+    {
+        "distributed_tracing.enabled": True,
+    }
+)
 def test_inbound_distributed_trace(app):
     transaction = Transaction(application_instance())
     dt_headers = ExternalTrace.generate_request_headers(transaction)
 
-    response = app.fetch('get', '/', headers=dict(dt_headers))
+    response = app.fetch("get", "/", headers=dict(dt_headers))
     assert response.status == 200
+
 
 @pytest.mark.parametrize("endpoint", ["error", "write_response_error"])
 def test_recorded_error(app, endpoint, sanic_version):
@@ -117,34 +125,34 @@ def test_recorded_error(app, endpoint, sanic_version):
         pytest.skip()
 
     ERROR_METRICS = [
-        ('Function/_target_application:%s' % endpoint, 1),
+        ("Function/_target_application:%s" % endpoint, 1),
     ]
 
-    @validate_transaction_errors(errors=['builtins:ValueError'])
+    @validate_transaction_errors(errors=["builtins:ValueError"])
     @validate_base_transaction_event_attr
     @validate_transaction_metrics(
-        '_target_application:%s' % endpoint,
+        "_target_application:%s" % endpoint,
         scoped_metrics=ERROR_METRICS,
         rollup_metrics=ERROR_METRICS + FRAMEWORK_METRICS,
     )
     def _test():
-        if endpoint == 'write_response_error':
+        if endpoint == "write_response_error":
             with pytest.raises(ValueError):
-                response = app.fetch('get', '/' + endpoint)
+                response = app.fetch("get", "/" + endpoint)
         else:
-            response = app.fetch('get', '/' + endpoint)
+            response = app.fetch("get", "/" + endpoint)
             assert response.status == 500
 
     _test()
 
 
 NOT_FOUND_METRICS = [
-    ('Function/_target_application:not_found', 1),
+    ("Function/_target_application:not_found", 1),
 ]
 
 
 @validate_transaction_metrics(
-    '_target_application:not_found',
+    "_target_application:not_found",
     scoped_metrics=NOT_FOUND_METRICS,
     rollup_metrics=NOT_FOUND_METRICS + FRAMEWORK_METRICS,
 )
@@ -152,88 +160,90 @@ NOT_FOUND_METRICS = [
 @override_ignore_status_codes([404])
 @validate_transaction_errors(errors=[])
 def test_ignored_by_status_error(app):
-    response = app.fetch('get', '/404')
+    response = app.fetch("get", "/404")
     assert response.status == 404
 
 
 DOUBLE_ERROR_METRICS = [
-    ('Function/_target_application:zero_division_error', 1),
+    ("Function/_target_application:zero_division_error", 1),
 ]
 
 
 @validate_transaction_metrics(
-    '_target_application:zero_division_error',
+    "_target_application:zero_division_error",
     scoped_metrics=DOUBLE_ERROR_METRICS,
     rollup_metrics=DOUBLE_ERROR_METRICS,
 )
-@validate_transaction_errors(
-        errors=['builtins:ValueError', 'builtins:ZeroDivisionError'])
+@validate_transaction_errors(errors=["builtins:ValueError", "builtins:ZeroDivisionError"])
 def test_error_raised_in_error_handler(app):
     # Because of a bug in Sanic versions <0.8.0, the response.status value is
     # inconsistent. Rather than assert the status value, we rely on the
     # transaction errors validator to confirm the application acted as we'd
     # expect it to.
-    app.fetch('get', '/zero')
+    app.fetch("get", "/zero")
 
 
-STREAMING_ATTRS = ['response.status', 'response.headers.contentType']
+STREAMING_ATTRS = ["response.status", "response.headers.contentType"]
 STREAMING_METRICS = [
-    ('Function/_target_application:streaming', 1),
+    ("Function/_target_application:streaming", 1),
 ]
 
 
 @validate_code_level_metrics("_target_application", "streaming")
 @validate_transaction_metrics(
-    '_target_application:streaming',
+    "_target_application:streaming",
     scoped_metrics=STREAMING_METRICS,
     rollup_metrics=STREAMING_METRICS,
 )
 @validate_transaction_event_attributes(
-    required_params={'agent': STREAMING_ATTRS, 'user': [], 'intrinsic': []},
+    required_params={"agent": STREAMING_ATTRS, "user": [], "intrinsic": []},
 )
 def test_streaming_response(app):
     # streaming responses do not have content-length headers
-    response = app.fetch('get', '/streaming')
+    response = app.fetch("get", "/streaming")
     assert response.status == 200
 
 
 ERROR_IN_ERROR_TESTS = [
-    ('/sync-error', '_target_application:sync_error',
-        [('Function/_target_application:sync_error', 1),
-            ('Function/_target_application:handle_custom_exception_sync', 1)],
-        ['_target_application:CustomExceptionSync',
-        'sanic.exceptions:SanicException']),
-
-    ('/async-error', '_target_application:async_error',
-        [('Function/_target_application:async_error', 1),
-            ('Function/_target_application:handle_custom_exception_async', 1)],
-        ['_target_application:CustomExceptionAsync']),
+    (
+        "/sync-error",
+        "_target_application:sync_error",
+        [
+            ("Function/_target_application:sync_error", 1),
+            ("Function/_target_application:handle_custom_exception_sync", 1),
+        ],
+        ["_target_application:CustomExceptionSync", "sanic.exceptions:SanicException"],
+    ),
+    (
+        "/async-error",
+        "_target_application:async_error",
+        [
+            ("Function/_target_application:async_error", 1),
+            ("Function/_target_application:handle_custom_exception_async", 1),
+        ],
+        ["_target_application:CustomExceptionAsync"],
+    ),
 ]
 
 
-@pytest.mark.parametrize('url,metric_name,metrics,errors',
-        ERROR_IN_ERROR_TESTS)
-@pytest.mark.parametrize('nr_enabled', (True, False))
-def test_errors_in_error_handlers(
-        nr_enabled, app, url, metric_name, metrics, errors):
+@pytest.mark.parametrize("url,metric_name,metrics,errors", ERROR_IN_ERROR_TESTS)
+@pytest.mark.parametrize("nr_enabled", (True, False))
+def test_errors_in_error_handlers(nr_enabled, app, url, metric_name, metrics, errors):
     settings = global_settings()
 
-    @override_generic_settings(settings, {'enabled': nr_enabled})
+    @override_generic_settings(settings, {"enabled": nr_enabled})
     def _test():
         # Because of a bug in Sanic versions <0.8.0, the response.status value
         # is inconsistent. Rather than assert the status value, we rely on the
         # transaction errors validator to confirm the application acted as we'd
         # expect it to.
-        app.fetch('get', url)
+        app.fetch("get", url)
 
     if nr_enabled:
         _test = validate_transaction_errors(errors=errors)(_test)
-        _test = validate_transaction_metrics(metric_name,
-                scoped_metrics=metrics,
-                rollup_metrics=metrics)(_test)
+        _test = validate_transaction_metrics(metric_name, scoped_metrics=metrics, rollup_metrics=metrics)(_test)
     else:
-        _test = function_not_called('newrelic.core.stats_engine',
-            'StatsEngine.record_transaction')(_test)
+        _test = function_not_called("newrelic.core.stats_engine", "StatsEngine.record_transaction")(_test)
 
     _test()
 
@@ -241,63 +251,82 @@ def test_errors_in_error_handlers(
 def test_no_transaction_when_nr_disabled(app):
     settings = global_settings()
 
-    @function_not_called('newrelic.core.stats_engine',
-            'StatsEngine.record_transaction')
-    @override_generic_settings(settings, {'enabled': False})
+    @function_not_called("newrelic.core.stats_engine", "StatsEngine.record_transaction")
+    @override_generic_settings(settings, {"enabled": False})
     def _test():
-        app.fetch('GET', '/')
+        app.fetch("GET", "/")
 
     _test()
 
 
 async def async_returning_middleware(*args, **kwargs):
     from sanic.response import json
-    return json({'oops': 'I returned it again'})
+
+    return json({"oops": "I returned it again"})
 
 
 def sync_returning_middleware(*args, **kwargs):
     from sanic.response import json
-    return json({'oops': 'I returned it again'})
+
+    return json({"oops": "I returned it again"})
 
 
 def sync_failing_middleware(*args, **kwargs):
     from sanic.exceptions import SanicException
-    raise SanicException('Everything is ok', status_code=200)
+
+    raise SanicException("Everything is ok", status_code=200)
 
 
-@pytest.mark.parametrize('middleware,attach_to,metric_name,transaction_name', [
-    (async_returning_middleware, 'request',
-        'test_application:async_returning_middleware',
-        'test_application:async_returning_middleware'),
-    (sync_returning_middleware, 'request',
-        'test_application:sync_returning_middleware',
-        'test_application:sync_returning_middleware'),
-    (sync_failing_middleware, 'request',
-        'test_application:sync_failing_middleware',
-        'test_application:sync_failing_middleware'),
-    (async_returning_middleware, 'response',
-        'test_application:async_returning_middleware',
-        '_target_application:index'),
-    (sync_returning_middleware, 'response',
-        'test_application:sync_returning_middleware',
-        '_target_application:index'),
-])
-def test_returning_middleware(app, middleware, attach_to, metric_name,
-        transaction_name):
+@pytest.mark.parametrize(
+    "middleware,attach_to,metric_name,transaction_name",
+    [
+        (
+            async_returning_middleware,
+            "request",
+            "test_application:async_returning_middleware",
+            "test_application:async_returning_middleware",
+        ),
+        (
+            sync_returning_middleware,
+            "request",
+            "test_application:sync_returning_middleware",
+            "test_application:sync_returning_middleware",
+        ),
+        (
+            sync_failing_middleware,
+            "request",
+            "test_application:sync_failing_middleware",
+            "test_application:sync_failing_middleware",
+        ),
+        (
+            async_returning_middleware,
+            "response",
+            "test_application:async_returning_middleware",
+            "_target_application:index",
+        ),
+        (
+            sync_returning_middleware,
+            "response",
+            "test_application:sync_returning_middleware",
+            "_target_application:index",
+        ),
+    ],
+)
+def test_returning_middleware(app, middleware, attach_to, metric_name, transaction_name):
 
     metrics = [
-        ('Function/%s' % metric_name, 1),
+        ("Function/%s" % metric_name, 1),
     ]
 
     @validate_code_level_metrics(*metric_name.split(":"))
     @validate_transaction_metrics(
-            transaction_name,
-            scoped_metrics=metrics,
-            rollup_metrics=metrics,
+        transaction_name,
+        scoped_metrics=metrics,
+        rollup_metrics=metrics,
     )
     @validate_base_transaction_event_attr
     def _test():
-        response = app.fetch('get', '/')
+        response = app.fetch("get", "/")
         assert response.status == 200
 
     original_request_middleware = deque(app.app.request_middleware)
@@ -316,17 +345,17 @@ def error_middleware(*args, **kwargs):
 
 
 def test_errors_in_middleware(app):
-    metrics = [('Function/test_application:error_middleware', 1)]
+    metrics = [("Function/test_application:error_middleware", 1)]
 
     @validate_transaction_metrics(
-            'test_application:error_middleware',
-            scoped_metrics=metrics,
-            rollup_metrics=metrics,
+        "test_application:error_middleware",
+        scoped_metrics=metrics,
+        rollup_metrics=metrics,
     )
     @validate_base_transaction_event_attr
-    @validate_transaction_errors(errors=['builtins:ValueError'])
+    @validate_transaction_errors(errors=["builtins:ValueError"])
     def _test():
-        response = app.fetch('get', '/')
+        response = app.fetch("get", "/")
         assert response.status == 500
 
     original_request_middleware = deque(app.app.request_middleware)
@@ -355,35 +384,38 @@ BLUEPRINT_METRICS = [
 )
 @validate_transaction_errors(errors=[])
 def test_blueprint_middleware(app):
-    response = app.fetch('get', '/blueprint')
+    response = app.fetch("get", "/blueprint")
     assert response.status == 200
 
 
-def test_unknown_route(app):
-    import sanic
-    sanic_version = [int(x) for x in sanic.__version__.split(".")]
-    _tx_name = "_target_application:CustomRouter.get" if sanic_version[0] < 21 else "_target_application:request_middleware"
+def test_unknown_route(app, sanic_version):
+    _tx_name = (
+        "_target_application:CustomRouter.get" if sanic_version[0] < 21 else "_target_application:request_middleware"
+    )
 
     @validate_transaction_metrics(_tx_name)
     def _test():
-        response = app.fetch('get', '/what-route')
+        response = app.fetch("get", "/what-route")
         assert response.status == 404
 
     _test()
 
-def test_bad_method(app):
-    import sanic
-    sanic_version = [int(x) for x in sanic.__version__.split(".")]
-    _tx_name = "_target_application:CustomRouter.get" if sanic_version[0] < 21 else "_target_application:request_middleware"
+
+def test_bad_method(app, sanic_version):
+    _tx_name = (
+        "_target_application:CustomRouter.get" if sanic_version[0] < 21 else "_target_application:request_middleware"
+    )
 
     @validate_transaction_metrics(_tx_name)
     @override_ignore_status_codes([405])
     @validate_transaction_errors(errors=[])
     def _test():
-        response = app.fetch('post', '/')
+        response = app.fetch("post", "/")
         assert response.status == 405
+
     _test()
+
 
 @pytest.fixture
 def sanic_version():
-    return tuple([int(v) for v in sanic.__version__.split(".")])
+    return tuple(int(v) for v in sanic.__version__.split("."))

--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,7 @@ envlist =
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy37,py37,py38,py39,py310}-Pyramid0110-cornice,
     python-framework_pyramid-{py37,py38,py39,py310,pypy37}-Pyramidmaster,
-    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300,2109,2112,2203},
+    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300,2109,2112,2203,2290},
     python-framework_sanic-{py37,py38,py39,py310,pypy37}-saniclatest,
     python-framework_starlette-{py310,pypy37}-starlette{0014,0015,0019},
     python-framework_starlette-{py37,py38}-starlette{002001},
@@ -337,8 +337,8 @@ deps =
     framework_sanic-sanic2109: sanic<21.10
     framework_sanic-sanic2112: sanic<21.13
     framework_sanic-sanic2203: sanic<22.4
-    ; Temporarily pin this to the second to last release
-    framework_sanic-saniclatest: sanic==22.6.2
+    framework_sanic-sanic2290: sanic<22.9.1
+    framework_sanic-saniclatest: sanic
     framework_sanic-sanic{1812,190301,1906}: aiohttp
     framework_starlette: graphene<3
     framework_starlette-starlette0014: starlette<0.15


### PR DESCRIPTION
# Overview
Fix instumentation for sanic 22.0.9

In 22.9.0 sanic introduced an API to control middleware ordering which broke 2 things:
* The addition of the new middleware mixin included a new method called `finalize_middleware` that sets the middleware to be used on the request.route during the `app._startup`. In order to register new middleware the `finalize_middleware` must be called, otherwise the app will use the previously registered middleware that was registered before `app._startup`.
* The middleware mixin wrapped certain middleware functions causing the name of the transaction and function trace to be the name of the mixin instead of the middleware function.

# Related Github Issue
https://issues.newrelic.com/browse/NR-53906
