### PR TITLE
Support confluent-kafka produce arguments

### DIFF
--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -66,12 +66,7 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         dt_headers = [(k, v.encode("utf-8")) for k, v in trace.generate_request_headers(transaction)]
         dt_headers.extend(headers if headers else [])
         try:
-            return wrapped(
-                topic,
-                *args,
-                headers=dt_headers,
-                **kwargs,
-            )
+            return wrapped(topic, headers=dt_headers, *args, **kwargs)
         except Exception as error:
             # Unwrap kafka errors
             while hasattr(error, "exception"):

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -63,8 +63,9 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         destination_name=topic or "Default",
         source=wrapped,
     ) as trace:
-        dt_headers = [(k, v.encode("utf-8")) for k, v in trace.generate_request_headers(transaction)]
-        dt_headers.extend(headers if headers else [])
+        dt_headers = {k: v.encode("utf-8") for k, v in trace.generate_request_headers(transaction)}
+        # headers can be a list of tuples or a dict so convert to dict for consistency.
+        dt_headers.update(dict(headers) if headers else {})
         try:
             return wrapped(topic, headers=dt_headers, *args, **kwargs)
         except Exception as error:

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -33,17 +33,28 @@ HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 
 
-def _bind_Producer_produce(topic, value=None, key=None, partition=-1, on_delivery=None, timestamp=0, headers=None):
-    return topic, value, key, partition, on_delivery, timestamp, headers
-
-
 def wrap_Producer_produce(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     if transaction is None:
         return wrapped(*args, **kwargs)
 
-    topic, value, key, partition, on_delivery, timestamp, headers = _bind_Producer_produce(*args, **kwargs)
-    headers = list(headers) if headers else []
+    # Binding with a standard function signature does not work properly due to a bug in handling arguments
+    # in the underlying C code, where callback=None being specified causes on_delivery=callback to never run.
+
+    # Bind out headers from end of args list
+    if len(args) == 8:
+        # Take headers off the end of the positional args
+        headers = args[7]
+        args = args[0:7]
+    else:
+        headers = kwargs.pop("headers", [])
+
+    # Bind topic off of the beginning of the args list
+    if len(args) >= 1:
+        topic = args[0]
+        args = args[1:]
+    else:
+        topic = kwargs.get("topic", None)
 
     with MessageTrace(
         library="Kafka",
@@ -53,16 +64,13 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         source=wrapped,
     ) as trace:
         dt_headers = [(k, v.encode("utf-8")) for k, v in trace.generate_request_headers(transaction)]
-        headers.extend(dt_headers)
+        dt_headers.extend(headers if headers else [])
         try:
             return wrapped(
                 topic,
-                value=value,
-                key=key,
-                partition=partition,
-                on_delivery=on_delivery,
-                timestamp=timestamp,
-                headers=headers,
+                *args,
+                headers=dt_headers,
+                **kwargs,
             )
         except Exception as error:
             # Unwrap kafka errors

--- a/tests/messagebroker_confluentkafka/conftest.py
+++ b/tests/messagebroker_confluentkafka/conftest.py
@@ -190,10 +190,19 @@ def topic():
 
 
 @pytest.fixture()
-def send_producer_message(topic, producer, serialize):
+def send_producer_message(topic, producer, serialize, client_type):
+    callback_called = []
+
+    def producer_callback(err, msg):
+        callback_called.append(True)
+
     def _test():
-        producer.produce(topic, value=serialize({"foo": 1}))
+        if client_type == "cimpl":
+            producer.produce(topic, value=serialize({"foo": 1}), callback=producer_callback)
+        else:
+            producer.produce(topic, value=serialize({"foo": 1}), on_delivery=producer_callback)
         producer.flush()
+        assert callback_called
 
     return _test
 

--- a/tests/messagebroker_confluentkafka/test_producer.py
+++ b/tests/messagebroker_confluentkafka/test_producer.py
@@ -29,8 +29,11 @@ from newrelic.common.object_names import callable_name
 from newrelic.packages import six
 
 
+@pytest.mark.parametrize(
+    "headers", [[("MY-HEADER", "nonsense")], {"MY-HEADER": "nonsense"}], ids=["list of tuples headers", "dict headers"]
+)
 @background_task()
-def test_produce_arguments(topic, producer, client_type, serialize):
+def test_produce_arguments(topic, producer, client_type, serialize, headers):
     callback_called = threading.Event()
 
     def producer_callback(err, msg):
@@ -44,7 +47,7 @@ def test_produce_arguments(topic, producer, client_type, serialize):
             callback=producer_callback,
             partition=1,
             timestamp=1,
-            headers=[("MY-HEADER", "nonsense")],
+            headers=headers,
         )
     else:
         producer.produce(
@@ -54,7 +57,7 @@ def test_produce_arguments(topic, producer, client_type, serialize):
             partition=1,
             on_delivery=producer_callback,
             timestamp=1,
-            headers=[("MY-HEADER", "nonsense")],
+            headers=headers,
         )
     producer.flush()
 

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,7 @@ envlist =
     rabbitmq-messagebroker_pika-{py27,py37,py38,py39,pypy,pypy37}-pika0.13,
     rabbitmq-messagebroker_pika-{py37,py38,py39,py310,pypy37}-pikalatest,
     kafka-messagebroker_confluentkafka-{py27,py37,py38,py39,py310}-confluentkafkalatest,
-    kafka-messagebroker_confluentkafka-{py27,py39}-confluentkafka{0107,0106},
+    kafka-messagebroker_confluentkafka-{py27,py39}-confluentkafka{0108,0107,0106},
     kafka-messagebroker_kafkapython-{pypy,py27,py37,py38,pypy37}-kafkapythonlatest,
     kafka-messagebroker_kafkapython-{py27,py38}-kafkapython{020001,020000,0104},
     python-template_mako-{py27,py37,py38,py39,py310}
@@ -362,6 +362,7 @@ deps =
     messagebroker_pika: tornado<5
     messagebroker_pika-{py27,pypy}: enum34
     messagebroker_confluentkafka-confluentkafkalatest: confluent-kafka
+    messagebroker_confluentkafka-confluentkafka0108: confluent-kafka<1.9
     messagebroker_confluentkafka-confluentkafka0107: confluent-kafka<1.8
     messagebroker_confluentkafka-confluentkafka0106: confluent-kafka<1.7
     messagebroker_kafkapython-kafkapythonlatest: kafka-python

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,9 @@ envlist =
     rabbitmq-messagebroker_pika-{py27,py37,py38,py39,pypy,pypy37}-pika0.13,
     rabbitmq-messagebroker_pika-{py37,py38,py39,py310,pypy37}-pikalatest,
     kafka-messagebroker_confluentkafka-{py27,py37,py38,py39,py310}-confluentkafkalatest,
-    kafka-messagebroker_confluentkafka-{py27,py39}-confluentkafka{0108,0107,0106},
+    kafka-messagebroker_confluentkafka-{py27,py39}-confluentkafka{0107,0106},
+    ; confluent-kafka had a bug in 1.8.2's setup.py file which was incompatible with 2.7.
+    kafka-messagebroker_confluentkafka-{py39}-confluentkafka{0108},
     kafka-messagebroker_kafkapython-{pypy,py27,py37,py38,pypy37}-kafkapythonlatest,
     kafka-messagebroker_kafkapython-{py27,py38}-kafkapython{020001,020000,0104},
     python-template_mako-{py27,py37,py38,py39,py310}


### PR DESCRIPTION
This PR fixes two bugs in our confluent-kafka instrumentation both related to the producer arguments:


1. Fixes #643.
   Previously the Producer.produce instrumentation did not support all arguments. Now it supports all arguments.
2. Fixes Producer.produce not supporting dict type for headers argument. Now it supports dict type and list of tuples.

Co-authored-by: Timothy Pansino <TimPansino@users.noreply.github.com>
Co-authored-by: Hannah Stepanek <hmstepanek@users.noreply.github.com>
Co-authored-by: Uma Annamalai <umaannamalai@users.noreply.github.com>
