### PR TITLE
Make scripts and entry_points mutually exclusive based on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,6 @@ kwargs = dict(
     package_data={
         "newrelic": ["newrelic.ini", "version.txt", "packages/urllib3/LICENSE.txt", "common/cacert.pem"],
     },
-    scripts=["scripts/newrelic-admin"],
     extras_require={"infinite-tracing": ["grpcio", "protobuf"]},
 )
 
@@ -162,6 +161,8 @@ if with_setuptools:
     kwargs["entry_points"] = {
         "console_scripts": ["newrelic-admin = newrelic.admin:main"],
     }
+else:
+    kwargs["scripts"] = ["scripts/newrelic-admin"]
 
 
 def with_librt():


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
When installing `newrelic-admin` with `setuptools`, the `newrelic-admin` shim is written to `bin` multiple times due to the inclusion of both `scripts` and `entry-points` as arguments to `setup`. This poses problems for installers that comply with newer PEP standards, such as the Pypa `installer` package: https://github.com/pypa/installer

This change ensures that `entry_points` is exclusively used when running `setuptools`, and `scripts` is exclusively used if not.

# Related Github Issue
This issue is briefly discussed in the `rules_python` repository, where we have observed this being an issue:
https://github.com/bazelbuild/rules_python/issues/765

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
