### PR TITLE
fix: ignore "cold starts" with provisioned concurrency

### DIFF
--- a/newrelic/api/lambda_handler.py
+++ b/newrelic/api/lambda_handler.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import os
 import warnings
 from newrelic.common.object_wrapper import FunctionWrapper
 from newrelic.api.transaction import current_transaction
@@ -117,7 +118,7 @@ def _LambdaHandlerWrapper(wrapped, application=None, name=None,
         # this container.
 
         global COLD_START_RECORDED
-        if COLD_START_RECORDED is False:
+        if COLD_START_RECORDED is False and os.getenv('AWS_LAMBDA_INITIALIZATION_TYPE') == 'on-demand':
             transaction._add_agent_attribute('aws.lambda.coldStart', True)
             COLD_START_RECORDED = True
 


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
Describe the changes present in the pull request

When using Lambda Provisioned Concurrency cold-starts do not impact customers an the lambda is initialized before it is invoked.

AWS has the environment variable `AWS_LAMBDA_INITIALIZATION_TYPE` to indicate the initialization type. https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html


# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
