### PR TITLE
Fix Flask view support in Code Level Metrics

### DIFF
--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -16,6 +16,7 @@
 
 """
 
+from inspect import isclass
 from newrelic.api.function_trace import (
     FunctionTrace,
     FunctionTraceWrapper,
@@ -54,6 +55,22 @@ def _nr_wrapper_handler_(wrapped, instance, args, kwargs):
 
     name = getattr(wrapped, "_nr_view_func_name", callable_name(wrapped))
     view = getattr(wrapped, "view_class", wrapped)
+
+    try:
+        # Attempt to narrow down class based views to the correct method
+        from flask.views import MethodView
+        from flask import request
+
+        if isclass(view):
+            if issubclass(view, MethodView):
+                # For method based views, use the corresponding method if available
+                method = request.method.lower()
+                view = getattr(view, method, view)
+            else:
+                # For class based views, use the dispatch_request function if available
+                view = getattr(view, "dispatch_request", view)
+    except ImportError:
+        pass
 
     # Set priority=2 so this will take precedence over any error
     # handler which will be at priority=1.

--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -17,6 +17,7 @@
 """
 
 from inspect import isclass
+
 from newrelic.api.function_trace import (
     FunctionTrace,
     FunctionTraceWrapper,
@@ -58,8 +59,8 @@ def _nr_wrapper_handler_(wrapped, instance, args, kwargs):
 
     try:
         # Attempt to narrow down class based views to the correct method
-        from flask.views import MethodView
         from flask import request
+        from flask.views import MethodView
 
         if isclass(view):
             if issubclass(view, MethodView):

--- a/tests/component_flask_rest/test_application.py
+++ b/tests/component_flask_rest/test_application.py
@@ -24,6 +24,9 @@ from newrelic.core.config import global_settings
 from newrelic.common.object_names import callable_name
 
 
+TEST_APPLICATION_PREFIX = "_test_application.create_app.<locals>" if six.PY3 else "_test_application"
+
+
 @pytest.fixture(params=["flask_restful", "flask_restplus", "flask_restx"])
 def application(request):
     from _test_application import get_test_application
@@ -53,7 +56,7 @@ _test_application_index_scoped_metrics = [
 ]
 
 
-@validate_code_level_metrics("_test_application.create_app.<locals>" if six.PY3 else "_test_application", "IndexResource")
+@validate_code_level_metrics(TEST_APPLICATION_PREFIX + ".IndexResource", "get")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics('_test_application:index',
         scoped_metrics=_test_application_index_scoped_metrics)
@@ -80,7 +83,7 @@ _test_application_raises_scoped_metrics = [
 def test_application_raises(exception, status_code, ignore_status_code,
         propagate_exceptions, application):
 
-    @validate_code_level_metrics("_test_application.create_app.<locals>" if six.PY3 else "_test_application", "ExceptionResource")
+    @validate_code_level_metrics(TEST_APPLICATION_PREFIX + ".ExceptionResource", "get")
     @validate_transaction_metrics('_test_application:exception',
             scoped_metrics=_test_application_raises_scoped_metrics)
     def _test():

--- a/tests/component_flask_rest/test_application.py
+++ b/tests/component_flask_rest/test_application.py
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 import pytest
+from testing_support.fixtures import (
+    override_generic_settings,
+    override_ignore_status_codes,
+    validate_transaction_errors,
+    validate_transaction_metrics,
+)
+from testing_support.validators.validate_code_level_metrics import (
+    validate_code_level_metrics,
+)
 
-from newrelic.packages import six
-from testing_support.fixtures import (validate_transaction_metrics,
-    validate_transaction_errors, override_ignore_status_codes,
-    override_generic_settings)
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-
-from newrelic.core.config import global_settings
 from newrelic.common.object_names import callable_name
-
+from newrelic.core.config import global_settings
+from newrelic.packages import six
 
 TEST_APPLICATION_PREFIX = "_test_application.create_app.<locals>" if six.PY3 else "_test_application"
 
@@ -30,6 +33,7 @@ TEST_APPLICATION_PREFIX = "_test_application.create_app.<locals>" if six.PY3 els
 @pytest.fixture(params=["flask_restful", "flask_restplus", "flask_restx"])
 def application(request):
     from _test_application import get_test_application
+
     if request.param == "flask_restful":
         import flask_restful as module
     elif request.param == "flask_restplus":
@@ -47,49 +51,46 @@ def application(request):
 
 
 _test_application_index_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/_test_application:index', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1),
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/_test_application:index", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
 ]
 
 
 @validate_code_level_metrics(TEST_APPLICATION_PREFIX + ".IndexResource", "get")
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_application:index',
-        scoped_metrics=_test_application_index_scoped_metrics)
+@validate_transaction_metrics("_test_application:index", scoped_metrics=_test_application_index_scoped_metrics)
 def test_application_index(application):
-    response = application.get('/index')
-    response.mustcontain('hello')
+    response = application.get("/index")
+    response.mustcontain("hello")
 
 
 _test_application_raises_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Function/_test_application:exception', 1),
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Function/_test_application:exception", 1),
 ]
 
 
 @pytest.mark.parametrize(
-    'exception,status_code,ignore_status_code,propagate_exceptions', [
-        ('werkzeug.exceptions:HTTPException', 404, False, False),
-        ('werkzeug.exceptions:HTTPException', 404, True, False),
-        ('werkzeug.exceptions:HTTPException', 503, False, False),
-        ('_test_application:CustomException', 500, False, False),
-        ('_test_application:CustomException', 500, False, True),
-])
-def test_application_raises(exception, status_code, ignore_status_code,
-        propagate_exceptions, application):
-
+    "exception,status_code,ignore_status_code,propagate_exceptions",
+    [
+        ("werkzeug.exceptions:HTTPException", 404, False, False),
+        ("werkzeug.exceptions:HTTPException", 404, True, False),
+        ("werkzeug.exceptions:HTTPException", 503, False, False),
+        ("_test_application:CustomException", 500, False, False),
+        ("_test_application:CustomException", 500, False, True),
+    ],
+)
+def test_application_raises(exception, status_code, ignore_status_code, propagate_exceptions, application):
     @validate_code_level_metrics(TEST_APPLICATION_PREFIX + ".ExceptionResource", "get")
-    @validate_transaction_metrics('_test_application:exception',
-            scoped_metrics=_test_application_raises_scoped_metrics)
+    @validate_transaction_metrics("_test_application:exception", scoped_metrics=_test_application_raises_scoped_metrics)
     def _test():
         try:
-            application.get('/exception/%s/%i' % (exception,
-                status_code), status=status_code, expect_errors=True)
+            application.get("/exception/%s/%i" % (exception, status_code), status=status_code, expect_errors=True)
         except Exception as e:
             assert propagate_exceptions
 
@@ -111,9 +112,8 @@ def test_application_outside_transaction(application):
 
     _settings = global_settings()
 
-    @override_generic_settings(_settings, {'enabled': False})
+    @override_generic_settings(_settings, {"enabled": False})
     def _test():
-        application.get('/exception/werkzeug.exceptions:HTTPException/404',
-                status=404)
+        application.get("/exception/werkzeug.exceptions:HTTPException/404", status=404)
 
     _test()

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -20,7 +20,9 @@ from testing_support.fixtures import (
     validate_transaction_errors,
     validate_transaction_metrics,
 )
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+from testing_support.validators.validate_code_level_metrics import (
+    validate_code_level_metrics,
+)
 
 scoped_metrics = [
     ("Function/flask.app:Flask.wsgi_app", 1),

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -20,6 +20,7 @@ from testing_support.fixtures import (
     validate_transaction_errors,
     validate_transaction_metrics,
 )
+from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 
 scoped_metrics = [
     ("Function/flask.app:Flask.wsgi_app", 1),
@@ -50,6 +51,7 @@ def target_application():
     return _test_application
 
 
+@validate_code_level_metrics("_test_views.TestView", "dispatch_request")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics("_test_views:test_view", scoped_metrics=scoped_metrics)
 def test_class_based_view():
@@ -59,6 +61,7 @@ def test_class_based_view():
 
 
 @skip_if_not_async_handler_support
+@validate_code_level_metrics("_test_views_async.TestAsyncView", "dispatch_request")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics("_test_views_async:test_async_view", scoped_metrics=scoped_metrics)
 def test_class_based_async_view():
@@ -67,6 +70,7 @@ def test_class_based_async_view():
     response.mustcontain("ASYNC VIEW RESPONSE")
 
 
+@validate_code_level_metrics("_test_views.TestMethodView", "get")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics("_test_views:test_methodview", scoped_metrics=scoped_metrics)
 def test_get_method_view():
@@ -75,6 +79,7 @@ def test_get_method_view():
     response.mustcontain("METHODVIEW GET RESPONSE")
 
 
+@validate_code_level_metrics("_test_views.TestMethodView", "post")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics("_test_views:test_methodview", scoped_metrics=scoped_metrics)
 def test_post_method_view():
@@ -84,6 +89,7 @@ def test_post_method_view():
 
 
 @skip_if_not_async_handler_support
+@validate_code_level_metrics("_test_views_async.TestAsyncMethodView", "get")
 @validate_transaction_errors(errors=[])
 @validate_transaction_metrics("_test_views_async:test_async_methodview", scoped_metrics=scoped_metrics)
 def test_get_method_async_view():


### PR DESCRIPTION
Co-authored-by: Lalleh Rafeei <lrafeei@users.noreply.github.com>
Co-authored-by: Hannah Stepanek <hmstepanek@users.noreply.github.com>
Co-authored-by: Uma Annamalai <umaannamalai@users.noreply.github.com>

# Overview

* Flask class-based and method-based views currently report the class name as the `code.function` source, causing Code Level Metrics to not work with them. This PR fixes that.