### PR TITLE
Add Python 3.11 stable release to GHA

### DIFF
--- a/.github/actions/setup-python-matrix/action.yml
+++ b/.github/actions/setup-python-matrix/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - uses: actions/setup-python@v3
       with:
-        python-version: "3.11-dev"
+        python-version: "3.11"
         architecture: x64
 
     - uses: actions/setup-python@v3


### PR DESCRIPTION
# Overview

* Upgrades dev python 3.11 version to stable.
