### PR TITLE
Add patch for sentry SDK to correct ASGI v2/v3 detection.

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2179,6 +2179,8 @@ def _process_module_builtin_defaults():
         "instrument_graphqlserver",
     )
 
+    _process_module_definition("sentry_sdk.integrations.asgi", "newrelic.hooks.component_sentry", "instrument_sentry_sdk_integrations_asgi")
+
     # _process_module_definition('web.application',
     #        'newrelic.hooks.framework_webpy')
     # _process_module_definition('web.template',

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2179,7 +2179,9 @@ def _process_module_builtin_defaults():
         "instrument_graphqlserver",
     )
 
-    _process_module_definition("sentry_sdk.integrations.asgi", "newrelic.hooks.component_sentry", "instrument_sentry_sdk_integrations_asgi")
+    _process_module_definition(
+        "sentry_sdk.integrations.asgi", "newrelic.hooks.component_sentry", "instrument_sentry_sdk_integrations_asgi"
+    )
 
     # _process_module_definition('web.application',
     #        'newrelic.hooks.framework_webpy')

--- a/newrelic/hooks/component_sentry.py
+++ b/newrelic/hooks/component_sentry.py
@@ -1,0 +1,41 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from newrelic.common.object_wrapper import wrap_function_wrapper, FunctionWrapper
+
+# This is NOT a fully-featured instrumentation for the sentry SDK. Instead
+# this is a monkey-patch of the sentry SDK to work around a bug that causes
+# improper ASGI 2/3 version detection when inspecting our wrappers. We fix this
+# by manually unwrapping the application when version detection is run.
+
+
+def bind__looks_like_asgi3(app):
+    return app
+
+
+def wrap__looks_like_asgi3(wrapped, instance, args, kwargs):
+    try:
+        app = bind__looks_like_asgi3(*args, **kwargs)
+    except Exception:
+        return wrapped(*args, **kwargs)
+
+    while isinstance(app, FunctionWrapper) and hasattr(app, "__wrapped__"):
+        app = app.__wrapped__
+
+    return wrapped(app)
+
+
+def instrument_sentry_sdk_integrations_asgi(module):
+    if hasattr(module, "_looks_like_asgi3"):
+        wrap_function_wrapper(module, "_looks_like_asgi3", wrap__looks_like_asgi3)

--- a/newrelic/hooks/component_sentry.py
+++ b/newrelic/hooks/component_sentry.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import wrap_function_wrapper, FunctionWrapper
+from newrelic.common.object_wrapper import FunctionWrapper, wrap_function_wrapper
 
 # This is NOT a fully-featured instrumentation for the sentry SDK. Instead
 # this is a monkey-patch of the sentry SDK to work around a bug that causes


### PR DESCRIPTION
This PR patches `sentry-sdk`  to fix a bug that causes incorrect ASGI application version detection with our wrapt function wrappers. To fix this, we now instrument the `_looks_like_asgi3()` function to bind out the wrapped app in sentry in order to unwrap it to be able to detect the proper ASGI version.

Related Issue: #117 