### PR TITLE
Fix failing flask_rest tests

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2163,11 +2163,6 @@ def _process_module_builtin_defaults():
 
     _process_module_definition("flask_restful", "newrelic.hooks.component_flask_rest", "instrument_flask_rest")
     _process_module_definition(
-        "flask_restplus.api",
-        "newrelic.hooks.component_flask_rest",
-        "instrument_flask_rest",
-    )
-    _process_module_definition(
         "flask_restx.api",
         "newrelic.hooks.component_flask_rest",
         "instrument_flask_rest",

--- a/tests/component_flask_rest/test_application.py
+++ b/tests/component_flask_rest/test_application.py
@@ -30,14 +30,12 @@ from newrelic.packages import six
 TEST_APPLICATION_PREFIX = "_test_application.create_app.<locals>" if six.PY3 else "_test_application"
 
 
-@pytest.fixture(params=["flask_restful", "flask_restplus", "flask_restx"])
+@pytest.fixture(params=["flask_restful", "flask_restx"])
 def application(request):
     from _test_application import get_test_application
 
     if request.param == "flask_restful":
         import flask_restful as module
-    elif request.param == "flask_restplus":
-        import flask_restplus as module
     elif request.param == "flask_restx":
         import flask_restx as module
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ envlist =
     gearman-application_gearman-{py27,pypy},
     python-component_djangorestframework-py27-djangorestframework0300,
     python-component_djangorestframework-{py37,py38,py39,py310,py311}-djangorestframeworklatest,
-    python-component_flask_rest-{py27,py37,py38,py39,pypy,pypy37},
+    python-component_flask_rest-{py37,py38,py39,pypy37}-flaskrestxlatest,
+    python-component_flask_rest-{py27,pypy}-flaskrestx051,
     python-component_graphqlserver-{py37,py38,py39,py310,py311},
     python-component_tastypie-{py27,pypy}-tastypie0143,
     python-component_tastypie-{py37,py38,py39,pypy37}-tastypie{0143,latest},
@@ -208,9 +209,10 @@ deps =
     component_flask_rest: flask<0.13
     component_flask_rest: flask-restful
     component_flask_rest: flask-restplus
-    component_flask_rest: flask-restx
     component_flask_rest: jinja2<3.1
     component_flask_rest: itsdangerous<2.1
+    component_flask_rest-flaskrestxlatest: flask-restx
+    component_flask_rest-flaskrestx051: flask-restx<1.0
     component_graphqlserver: graphql-server[sanic,flask]==3.0.0b5
     component_graphqlserver: sanic>20
     component_graphqlserver: Flask

--- a/tox.ini
+++ b/tox.ini
@@ -206,11 +206,10 @@ deps =
     component_djangorestframework-djangorestframework0300: djangorestframework < 3.1
     component_djangorestframework-djangorestframeworklatest: Django
     component_djangorestframework-djangorestframeworklatest: djangorestframework
-    component_flask_rest: flask<0.13
+    component_flask_rest: flask
     component_flask_rest: flask-restful
-    component_flask_rest: flask-restplus
-    component_flask_rest: jinja2<3.1
-    component_flask_rest: itsdangerous<2.1
+    component_flask_rest: jinja2
+    component_flask_rest: itsdangerous
     component_flask_rest-flaskrestxlatest: flask-restx
     component_flask_rest-flaskrestx051: flask-restx<1.0
     component_graphqlserver: graphql-server[sanic,flask]==3.0.0b5


### PR DESCRIPTION
# Overview
Fix failing flask_rest tests
* Drop support for flask-restplus.
* The latest version of flask-restx dropped support for 2.7 so split the flask_rest tests up into 2 tox envs.