### PR TITLE
Fix tornado master tests & instrument redis 4.3.5

### DIFF
--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -66,6 +66,8 @@ _redis_client_methods = {
     "blpop",
     "brpop",
     "brpoplpush",
+    "byrank",
+    "byrevrank",
     "bzmpop",
     "bzpopmax",
     "bzpopmin",
@@ -289,6 +291,7 @@ _redis_client_methods = {
     "quit",
     "randomkey",
     "range",
+    "rank",
     "readonly",
     "readwrite",
     "rename",
@@ -299,6 +302,7 @@ _redis_client_methods = {
     "resp",
     "restore",
     "revrange",
+    "revrank",
     "role",
     "rpop",
     "rpoplpush",
@@ -376,6 +380,7 @@ _redis_client_methods = {
     "time",
     "toggle",
     "touch",
+    "trimmed_mean",
     "ttl",
     "type",
     "unlink",
@@ -528,7 +533,15 @@ def _nr_Connection_send_command_wrapper_(wrapped, instance, args, kwargs):
 
     operation = _redis_operation_re.sub("_", operation)
 
-    with DatastoreTrace(product="Redis", target=None, operation=operation, host=host, port_path_or_id=port_path_or_id, database_name=db, source=wrapped):
+    with DatastoreTrace(
+        product="Redis",
+        target=None,
+        operation=operation,
+        host=host,
+        port_path_or_id=port_path_or_id,
+        database_name=db,
+        source=wrapped,
+    ):
         return wrapped(*args, **kwargs)
 
 
@@ -574,7 +587,7 @@ def instrument_redis_commands_bf_commands(module):
     _instrument_redis_commands_module(module, "CMSCommands")
     _instrument_redis_commands_module(module, "TDigestCommands")
     _instrument_redis_commands_module(module, "TOPKCommands")
-    
+
 
 def _instrument_redis_commands_module(module, class_name):
     for name in _redis_client_methods:

--- a/tox.ini
+++ b/tox.ini
@@ -153,7 +153,7 @@ envlist =
     python-logger_loguru-{py37,py38,py39,py310,py311,pypy37}-logurulatest,
     python-logger_loguru-py39-loguru{06,05,04,03},
     libcurl-framework_tornado-{py37,py38,py39,py310,py311,pypy37}-tornado0600,
-    libcurl-framework_tornado-{py37,py38,py39,py310,py311}-tornadomaster,
+    libcurl-framework_tornado-{py38,py39,py310,py311}-tornadomaster,
     rabbitmq-messagebroker_pika-{py27,py37,py38,py39,pypy,pypy37}-pika0.13,
     rabbitmq-messagebroker_pika-{py37,py38,py39,py310,py311,pypy37}-pikalatest,
     kafka-messagebroker_confluentkafka-{py27,py37,py38,py39,py310,py311}-confluentkafkalatest,


### PR DESCRIPTION
# Overview
Fix tornado master tests & instrument redis 4.3.5
1. Drop 3.7 testing from tornado master.
   * Tornado master dropped support for 3.7
1. Instrument new redis 4.3.5 client methods.
