### PR TITLE
Fix bug in celery where workers don't report data

### DIFF
--- a/newrelic/api/application.py
+++ b/newrelic/api/application.py
@@ -33,18 +33,18 @@ class Application(object):
         if name is None:
             name = newrelic.core.config.global_settings().app_name
 
-        # Ensure we grab a reference to the agent before grabbing
-        # the lock, else startup callback on agent initialisation
-        # could deadlock as it tries to create a application when
-        # we already have the lock held.
-
-        agent = newrelic.core.agent.agent_instance()
-
         # Try first without lock. If we find it we can return.
 
         instance = Application._instances.get(name, None)
 
         if not instance and activate:
+            # Ensure we grab a reference to the agent before grabbing
+            # the lock, else startup callback on agent initialisation
+            # could deadlock as it tries to create a application when
+            # we already have the lock held.
+
+            agent = newrelic.core.agent.agent_instance()
+
             with Application._lock:
                 # Now try again with lock so that only one gets
                 # to create and add it.


### PR DESCRIPTION
# Overview
This fixes Missing information from Celery workers when using MAX_TASKS_PER_CHILD issue.

Previously, if celery was run with the --loglevel=INFO flag, an agent instance would be created for the main celery process and after the first worker shutdown, all following worker's agent instances would point to that agent instance instead of creating a new instance. This was root caused to incorrectly creating an agent instance when application activate was not set. Now no agent instance will be created for the main celery process.