### PR TITLE
Pin Github Actions Runner to Ubuntu 20 for Py27

### DIFF
--- a/.github/actions/setup-python-matrix/action.yml
+++ b/.github/actions/setup-python-matrix/action.yml
@@ -3,42 +3,42 @@ description: "Sets up all versions of python required for matrix testing in this
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "pypy-3.7"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "pypy-2.7"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.7"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.8"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.9"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.11"
         architecture: x64
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "2.7"
         architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   tests: # Aggregate job that provides a single check for workflow success
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - python
       - elasticsearchserver01
@@ -78,7 +78,7 @@ jobs:
             20,
           ]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     steps:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     steps:
@@ -138,7 +138,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     steps:
@@ -174,7 +174,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -219,7 +219,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -267,7 +267,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -310,7 +310,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -355,7 +355,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -398,7 +398,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -442,7 +442,7 @@ jobs:
       matrix:
         group-number: [1, 2, 3, 4]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -507,7 +507,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -550,7 +550,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -595,7 +595,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:
@@ -640,7 +640,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
 
     services:


### PR DESCRIPTION
# Overview

* The `ubuntu-latest` tag changed from 20.04 to 22.04, and 22.04 does not provide python 2.7 in the tools cache. This PR pins to the previous runner version for now.
* setup-python@v3 is emitting deprecation warnings, fixed by upgrading to v4.

# Related Github Issue

Related to https://github.com/actions/setup-python/issues/543

