### PR TITLE
Revert Removal of Flask Restplus Hook

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2163,6 +2163,11 @@ def _process_module_builtin_defaults():
 
     _process_module_definition("flask_restful", "newrelic.hooks.component_flask_rest", "instrument_flask_rest")
     _process_module_definition(
+        "flask_restplus.api",
+        "newrelic.hooks.component_flask_rest",
+        "instrument_flask_rest",
+    )
+    _process_module_definition(
         "flask_restx.api",
         "newrelic.hooks.component_flask_rest",
         "instrument_flask_rest",


### PR DESCRIPTION
# Overview

* Flask Restplus hook was removed, adding it back. 
* This module is now unmaintained and outside our support window, and will have no tested support going forward but existing hooks and functionality will remain in place.

# Related Github Issue

Partially Reverts #683
