### PR TITLE
Fix Type Constructor Classes in Code Level Metrics

### DIFF
--- a/.github/actions/setup-python-matrix/action.yml
+++ b/.github/actions/setup-python-matrix/action.yml
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         python3.10 -m pip install -U pip
-        python3.10 -m pip install -U wheel setuptools tox virtualenv!=20.0.24
+        python3.10 -m pip install -U wheel setuptools 'tox<4' virtualenv!=20.0.24

--- a/newrelic/core/code_level_metrics.py
+++ b/newrelic/core/code_level_metrics.py
@@ -89,7 +89,7 @@ def extract_code_from_callable(func):
             # Use inspect to get file and line number
             file_path = inspect.getsourcefile(func)
             line_number = inspect.getsourcelines(func)[1]
-        except TypeError:
+        except Exception:
             pass
 
     # Split function path to extract class name

--- a/tests/agent_features/_test_code_level_metrics.py
+++ b/tests/agent_features/_test_code_level_metrics.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import functools
 
+
 def exercise_function():
     return
 
 
-class ExerciseClass():
+class ExerciseClass(object):
     def exercise_method(self):
         return
 
@@ -30,7 +31,7 @@ class ExerciseClass():
         return
 
 
-class ExerciseClassCallable():
+class ExerciseClassCallable(object):
     def __call__(self):
         return
 

--- a/tests/agent_features/_test_code_level_metrics.py
+++ b/tests/agent_features/_test_code_level_metrics.py
@@ -35,8 +35,42 @@ class ExerciseClassCallable(object):
     def __call__(self):
         return
 
+
+def exercise_method(self):
+    return
+
+
+@staticmethod
+def exercise_static_method():
+    return
+
+
+@classmethod
+def exercise_class_method(cls):
+    return
+
+
+def __call__(self):
+    return
+
+
+type_dict = {
+    "exercise_method": exercise_method,
+    "exercise_static_method": exercise_static_method,
+    "exercise_class_method": exercise_class_method,
+    "exercise_lambda": lambda: None,
+}
+callable_type_dict = type_dict.copy()
+callable_type_dict["__call__"] = __call__
+
+ExerciseTypeConstructor = type("ExerciseTypeConstructor", (object,), type_dict)
+ExerciseTypeConstructorCallable = type("ExerciseTypeConstructorCallable", (object,), callable_type_dict)
+
+
 CLASS_INSTANCE = ExerciseClass()
 CLASS_INSTANCE_CALLABLE = ExerciseClassCallable()
+TYPE_CONSTRUCTOR_CLASS_INSTANCE = ExerciseTypeConstructor()
+TYPE_CONSTRUCTOR_CALLABLE_CLASS_INSTANCE = ExerciseTypeConstructorCallable()
 
 exercise_lambda = lambda: None
 exercise_partial = functools.partial(exercise_function)

--- a/tests/agent_features/_test_code_level_metrics.py
+++ b/tests/agent_features/_test_code_level_metrics.py
@@ -72,5 +72,5 @@ CLASS_INSTANCE_CALLABLE = ExerciseClassCallable()
 TYPE_CONSTRUCTOR_CLASS_INSTANCE = ExerciseTypeConstructor()
 TYPE_CONSTRUCTOR_CALLABLE_CLASS_INSTANCE = ExerciseTypeConstructorCallable()
 
-exercise_lambda = lambda: None
+exercise_lambda = lambda: None  # noqa: E731
 exercise_partial = functools.partial(exercise_function)

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -12,20 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import sqlite3
-import newrelic.packages.six as six
-import pytest
+import sys
 
-from testing_support.fixtures import override_application_settings, dt_enabled
+import pytest
+from _test_code_level_metrics import (
+    CLASS_INSTANCE,
+    CLASS_INSTANCE_CALLABLE,
+    TYPE_CONSTRUCTOR_CALLABLE_CLASS_INSTANCE,
+    TYPE_CONSTRUCTOR_CLASS_INSTANCE,
+    ExerciseClass,
+    ExerciseClassCallable,
+    ExerciseTypeConstructor,
+    ExerciseTypeConstructorCallable,
+)
+from _test_code_level_metrics import __file__ as FILE_PATH
+from _test_code_level_metrics import (
+    exercise_function,
+    exercise_lambda,
+    exercise_partial,
+)
+from testing_support.fixtures import dt_enabled, override_application_settings
 from testing_support.validators.validate_span_events import validate_span_events
 
+import newrelic.packages.six as six
 from newrelic.api.background_task import background_task
-from newrelic.api.function_trace import FunctionTrace, FunctionTraceWrapper
-
-from _test_code_level_metrics import *
-from _test_code_level_metrics import __file__ as FILE_PATH
-
+from newrelic.api.function_trace import FunctionTrace
 
 is_pypy = hasattr(sys, "pypy_version_info")
 

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -32,6 +32,8 @@ is_pypy = hasattr(sys, "pypy_version_info")
 NAMESPACE = "_test_code_level_metrics"
 CLASS_NAMESPACE = ".".join((NAMESPACE, "ExerciseClass"))
 CALLABLE_CLASS_NAMESPACE = ".".join((NAMESPACE, "ExerciseClassCallable"))
+TYPE_CONSTRUCTOR_NAMESPACE = ".".join((NAMESPACE, "ExerciseTypeConstructor"))
+TYPE_CONSTRUCTOR_CALLABLE_NAMESPACE = ".".join((NAMESPACE, "ExerciseTypeConstructorCallable"))
 FUZZY_NAMESPACE = CLASS_NAMESPACE if six.PY3 else NAMESPACE
 if FILE_PATH.endswith(".pyc"):
     FILE_PATH = FILE_PATH[:-1]
@@ -208,7 +210,82 @@ def test_code_level_metrics_methods(func, args, agents):
     _test()
 
 
+_TEST_TYPE_CONSTRUCTOR_METHODS = {
+    "method": (
+        TYPE_CONSTRUCTOR_CLASS_INSTANCE.exercise_method,
+        (),
+        {
+            "code.filepath": FILE_PATH,
+            "code.function": "exercise_method",
+            "code.lineno": 39,
+            "code.namespace": TYPE_CONSTRUCTOR_NAMESPACE,
+        },
+    ),
+    "static_method": (
+        TYPE_CONSTRUCTOR_CLASS_INSTANCE.exercise_static_method,
+        (),
+        {
+            "code.filepath": FILE_PATH,
+            "code.function": "exercise_static_method",
+            "code.lineno": 43,
+            "code.namespace": NAMESPACE,
+        },
+    ),
+    "class_method": (
+        ExerciseTypeConstructor.exercise_class_method,
+        (),
+        {
+            "code.filepath": FILE_PATH,
+            "code.function": "exercise_class_method",
+            "code.lineno": 48,
+            "code.namespace": TYPE_CONSTRUCTOR_NAMESPACE,
+        },
+    ),
+    "lambda_method": (
+        ExerciseTypeConstructor.exercise_lambda,
+        (),
+        {
+            "code.filepath": FILE_PATH,
+            "code.function": "<lambda>",
+            "code.lineno": 61,
+            "code.namespace": NAMESPACE,
+        },
+    ),
+    "call_method": (
+        TYPE_CONSTRUCTOR_CALLABLE_CLASS_INSTANCE,
+        (),
+        {
+            "code.filepath": FILE_PATH,
+            "code.function": "__call__",
+            "code.lineno": 53,
+            "code.namespace": TYPE_CONSTRUCTOR_CALLABLE_NAMESPACE,
+        },
+    ),
+}
+
+
 @pytest.mark.parametrize(
+    "func,args,agents",
+    [pytest.param(*args, id=id_) for id_, args in six.iteritems(_TEST_TYPE_CONSTRUCTOR_METHODS)],
+)
+def test_code_level_metrics_type_constructor_methods(func, args, agents):
+    @override_application_settings(
+        {
+            "code_level_metrics.enabled": True,
+        }
+    )
+    @dt_enabled
+    @validate_span_events(
+        count=1,
+        exact_agents=agents,
+    )
+    @background_task()
+    def _test():
+        extract(func)
+
+    _test()
+
+
 _TEST_OBJECTS = {
     "class": (
         ExerciseClass,

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -248,7 +248,8 @@ _TEST_TYPE_CONSTRUCTOR_METHODS = {
             "code.filepath": FILE_PATH,
             "code.function": "<lambda>",
             "code.lineno": 61,
-            "code.namespace": NAMESPACE,
+            # Lambdas behave strangely in type constructors on Python 2 and use the class namespace.
+            "code.namespace": NAMESPACE if six.PY3 else TYPE_CONSTRUCTOR_NAMESPACE,
         },
     ),
     "call_method": (

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -326,7 +326,7 @@ _TEST_OBJECTS = {
         {
             "code.filepath": FILE_PATH,
             "code.function": "ExerciseClass",
-            "code.lineno": 20,
+            "code.lineno": 21,
             "code.namespace": NAMESPACE,
         },
     ),

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -62,9 +62,13 @@ def merge_dicts(A, B):
     return d
 
 
-def extract(obj):
-    with FunctionTrace("_test", source=obj):
-        pass
+@pytest.fixture
+def extract():
+    def _extract(obj):
+        with FunctionTrace("_test", source=obj):
+            pass
+
+    return _extract
 
 
 _TEST_BASIC_CALLABLES = {
@@ -127,7 +131,7 @@ _TEST_BASIC_CALLABLES = {
     "func,args,agents",
     [pytest.param(*args, id=id_) for id_, args in six.iteritems(_TEST_BASIC_CALLABLES)],
 )
-def test_code_level_metrics_basic_callables(func, args, agents):
+def test_code_level_metrics_basic_callables(func, args, agents, extract):
     @override_application_settings(
         {
             "code_level_metrics.enabled": True,
@@ -204,7 +208,7 @@ _TEST_METHODS = {
     "func,args,agents",
     [pytest.param(*args, id=id_) for id_, args in six.iteritems(_TEST_METHODS)],
 )
-def test_code_level_metrics_methods(func, args, agents):
+def test_code_level_metrics_methods(func, args, agents, extract):
     @override_application_settings(
         {
             "code_level_metrics.enabled": True,
@@ -281,7 +285,7 @@ _TEST_TYPE_CONSTRUCTOR_METHODS = {
     "func,args,agents",
     [pytest.param(*args, id=id_) for id_, args in six.iteritems(_TEST_TYPE_CONSTRUCTOR_METHODS)],
 )
-def test_code_level_metrics_type_constructor_methods(func, args, agents):
+def test_code_level_metrics_type_constructor_methods(func, args, agents, extract):
     @override_application_settings(
         {
             "code_level_metrics.enabled": True,
@@ -350,7 +354,7 @@ _TEST_OBJECTS = {
     "obj,agents",
     [pytest.param(*args, id=id_) for id_, args in six.iteritems(_TEST_OBJECTS)],
 )
-def test_code_level_metrics_objects(obj, agents):
+def test_code_level_metrics_objects(obj, agents, extract):
     @override_application_settings(
         {
             "code_level_metrics.enabled": True,


### PR DESCRIPTION
# Overview

* Previously either no data was reported or a crash occurred (depending on agent version) when using a class created using the [3 argument type constructor](https://docs.python.org/3/library/functions.html?highlight=type#type). Fixed and properly returns without line number (which is unavailable).
* Pin tox major version to v3 until CI can be fixed.

# Related Github Issue
Closes #515