### PR TITLE
Add kernel ridge model function traces

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2903,6 +2903,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "sklearn.kernel_ridge",
+        "newrelic.hooks.mlmodel_sklearn",
+        "instrument_sklearn_kernel_ridge_models",
+    )
+
+    _process_module_definition(
         "rest_framework.views",
         "newrelic.hooks.component_djangorestframework",
         "instrument_rest_framework_views",

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -201,6 +201,11 @@ def instrument_sklearn_ensemble_hist_models(module):
     _instrument_sklearn_models(module, model_classes)
 
 
+def instrument_sklearn_kernel_ridge_models(module):
+    model_classes = ("KernelRidge",)
+    _instrument_sklearn_models(module, model_classes)
+
+
 def instrument_sklearn_metrics(module):
     for scorer in METRIC_SCORERS:
         if hasattr(module, scorer):

--- a/tests/mlmodel_sklearn/test_ensemble_models.py
+++ b/tests/mlmodel_sklearn/test_ensemble_models.py
@@ -279,7 +279,7 @@ def run_ensemble_model():
                 "voting": "soft",
             }
         elif ensemble_model_name == "VotingRegressor":
-            kwargs = {"estimators": [("rf", RandomForestRegressor()), ("lr", LinearRegression())]}
+            kwargs = {"estimators": [("lr", LinearRegression())]}
         elif ensemble_model_name == "StackingRegressor":
             kwargs = {"estimators": [("rf", RandomForestRegressor())]}
         clf = getattr(sklearn.ensemble, ensemble_model_name)(**kwargs)

--- a/tests/mlmodel_sklearn/test_kernel_ridge_models.py
+++ b/tests/mlmodel_sklearn/test_kernel_ridge_models.py
@@ -1,0 +1,74 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+from newrelic.api.background_task import background_task
+from newrelic.packages import six
+
+
+@pytest.mark.parametrize(
+    "kernel_ridge_model_name",
+    [
+        "KernelRidge",
+    ],
+)
+def test_model_methods_wrapped_in_function_trace(kernel_ridge_model_name, run_kernel_ridge_model):
+    expected_scoped_metrics = {
+        "KernelRidge": [
+            ("Function/MLModel/Sklearn/Named/KernelRidge.fit", 1),
+            ("Function/MLModel/Sklearn/Named/KernelRidge.predict", 1),
+        ],
+    }
+
+    expected_transaction_name = (
+        "test_kernel_ridge_models:test_model_methods_wrapped_in_function_trace.<locals>._test"
+        if six.PY3
+        else "test_kernel_ridge_models:_test"
+    )
+
+    @validate_transaction_metrics(
+        expected_transaction_name,
+        scoped_metrics=expected_scoped_metrics[kernel_ridge_model_name],
+        rollup_metrics=expected_scoped_metrics[kernel_ridge_model_name],
+        background_task=True,
+    )
+    @background_task()
+    def _test():
+        run_kernel_ridge_model(kernel_ridge_model_name)
+
+    _test()
+
+
+@pytest.fixture
+def run_kernel_ridge_model():
+    def _run(kernel_ridge_model_name):
+        import sklearn.kernel_ridge
+        from sklearn.datasets import load_iris
+        from sklearn.model_selection import train_test_split
+
+        X, y = load_iris(return_X_y=True)
+        x_train, x_test, y_train, _ = train_test_split(X, y, stratify=y, random_state=0)
+
+        clf = getattr(sklearn.kernel_ridge, kernel_ridge_model_name)()
+
+        model = clf.fit(x_train, y_train)
+        model.predict(x_test)
+
+        return model
+
+    return _run


### PR DESCRIPTION
Add function traces around the following methods in the sklearn kernel ridge models:

- fit
- predict