### PR TITLE
Fix sanic and starlette tests

### DIFF
--- a/tests/framework_sanic/test_application.py
+++ b/tests/framework_sanic/test_application.py
@@ -44,11 +44,11 @@ from newrelic.core.config import global_settings
 SANIC_VERSION = tuple(map(int, get_package_version("sanic").split(".")))
 
 sanic_21 = SANIC_VERSION >= (21,)
-sanic_v18_to_v22_12 = SANIC_VERSION > (18,) and SANIC_VERSION < (22, 12)
+sanic_v19_to_v22_12 = SANIC_VERSION >= (19,) and SANIC_VERSION < (22, 12)
 
 BASE_METRICS = [
     ("Function/_target_application:index", 1),
-    ("Function/_target_application:request_middleware", 1 if sanic_v18_to_v22_12 else 2),
+    ("Function/_target_application:request_middleware", 1 if sanic_v19_to_v22_12 else 2),
 ]
 FRAMEWORK_METRICS = [
     ("Python/Framework/Sanic/%s" % sanic.__version__, 1),

--- a/tests/framework_sanic/test_application.py
+++ b/tests/framework_sanic/test_application.py
@@ -38,14 +38,17 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.application import application_instance
 from newrelic.api.external_trace import ExternalTrace
 from newrelic.api.transaction import Transaction
+from newrelic.common.package_version_utils import get_package_version
 from newrelic.core.config import global_settings
 
-sanic_21 = int(sanic.__version__.split(".", 1)[0]) >= 21
+SANIC_VERSION = tuple(map(int, get_package_version("sanic").split(".")))
 
+sanic_21 = SANIC_VERSION >= (21,)
+sanic_v18_to_v22_12 = SANIC_VERSION > (18,) and SANIC_VERSION < (22, 12)
 
 BASE_METRICS = [
     ("Function/_target_application:index", 1),
-    ("Function/_target_application:request_middleware", 1 if int(sanic.__version__.split(".", 1)[0]) > 18 else 2),
+    ("Function/_target_application:request_middleware", 1 if sanic_v18_to_v22_12 else 2),
 ]
 FRAMEWORK_METRICS = [
     ("Python/Framework/Sanic/%s" % sanic.__version__, 1),

--- a/tox.ini
+++ b/tox.ini
@@ -143,7 +143,7 @@ envlist =
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy37,py37,py38,py39,py310,py311}-Pyramid0110-cornice,
     python-framework_pyramid-{py37,py38,py39,py310,py311,pypy37}-Pyramidmaster,
-    python-framework_sanic-{py38,pypy37}-sanic{1812,190301,1906,1912,200904,210300,2109,2112,2203,2290},
+    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1912,200904,210300,2109,2112,2203,2290},
     python-framework_sanic-{py37,py38,py39,py310,py311,pypy37}-saniclatest,
     python-framework_starlette-{py310,pypy37}-starlette{0014,0015,0019},
     python-framework_starlette-{py37,py38}-starlette{002001},

--- a/tox.ini
+++ b/tox.ini
@@ -143,7 +143,7 @@ envlist =
     python-framework_pyramid-{pypy,py27,py38}-Pyramid0104,
     python-framework_pyramid-{pypy,py27,pypy37,py37,py38,py39,py310,py311}-Pyramid0110-cornice,
     python-framework_pyramid-{py37,py38,py39,py310,py311,pypy37}-Pyramidmaster,
-    python-framework_sanic-{py38,pypy37}-sanic{190301,1906,1812,1912,200904,210300,2109,2112,2203,2290},
+    python-framework_sanic-{py38,pypy37}-sanic{1812,190301,1906,1912,200904,210300,2109,2112,2203,2290},
     python-framework_sanic-{py37,py38,py39,py310,py311,pypy37}-saniclatest,
     python-framework_starlette-{py310,pypy37}-starlette{0014,0015,0019},
     python-framework_starlette-{py37,py38}-starlette{002001},

--- a/tox.ini
+++ b/tox.ini
@@ -357,7 +357,7 @@ deps =
     framework_starlette-starlette0015: starlette<0.16
     framework_starlette-starlette0019: starlette<0.20
     framework_starlette-starlette002001: starlette==0.20.1
-    framework_starlette-starlettelatest: starlette
+    framework_starlette-starlettelatest: starlette<0.23.1
     framework_strawberry: starlette
     framework_strawberry-strawberrylatest: strawberry-graphql
     framework_tornado: pycurl

--- a/tox.ini
+++ b/tox.ini
@@ -357,6 +357,7 @@ deps =
     framework_starlette-starlette0015: starlette<0.16
     framework_starlette-starlette0019: starlette<0.20
     framework_starlette-starlette002001: starlette==0.20.1
+    ; Starlette latest version temporarily pinned
     framework_starlette-starlettelatest: starlette<0.23.1
     framework_strawberry: starlette
     framework_strawberry-strawberrylatest: strawberry-graphql


### PR DESCRIPTION
This PR fixes the tests for Sanic when Sanic v22.12 was released.  Changes in `register_middleware` affected tests.
Starlette v0.23.1 is pinned as latest for now.