### PR TITLE
Add "card" method to instrument in Redis

### DIFF
--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -72,6 +72,7 @@ _redis_client_methods = {
     "bzmpop",
     "bzpopmax",
     "bzpopmin",
+    "card",
     "cdf",
     "clear",
     "client_getname",


### PR DESCRIPTION
This PR instruments the "card" method that was added in Redis v4.4.2.