### PR TITLE
Support `redis.asyncio`

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2665,6 +2665,14 @@ def _process_module_builtin_defaults():
         "aioredis.connection", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_connection"
     )
 
+    _process_module_definition("redis.asyncio.client", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client")
+
+    _process_module_definition("redis.asyncio.commands", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client")
+
+    _process_module_definition(
+        "redis.asyncio.connection", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_connection"
+    )
+
     _process_module_definition(
         "elasticsearch.client",
         "newrelic.hooks.datastore_elasticsearch",

--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -12,27 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.datastore_trace import DatastoreTrace, DatastoreTraceWrapper
+from newrelic.api.datastore_trace import DatastoreTrace
 from newrelic.api.time_trace import current_trace
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper, FunctionWrapper
+from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
 from newrelic.hooks.datastore_redis import (
     _redis_client_methods,
     _redis_multipart_commands,
     _redis_operation_re,
 )
 
-from newrelic.common.async_wrapper import async_wrapper
 
-try:
-    import aioredis as aioredis_legacy
-except ModuleNotFoundError:
-    aioredis_legacy = None
-
-try:
-    AIOREDIS_VERSION = lambda: tuple(int(x) for x in getattr(aioredis_legacy, "__version__").split("."))
-except Exception:
-    AIOREDIS_VERSION = lambda: (0, 0, 0)
+def get_aioredis_version():
+    try:
+        import aioredis as aioredis_legacy
+    except ModuleNotFoundError:
+        return None
+    try:
+        return tuple(int(x) for x in getattr(aioredis_legacy, "__version__").split("."))
+    except Exception:
+        return 0, 0, 0
 
 
 def _conn_attrs_to_dict(connection):
@@ -71,7 +70,8 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
         # Check for transaction and return early if found.
         # Method will return synchronously without executing,
         # it will be added to the command stack and run later.
-        if aioredis_legacy and AIOREDIS_VERSION() < (2,):
+        aioredis_version = get_aioredis_version()
+        if aioredis_version and aioredis_version < (2,):
             # AioRedis v1 uses a RedisBuffer instead of a real connection for queueing up pipeline commands
             from aioredis.commands.transaction import _RedisBuffer
             if isinstance(instance._pool_or_conn, _RedisBuffer):
@@ -80,7 +80,7 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
                 return wrapped(*args, **kwargs)
         else:
             # AioRedis v2 uses a Pipeline object for a client and internally queues up pipeline commands
-            if aioredis_legacy:
+            if aioredis_version:
                 from aioredis.client import Pipeline
             else:
                 from redis.asyncio.client import Pipeline


### PR DESCRIPTION
_Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst) and [code of conduct](https://github.com/newrelic/.github/blob/master/CODE_OF_CONDUCT.md)._

# Overview
`aioredis` is included to redis-py since version 4.2.0rc1 as `redis.asyncio` (https://github.com/redis/redis-py/pull/1899). This PR adapts the current `newrelic.hooks.datastore_aioredis` for supporting `redis.asyncio`.