### PR TITLE
Revert "Fix log decorating to be JSON compatible"

### DIFF
--- a/newrelic/hooks/logger_logging.py
+++ b/newrelic/hooks/logger_logging.py
@@ -15,9 +15,8 @@
 from newrelic.api.application import application_instance
 from newrelic.api.time_trace import get_linking_metadata
 from newrelic.api.transaction import current_transaction, record_log_event
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 from newrelic.core.config import global_settings
-
 
 try:
     from urllib import quote
@@ -28,7 +27,7 @@ except ImportError:
 def add_nr_linking_metadata(message):
     available_metadata = get_linking_metadata()
     entity_name = quote(available_metadata.get("entity.name", ""))
-    entity_guid = available_metadata.get("entity.guid", "") 
+    entity_guid = available_metadata.get("entity.guid", "")
     span_id = available_metadata.get("span.id", "")
     trace_id = available_metadata.get("trace.id", "")
     hostname = available_metadata.get("hostname", "")
@@ -72,7 +71,7 @@ def wrap_callHandlers(wrapped, instance, args, kwargs):
                 if application and application.enabled:
                     application.record_custom_metric("Logging/lines", {"count": 1})
                     application.record_custom_metric("Logging/lines/%s" % level_name, {"count": 1})
-            
+
         if settings.application_logging.forwarding and settings.application_logging.forwarding.enabled:
             try:
                 message = record.getMessage()

--- a/tests/logger_logging/test_local_decorating.py
+++ b/tests/logger_logging/test_local_decorating.py
@@ -14,13 +14,16 @@
 
 import platform
 
+from testing_support.fixtures import reset_core_stats_engine
+from testing_support.validators.validate_log_event_count import validate_log_event_count
+from testing_support.validators.validate_log_event_count_outside_transaction import (
+    validate_log_event_count_outside_transaction,
+)
+
 from newrelic.api.application import application_settings
 from newrelic.api.background_task import background_task
 from newrelic.api.time_trace import current_trace
 from newrelic.api.transaction import current_transaction
-from testing_support.fixtures import reset_core_stats_engine
-from testing_support.validators.validate_log_event_count import validate_log_event_count
-from testing_support.validators.validate_log_event_count_outside_transaction import validate_log_event_count_outside_transaction
 
 
 def set_trace_ids():
@@ -30,6 +33,7 @@ def set_trace_ids():
     trace = current_trace()
     if trace:
         trace.guid = "abcdefgh"
+
 
 def exercise_logging(logger):
     set_trace_ids()
@@ -42,9 +46,19 @@ def get_metadata_string(log_message, is_txn):
     assert host
     entity_guid = application_settings().entity_guid
     if is_txn:
-        metadata_string = "".join(('NR-LINKING|', entity_guid, '|', host, '|abcdefgh12345678|abcdefgh|Python%20Agent%20Test%20%28logger_logging%29|'))
+        metadata_string = "".join(
+            (
+                "NR-LINKING|",
+                entity_guid,
+                "|",
+                host,
+                "|abcdefgh12345678|abcdefgh|Python%20Agent%20Test%20%28logger_logging%29|",
+            )
+        )
     else:
-        metadata_string = "".join(('NR-LINKING|', entity_guid, '|', host, '|||Python%20Agent%20Test%20%28logger_logging%29|'))
+        metadata_string = "".join(
+            ("NR-LINKING|", entity_guid, "|", host, "|||Python%20Agent%20Test%20%28logger_logging%29|")
+        )
     formatted_string = log_message + " " + metadata_string
     return formatted_string
 
@@ -55,7 +69,7 @@ def test_local_log_decoration_inside_transaction(logger):
     @background_task()
     def test():
         exercise_logging(logger)
-        assert logger.caplog.records[0] == get_metadata_string('C', True)
+        assert logger.caplog.records[0] == get_metadata_string("C", True)
 
     test()
 
@@ -65,6 +79,6 @@ def test_local_log_decoration_outside_transaction(logger):
     @validate_log_event_count_outside_transaction(1)
     def test():
         exercise_logging(logger)
-        assert logger.caplog.records[0] == get_metadata_string('C', False)
+        assert logger.caplog.records[0] == get_metadata_string("C", False)
 
     test()

--- a/tests/logger_logging/test_local_decorating.py
+++ b/tests/logger_logging/test_local_decorating.py
@@ -14,16 +14,13 @@
 
 import platform
 
-from testing_support.fixtures import reset_core_stats_engine
-from testing_support.validators.validate_log_event_count import validate_log_event_count
-from testing_support.validators.validate_log_event_count_outside_transaction import (
-    validate_log_event_count_outside_transaction,
-)
-
 from newrelic.api.application import application_settings
 from newrelic.api.background_task import background_task
 from newrelic.api.time_trace import current_trace
 from newrelic.api.transaction import current_transaction
+from testing_support.fixtures import reset_core_stats_engine
+from testing_support.validators.validate_log_event_count import validate_log_event_count
+from testing_support.validators.validate_log_event_count_outside_transaction import validate_log_event_count_outside_transaction
 
 
 def set_trace_ids():
@@ -34,17 +31,22 @@ def set_trace_ids():
     if trace:
         trace.guid = "abcdefgh"
 
-
 def exercise_logging(logger):
     set_trace_ids()
 
     logger.warning("C")
 
 
-def exercise_logging_json(logger):
-    set_trace_ids()
-
-    logger.warning('{"first_name": "Hugh", "last_name": "Man"}')
+def get_metadata_string(log_message, is_txn):
+    host = platform.uname()[1]
+    assert host
+    entity_guid = application_settings().entity_guid
+    if is_txn:
+        metadata_string = "".join(('NR-LINKING|', entity_guid, '|', host, '|abcdefgh12345678|abcdefgh|Python%20Agent%20Test%20%28logger_logging%29|'))
+    else:
+        metadata_string = "".join(('NR-LINKING|', entity_guid, '|', host, '|||Python%20Agent%20Test%20%28logger_logging%29|'))
+    formatted_string = log_message + " " + metadata_string
+    return formatted_string
 
 
 @reset_core_stats_engine()
@@ -52,37 +54,8 @@ def test_local_log_decoration_inside_transaction(logger):
     @validate_log_event_count(1)
     @background_task()
     def test():
-        host = platform.uname()[1]
-        assert host
-        entity_guid = application_settings().entity_guid
-        entity_name = "Python%20Agent%20Test%20%28logger_logging%29"
         exercise_logging(logger)
-        assert logger.caplog.records[0] == "C NR-LINKING|%s|%s|abcdefgh12345678|abcdefgh|%s|" % (
-            entity_guid,
-            host,
-            entity_name,
-        )
-
-    test()
-
-
-@reset_core_stats_engine()
-def test_local_log_decoration_inside_transaction_with_json(logger):
-    @validate_log_event_count(1)
-    @background_task()
-    def test():
-        host = platform.uname()[1]
-        assert host
-        entity_guid = application_settings().entity_guid
-        entity_name = "Python%20Agent%20Test%20%28logger_logging%29"
-        exercise_logging_json(logger)
-        assert logger.caplog.records[
-            0
-        ] == '{"first_name": "Hugh", "last_name": "Man", "NR-LINKING": "%s|%s|abcdefgh12345678|abcdefgh|%s|"}' % (
-            entity_guid,
-            host,
-            entity_name,
-        )
+        assert logger.caplog.records[0] == get_metadata_string('C', True)
 
     test()
 
@@ -91,29 +64,7 @@ def test_local_log_decoration_inside_transaction_with_json(logger):
 def test_local_log_decoration_outside_transaction(logger):
     @validate_log_event_count_outside_transaction(1)
     def test():
-        host = platform.uname()[1]
-        assert host
-        entity_guid = application_settings().entity_guid
-        entity_name = "Python%20Agent%20Test%20%28logger_logging%29"
         exercise_logging(logger)
-        assert logger.caplog.records[0] == "C NR-LINKING|%s|%s|||%s|" % (entity_guid, host, entity_name)
-
-    test()
-
-
-@reset_core_stats_engine()
-def test_local_log_decoration_outside_transaction_with_json(logger):
-    @validate_log_event_count_outside_transaction(1)
-    def test():
-        host = platform.uname()[1]
-        assert host
-        entity_guid = application_settings().entity_guid
-        entity_name = "Python%20Agent%20Test%20%28logger_logging%29"
-        exercise_logging_json(logger)
-        assert logger.caplog.records[0] == '{"first_name": "Hugh", "last_name": "Man", "NR-LINKING": "%s|%s|||%s|"}' % (
-            entity_guid,
-            host,
-            entity_name,
-        )
+        assert logger.caplog.records[0] == get_metadata_string('C', False)
 
     test()


### PR DESCRIPTION
Reverts newrelic/newrelic-python-agent#736

It looks like what was implemented in [logging](https://source.datanerd.us/logging/log-parser-consumer/pull/933) is not necessarily compatible with this change so reverting for now.