### PR TITLE
Redis Asyncio Testing

### DIFF
--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -24,9 +24,6 @@ from newrelic.hooks.datastore_redis import (
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 
-get_aioredis_version = lambda: get_package_version_tuple("aioredis")
-
-
 def _conn_attrs_to_dict(connection):
     host = getattr(connection, "host", None)
     port = getattr(connection, "port", None)
@@ -63,7 +60,7 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
         # Check for transaction and return early if found.
         # Method will return synchronously without executing,
         # it will be added to the command stack and run later.
-        aioredis_version = get_aioredis_version()
+        aioredis_version = get_package_version_tuple("aioredis")
         if aioredis_version and aioredis_version < (2,):
             # AioRedis v1 uses a RedisBuffer instead of a real connection for queueing up pipeline commands
             from aioredis.commands.transaction import _RedisBuffer

--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -21,17 +21,15 @@ from newrelic.hooks.datastore_redis import (
     _redis_multipart_commands,
     _redis_operation_re,
 )
+from newrelic.common.package_version_utils import get_package_version_tuple
 
 
 def get_aioredis_version():
     try:
-        import aioredis as aioredis_legacy
-    except ModuleNotFoundError:
+        import aioredis
+        return get_package_version_tuple(aioredis)
+    except ImportError:
         return None
-    try:
-        return tuple(int(x) for x in getattr(aioredis_legacy, "__version__").split("."))
-    except Exception:
-        return 0, 0, 0
 
 
 def _conn_attrs_to_dict(connection):

--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -24,12 +24,7 @@ from newrelic.hooks.datastore_redis import (
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 
-def get_aioredis_version():
-    try:
-        import aioredis
-        return get_package_version_tuple(aioredis)
-    except ImportError:
-        return None
+get_aioredis_version = lambda: get_package_version_tuple("aioredis")
 
 
 def _conn_attrs_to_dict(connection):

--- a/tests/agent_unittests/test_package_version_utils.py
+++ b/tests/agent_unittests/test_package_version_utils.py
@@ -21,6 +21,7 @@ from newrelic.common.package_version_utils import (
     NULL_VERSIONS,
     VERSION_ATTRS,
     get_package_version,
+    get_package_version_tuple,
 )
 
 IS_PY38_PLUS = sys.version_info[:2] >= (3, 8)
@@ -53,6 +54,24 @@ def test_get_package_version(attr, value, expected_value):
     # pytest instead for our purposes
     setattr(pytest, attr, value)
     version = get_package_version("pytest")
+    assert version == expected_value
+    delattr(pytest, attr)
+
+
+@pytest.mark.parametrize(
+    "attr,value,expected_value",
+    (
+        ("version", "1.2.3.4", (1, 2, 3, 4)),
+        ("__version__", "1.3.5rc2", (1, 3, "5rc2")),
+        ("__version_tuple__", (3, 5, 8), (3, 5, 8)),
+        ("version_tuple", [3, 1, "0b2"], (3, 1, "0b2")),
+    ),
+)
+def test_get_package_version_tuple(attr, value, expected_value):
+    # There is no file/module here, so we monkeypatch
+    # pytest instead for our purposes
+    setattr(pytest, attr, value)
+    version = get_package_version_tuple("pytest")
     assert version == expected_value
     delattr(pytest, attr)
 

--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -27,7 +27,7 @@ from testing_support.fixtures import (  # noqa: F401
 try:
     import aioredis
 
-    AIOREDIS_VERSION = get_package_version_tuple(aioredis)
+    AIOREDIS_VERSION = get_package_version_tuple("aioredis")
 except ImportError:
     import redis.asyncio as aioredis
 

--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import aioredis
 import pytest
 
+from newrelic.common.package_version_utils import get_package_version_tuple
 from testing_support.db_settings import redis_settings
 
 from testing_support.fixture.event_loop import event_loop as loop
@@ -24,7 +24,17 @@ from testing_support.fixtures import (  # noqa: F401
     collector_available_fixture,
 )
 
-AIOREDIS_VERSION = tuple(int(x) for x in aioredis.__version__.split(".")[:2])
+try:
+    import aioredis
+
+    AIOREDIS_VERSION = get_package_version_tuple(aioredis)
+except ImportError:
+    import redis.asyncio as aioredis
+
+    # Fake aioredis version to show when it was moved to redis.asyncio
+    AIOREDIS_VERSION = (2, 0, 2)
+
+
 SKIPIF_AIOREDIS_V1 = pytest.mark.skipif(AIOREDIS_VERSION < (2,), reason="Unsupported aioredis version.")
 SKIPIF_AIOREDIS_V2 = pytest.mark.skipif(AIOREDIS_VERSION >= (2,), reason="Unsupported aioredis version.")
 DB_SETTINGS = redis_settings()[0]

--- a/tests/datastore_aioredis/test_instance_info.py
+++ b/tests/datastore_aioredis/test_instance_info.py
@@ -14,10 +14,9 @@
 
 from inspect import isawaitable
 import pytest
-import aioredis
 
 from newrelic.hooks.datastore_aioredis import _conn_attrs_to_dict, _instance_info
-from conftest import AIOREDIS_VERSION, SKIPIF_AIOREDIS_V1
+from conftest import aioredis, AIOREDIS_VERSION, SKIPIF_AIOREDIS_V1
 
 _instance_info_tests = [
     ({}, ("localhost", "6379", "0")),
@@ -35,6 +34,10 @@ if AIOREDIS_VERSION >= (2, 0):
         @staticmethod
         async def connect(*args, **kwargs):
             pass
+    
+        async def can_read_destructive(self, *args, **kwargs):
+            return False
+
 
 
     class DisabledUnixConnection(aioredis.UnixDomainSocketConnection, DisabledConnection):

--- a/tests/datastore_aioredis/test_multiple_dbs.py
+++ b/tests/datastore_aioredis/test_multiple_dbs.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import aioredis
+from conftest import aioredis
+
 import pytest
 from conftest import AIOREDIS_VERSION, loop  # noqa
 from testing_support.db_settings import redis_settings

--- a/tests/datastore_aioredis/test_uninstrumented_methods.py
+++ b/tests/datastore_aioredis/test_uninstrumented_methods.py
@@ -15,7 +15,10 @@
 
 IGNORED_METHODS = {
     "address",
+    "auto_close_connection_pool",
     "channels",
+    "client_tracking_off",
+    "client_tracking_on",
     "close",
     "closed",
     "connection_pool",
@@ -25,6 +28,9 @@ IGNORED_METHODS = {
     "execute_command",
     "execute",
     "from_url",
+    "get_connection_kwargs",
+    "get_encoder",
+    "get_retry",
     "hscan_iter",
     "ihscan",
     "in_pubsub",
@@ -33,6 +39,7 @@ IGNORED_METHODS = {
     "iscan",
     "isscan",
     "izscan",
+    "load_external_module",
     "lock",
     "multi_exec",
     "parse_response",
@@ -42,9 +49,11 @@ IGNORED_METHODS = {
     "register_script",
     "response_callbacks",
     "RESPONSE_CALLBACKS",
+    "sentinel",
     "SET_IF_EXIST",
     "SET_IF_NOT_EXIST",
     "set_response_callback",
+    "set_retry",
     "SHUTDOWN_NOSAVE",
     "SHUTDOWN_SAVE",
     "single_connection_client",
@@ -60,6 +69,20 @@ IGNORED_METHODS = {
     "ZSET_IF_EXIST",
     "ZSET_IF_NOT_EXIST",
 }
+
+REDIS_MODULES = {
+    "bf",
+    "cf",
+    "cms",
+    "ft",
+    "graph",
+    "json",
+    "tdigest",
+    "topk",
+    "ts",
+}
+
+IGNORED_METHODS |= REDIS_MODULES
 
 
 def test_uninstrumented_methods(client):

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ envlist =
     redis-datastore_redis-{py37,py38,py39,py310,py311,pypy37}-redis{0400,latest},
     redis-datastore_aioredis-{py37,py38,py39,py310,pypy37}-aioredislatest,
     redis-datastore_aioredis-{py37,py310}-aioredis01,
+    redis-datastore_aioredis-{py37,py38,py39,py310,py311,pypy37}-redislatest,
     redis-datastore_aredis-{py37,py38,py39,pypy37}-aredislatest,
     solr-datastore_solrpy-{py27,pypy}-solrpy{00,01},
     python-datastore_sqlite-{py27,py37,py38,py39,py310,py311,pypy,pypy37},
@@ -253,6 +254,7 @@ deps =
     datastore_redis-redis0400: redis<4.1
     datastore_redis-redis03: redis<4.0
     datastore_redis-{py27,pypy}: rb
+    datastore_aioredis-redislatest: redis
     datastore_aioredis-aioredislatest: aioredis
     datastore_aioredis-aioredis01: aioredis<2
     datastore_aredis-aredislatest: aredis


### PR DESCRIPTION
# Overview

* Adapt `aioredis` tests to the moved version of the library located at `redis.asyncio` in the `redis-py` lib.
* Add tox envs for `redis.asyncio` separate from `aioredis` or existing `redis-py` envs to avoid as much confusing overlap as possible.
* Add `get_package_version_tuple` to replace common logic of splitting strings to tuples with safer alternative.

# Related Github Issue

Testing for #744
Related to #747
