### PR TITLE
Fix tests in starlette v0.23.1

### DIFF
--- a/tests/framework_starlette/test_bg_tasks.py
+++ b/tests/framework_starlette/test_bg_tasks.py
@@ -87,6 +87,8 @@ def test_basehttp_style_middleware(target_application, route):
         response = app.get("/" + route)
         assert response.status == 200
 
+    # The bug was fixed in version 0.21.0 but re-occured in 0.23.1.
+    # The bug was also not present on 0.20.1 to 0.23.1 if using Python3.7.
     BUG_COMPLETELY_FIXED = (0, 21, 0) <= starlette_version < (0, 23, 1) or (
         (0, 20, 1) <= starlette_version < (0, 23, 1) and sys.version_info[:2] > (3, 7)
     )

--- a/tests/framework_starlette/test_bg_tasks.py
+++ b/tests/framework_starlette/test_bg_tasks.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import pytest
 from starlette import __version__
 from testing_support.validators.validate_transaction_count import (
@@ -87,10 +85,8 @@ def test_basehttp_style_middleware(target_application, route):
         response = app.get("/" + route)
         assert response.status == 200
 
-    BUG_COMPLETELY_FIXED = (starlette_version >= (0, 21, 0)) or (
-        starlette_version >= (0, 20, 1) and sys.version_info[:2] > (3, 7)
-    )
-    BUG_PARTIALLY_FIXED = (0, 20, 1) <= starlette_version < (0, 21, 0) and sys.version_info[:2] <= (3, 7)
+    BUG_COMPLETELY_FIXED = (0, 21, 0) <= starlette_version < (0, 23, 1)
+    BUG_PARTIALLY_FIXED = (0, 20, 1) <= starlette_version < (0, 21, 0) or starlette_version >= (0, 23, 1)
 
     if BUG_COMPLETELY_FIXED:
         # Assert both web transaction and background task transactions are present.
@@ -103,6 +99,7 @@ def test_basehttp_style_middleware(target_application, route):
         # The background task no longer blocks the completion of the web request/web transaction.
         # However, the BaseHTTPMiddleware causes the task to be cancelled when the web request disconnects, so there are no
         # longer function traces or background task transactions.
+        # In version 0.23.1, the check to see if more_body exists is removed, reverting behavior to this model
         _test = validate_transaction_metrics("_test_bg_tasks:run_%s_bg_task" % route, scoped_metrics=[route_metric])(
             _test
         )

--- a/tests/framework_starlette/test_bg_tasks.py
+++ b/tests/framework_starlette/test_bg_tasks.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import pytest
 from starlette import __version__
 from testing_support.validators.validate_transaction_count import (
@@ -85,7 +87,9 @@ def test_basehttp_style_middleware(target_application, route):
         response = app.get("/" + route)
         assert response.status == 200
 
-    BUG_COMPLETELY_FIXED = (0, 21, 0) <= starlette_version < (0, 23, 1)
+    BUG_COMPLETELY_FIXED = (0, 21, 0) <= starlette_version < (0, 23, 1) or (
+        (0, 20, 1) <= starlette_version < (0, 23, 1) and sys.version_info[:2] > (3, 7)
+    )
     BUG_PARTIALLY_FIXED = (0, 20, 1) <= starlette_version < (0, 21, 0) or starlette_version >= (0, 23, 1)
 
     if BUG_COMPLETELY_FIXED:

--- a/tox.ini
+++ b/tox.ini
@@ -357,8 +357,7 @@ deps =
     framework_starlette-starlette0015: starlette<0.16
     framework_starlette-starlette0019: starlette<0.20
     framework_starlette-starlette002001: starlette==0.20.1
-    ; Starlette latest version temporarily pinned
-    framework_starlette-starlettelatest: starlette<0.23.1
+    framework_starlette-starlettelatest: starlette
     framework_strawberry: starlette
     framework_strawberry-strawberrylatest: strawberry-graphql
     framework_tornado: pycurl


### PR DESCRIPTION
With the release of [Starlette v0.23.1](https://github.com/encode/starlette/pull/1940), the check to see if "more_body" exists is removed