### PR TITLE
Add apdexPerfZone attribute to Transaction.

### DIFF
--- a/newrelic/core/transaction_node.py
+++ b/newrelic/core/transaction_node.py
@@ -452,6 +452,10 @@ class TransactionNode(_TransactionNode):
         def _add_if_not_empty(key, value):
             if value:
                 intrinsics[key] = value
+        
+        apdex_perf_zone = self.apdex_perf_zone()
+        _add_if_not_empty('apdexPerfZone', apdex_perf_zone)
+        _add_if_not_empty('nr.apdexPerfZone', apdex_perf_zone)
 
         if self.errors:
             intrinsics['error'] = True
@@ -467,8 +471,6 @@ class TransactionNode(_TransactionNode):
                     ','.join(self.alternate_path_hashes))
             _add_if_not_empty('nr.referringTransactionGuid',
                     self.referring_transaction_guid)
-            _add_if_not_empty('nr.apdexPerfZone',
-                    self.apdex_perf_zone())
 
         if self.synthetics_resource_id:
             intrinsics['nr.guid'] = self.guid

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -93,7 +93,7 @@ TRACE_ERROR_AGENT_KEYS = [
 
 AGENT_KEYS_ALL = TRACE_ERROR_AGENT_KEYS + REQ_PARAMS
 
-TRANS_EVENT_INTRINSICS = ("name", "duration", "type", "timestamp", "totalTime", "error")
+TRANS_EVENT_INTRINSICS = ("name", "duration", "type", "timestamp", "totalTime", "error", "nr.apdexPerfZone", "apdexPerfZone")
 TRANS_EVENT_AGENT_KEYS = [
     "response.status",
     "request.method",


### PR DESCRIPTION
# Summary
Add apdexPerfZone and nr.apdexPerfZone attribute to Web Transaction event intrinsic attributes.

Co-authored-by: Enriqueta De Leon <deleonenriqueta@users.noreply.github.com>
Co-authored-by: Kate Anderson <kanderson250@users.noreply.github.com>
Co-authored-by: Mary Martinez <mary-martinez@users.noreply.github.com>

# Overview
This PR 
- Updates transaction_node.py to include the attribute "apdexPerfZone".
- Moves "nr.apdexPerfZone" to be appended for all Web transaction events instead of just Cross Application Transaction events. 

# Testing
Updates test_attributes_in_action to validate both "apdexPerfZone" and "nr.apdexPerfZone".  
