### PR TITLE
Add Retry to Pip Install

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Time in seconds to backoff after the initial attempt.
 INITIAL_BACKOFF=10

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Grab first arg as number of retries
+retries=$1
+shift
+
+# Use for loop to repeatedly try the wrapped command, breaking on success
+for i in $(seq 1 $retries); do
+    echo "Running: $@"
+
+    # Exponential backoff
+    if [[ i -gt 1 ]]; then
+        # Start with 10 seconds, then double every retry.
+        backoff=$((1 * (2 ** (i - 2))))
+        echo "Command failed, retrying in $backoff seconds..."
+        sleep $backoff
+    fi
+    
+    # Run wrapped command, and exit on success
+    $@ && break
+    result=$?
+done
+
+# Exit with status code of wrapped command
+exit $?

--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Time in seconds to backoff after the initial attempt.
+INITIAL_BACKOFF=10
+
 # Grab first arg as number of retries
 retries=$1
 shift
@@ -10,8 +13,8 @@ for i in $(seq 1 $retries); do
 
     # Exponential backoff
     if [[ i -gt 1 ]]; then
-        # Start with 10 seconds, then double every retry.
-        backoff=$((1 * (2 ** (i - 2))))
+        # Starts with the initial backoff then doubles every retry.
+        backoff=$(($INITIAL_BACKOFF * (2 ** (i - 2))))
         echo "Command failed, retrying in $backoff seconds..."
         sleep $backoff
     fi

--- a/tox.ini
+++ b/tox.ini
@@ -416,8 +416,8 @@ commands =
 
 install_command=
     # Older pip versions that support python 2 have issues with using the cache directory and cause crashes on GitHub Actions
-    {py27,pypy}: pip install --no-cache-dir {opts} {packages}
-    !{py27,pypy}: pip install {opts} {packages}
+    {py27,pypy}: {toxinidir}/.github/scripts/retry.sh 3 pip install --no-cache-dir {opts} {packages}
+    !{py27,pypy}: {toxinidir}/.github/scripts/retry.sh 3 pip install {opts} {packages}
 
 extras =
     agent_streaming: infinite-tracing

--- a/tox.ini
+++ b/tox.ini
@@ -208,8 +208,8 @@ deps =
     application_celery: celery<6.0
     application_celery-py{py37,37}: importlib-metadata<5.0
     application_gearman: gearman<3.0.0
-    component_djangorestframework-djangorestframework0300: Django < 1.9
-    component_djangorestframework-djangorestframework0300: djangorestframework < 3.1
+    component_djangorestframework-djangorestframework0300: Django<1.9
+    component_djangorestframework-djangorestframework0300: djangorestframework<3.1
     component_djangorestframework-djangorestframeworklatest: Django
     component_djangorestframework-djangorestframeworklatest: djangorestframework
     component_flask_rest: flask


### PR DESCRIPTION
# Overview

* Fixes intermittent pip failures using retry with exponential backoff.
* Should drastically reduce the amount of manually test reruns required and allow merge queue to be useful.
