### PR TITLE
Fix PyPy Priority Sampling Test

### DIFF
--- a/tests/agent_features/test_priority_sampling.py
+++ b/tests/agent_features/test_priority_sampling.py
@@ -41,8 +41,9 @@ def test_priority_used_in_transaction_events(first_transaction_saved):
         transaction_events = list(stats_engine.transaction_events)
         assert len(transaction_events) == 1
 
-        # highest priority should win
-        assert stats_engine.transaction_events.pq[0][0] == 1
+        # Highest priority should win.
+        # Priority can be 1 or 2 depending on randomness in sampling computation.
+        assert stats_engine.transaction_events.pq[0][0] >= 1
 
         if first_transaction_saved:
             assert transaction_events[0][0]['name'].endswith('/T1')

--- a/tests/agent_features/test_priority_sampling.py
+++ b/tests/agent_features/test_priority_sampling.py
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 import pytest
+from testing_support.fixtures import (
+    core_application_stats_engine,
+    override_application_settings,
+    reset_core_stats_engine,
+)
 
-from testing_support.fixtures import (reset_core_stats_engine,
-        core_application_stats_engine, override_application_settings)
 from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import BackgroundTask
 
 
-@override_application_settings(
-        {'event_harvest_config.harvest_limits.analytic_event_data': 1})
-@pytest.mark.parametrize('first_transaction_saved', [True, False])
+@override_application_settings({"event_harvest_config.harvest_limits.analytic_event_data": 1})
+@pytest.mark.parametrize("first_transaction_saved", [True, False])
 def test_priority_used_in_transaction_events(first_transaction_saved):
     first_priority = 1 if first_transaction_saved else 0
     second_priority = 0 if first_transaction_saved else 1
@@ -32,10 +34,10 @@ def test_priority_used_in_transaction_events(first_transaction_saved):
         # Stats engine
         stats_engine = core_application_stats_engine()
 
-        with BackgroundTask(application(), name='T1') as txn:
+        with BackgroundTask(application(), name="T1") as txn:
             txn._priority = first_priority
 
-        with BackgroundTask(application(), name='T2') as txn:
+        with BackgroundTask(application(), name="T2") as txn:
             txn._priority = second_priority
 
         transaction_events = list(stats_engine.transaction_events)
@@ -46,33 +48,32 @@ def test_priority_used_in_transaction_events(first_transaction_saved):
         assert stats_engine.transaction_events.pq[0][0] >= 1
 
         if first_transaction_saved:
-            assert transaction_events[0][0]['name'].endswith('/T1')
+            assert transaction_events[0][0]["name"].endswith("/T1")
         else:
-            assert transaction_events[0][0]['name'].endswith('/T2')
+            assert transaction_events[0][0]["name"].endswith("/T2")
 
     _test()
 
 
-@override_application_settings({
-        'event_harvest_config.harvest_limits.error_event_data': 1})
-@pytest.mark.parametrize('first_transaction_saved', [True, False])
+@override_application_settings({"event_harvest_config.harvest_limits.error_event_data": 1})
+@pytest.mark.parametrize("first_transaction_saved", [True, False])
 def test_priority_used_in_transaction_error_events(first_transaction_saved):
     first_priority = 1 if first_transaction_saved else 0
     second_priority = 0 if first_transaction_saved else 1
 
     @reset_core_stats_engine()
     def _test():
-        with BackgroundTask(application(), name='T1') as txn:
+        with BackgroundTask(application(), name="T1") as txn:
             txn._priority = first_priority
             try:
-                raise ValueError('OOPS')
+                raise ValueError("OOPS")
             except ValueError:
                 txn.notice_error()
 
-        with BackgroundTask(application(), name='T2') as txn:
+        with BackgroundTask(application(), name="T2") as txn:
             txn._priority = second_priority
             try:
-                raise ValueError('OOPS')
+                raise ValueError("OOPS")
             except ValueError:
                 txn.notice_error()
 
@@ -86,29 +87,28 @@ def test_priority_used_in_transaction_error_events(first_transaction_saved):
         assert stats_engine.error_events.pq[0][0] == 1
 
         if first_transaction_saved:
-            assert error_events[0][0]['transactionName'].endswith('/T1')
+            assert error_events[0][0]["transactionName"].endswith("/T1")
         else:
-            assert error_events[0][0]['transactionName'].endswith('/T2')
+            assert error_events[0][0]["transactionName"].endswith("/T2")
 
     _test()
 
 
-@override_application_settings({
-        'event_harvest_config.harvest_limits.custom_event_data': 1})
-@pytest.mark.parametrize('first_transaction_saved', [True, False])
+@override_application_settings({"event_harvest_config.harvest_limits.custom_event_data": 1})
+@pytest.mark.parametrize("first_transaction_saved", [True, False])
 def test_priority_used_in_transaction_custom_events(first_transaction_saved):
     first_priority = 1 if first_transaction_saved else 0
     second_priority = 0 if first_transaction_saved else 1
 
     @reset_core_stats_engine()
     def _test():
-        with BackgroundTask(application(), name='T1') as txn:
+        with BackgroundTask(application(), name="T1") as txn:
             txn._priority = first_priority
-            txn.record_custom_event('foobar', {'foo': 'bar'})
+            txn.record_custom_event("foobar", {"foo": "bar"})
 
-        with BackgroundTask(application(), name='T2') as txn:
+        with BackgroundTask(application(), name="T2") as txn:
             txn._priority = second_priority
-            txn.record_custom_event('barbaz', {'foo': 'bar'})
+            txn.record_custom_event("barbaz", {"foo": "bar"})
 
         # Stats engine
         stats_engine = core_application_stats_engine()
@@ -120,8 +120,8 @@ def test_priority_used_in_transaction_custom_events(first_transaction_saved):
         assert stats_engine.custom_events.pq[0][0] == 1
 
         if first_transaction_saved:
-            assert custom_events[0][0]['type'] == 'foobar'
+            assert custom_events[0][0]["type"] == "foobar"
         else:
-            assert custom_events[0][0]['type'] == 'barbaz'
+            assert custom_events[0][0]["type"] == "barbaz"
 
     _test()


### PR DESCRIPTION
# Overview

* Due to randomness in the adaptive sampler, PyPy tests are randomly failing today (no idea why now) where the priority queue automatically adds 1 to the priority when marking a transaction as definitively sampled. Fixing existing test to account for this while still testing what it's aimed at.
