### PR TITLE
Infinite Tracing Supportability Feature Toggle Metrics

### DIFF
--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -566,16 +566,17 @@ class Application(object):
 
             # Infinite tracing feature toggle metrics
             infinite_tracing = configuration.infinite_tracing.enabled  # Property that checks trace observer host
-            infinite_tracing_batching = infinite_tracing and configuration.infinite_tracing.batching
-            infinite_tracing_compression = infinite_tracing and configuration.infinite_tracing.compression
-            internal_metric(
-                "Supportability/InfiniteTracing/gRPC/Batching/%s" % ("enabled" if infinite_tracing_batching else "disabled"),
-                1,
-            )
-            internal_metric(
-                "Supportability/InfiniteTracing/gRPC/Compression/%s" % ("enabled" if infinite_tracing_compression else "disabled"),
-                1,
-            )
+            if infinite_tracing:
+                infinite_tracing_batching = configuration.infinite_tracing.batching
+                infinite_tracing_compression = configuration.infinite_tracing.compression
+                internal_metric(
+                    "Supportability/InfiniteTracing/gRPC/Batching/%s" % ("enabled" if infinite_tracing_batching else "disabled"),
+                    1,
+                )
+                internal_metric(
+                    "Supportability/InfiniteTracing/gRPC/Compression/%s" % ("enabled" if infinite_tracing_compression else "disabled"),
+                    1,
+                )
 
         self._stats_engine.merge_custom_metrics(internal_metrics.metrics())
 

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -531,7 +531,7 @@ class Application(object):
             # which they were recorded. Make sure we do this before we
             # mark the session active so we don't have to grab a lock on
             # merging the internal metrics.
-            
+
             internal_metric(
                 "Supportability/Python/Application/Registration/Duration", self._period_start - connect_start
             )
@@ -570,11 +570,13 @@ class Application(object):
                 infinite_tracing_batching = configuration.infinite_tracing.batching
                 infinite_tracing_compression = configuration.infinite_tracing.compression
                 internal_metric(
-                    "Supportability/InfiniteTracing/gRPC/Batching/%s" % ("enabled" if infinite_tracing_batching else "disabled"),
+                    "Supportability/InfiniteTracing/gRPC/Batching/%s"
+                    % ("enabled" if infinite_tracing_batching else "disabled"),
                     1,
                 )
                 internal_metric(
-                    "Supportability/InfiniteTracing/gRPC/Compression/%s" % ("enabled" if infinite_tracing_compression else "disabled"),
+                    "Supportability/InfiniteTracing/gRPC/Compression/%s"
+                    % ("enabled" if infinite_tracing_compression else "disabled"),
                     1,
                 )
 

--- a/tests/agent_streaming/test_infinite_tracing.py
+++ b/tests/agent_streaming/test_infinite_tracing.py
@@ -17,15 +17,14 @@ import time
 
 import pytest
 from testing_support.fixtures import override_generic_settings
-from testing_support.validators.validate_metric_payload import validate_metric_payload
 from testing_support.util import conditional_decorator
+from testing_support.validators.validate_metric_payload import validate_metric_payload
 
 from newrelic.common.streaming_utils import StreamBuffer
 from newrelic.core.agent_streaming import StreamingRpc
 from newrelic.core.application import Application
 from newrelic.core.config import global_settings
 from newrelic.core.infinite_tracing_pb2 import AttributeValue, Span
-
 from newrelic.packages import six
 
 settings = global_settings()
@@ -331,7 +330,9 @@ def test_no_delay_on_ok(mock_grpc_server, monkeypatch, app, batching):
     _test()
 
 
-@conditional_decorator(condition=six.PY2, decorator=pytest.mark.xfail(reason="Test frequently times out on Py2.", strict=False))
+@conditional_decorator(
+    condition=six.PY2, decorator=pytest.mark.xfail(reason="Test frequently times out on Py2.", strict=False)
+)
 def test_no_data_loss_on_reconnect(mock_grpc_server, app, buffer_empty_event, batching, spans_processed_event):
     """
     Test for data loss when channel is closed by the server while waiting for more data in a request iterator.
@@ -494,7 +495,7 @@ def test_settings_supportability_metrics(mock_grpc_server, app, trace_observer_h
         },
     )
     @validate_metric_payload(metrics)
-    def _test():        
+    def _test():
         def connect_complete():
             connect_event.set()
 


### PR DESCRIPTION
# Overview

* Add feature toggle metrics for infinite tracing to supportability on agent startup. Note these are only sent ONCE and not on each harvest.
* Add testing for the new supportability metrics.
