### PR TITLE
Fix DT settings for transaction feature toggles test

### DIFF
--- a/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
+++ b/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
@@ -286,6 +286,7 @@ def validate_no_analytics_sample_data(wrapped, instance, args, kwargs):
 
 _test_collect_analytic_events_disabled_settings = {
     "collect_analytics_events": False,
+    "distributed_tracing.enabled": False,
     "browser_monitoring.attributes.enabled": True,
 }
 
@@ -328,6 +329,7 @@ def test_collect_analytic_events_disabled():
 
 _test_analytic_events_disabled_settings = {
     "transaction_events.enabled": False,
+    "distributed_tracing.enabled": False,
     "browser_monitoring.attributes.enabled": True,
 }
 


### PR DESCRIPTION
# Overview

* Test recently started failing as a result of #379. Fixed by disabling DT to prevent span event erroneously failing the test.
  * Unknown why this test went 500 days without having issues, and even now only seems to affect PyPy 3.7 in CI. Locally these tests seem to all fail fairly consistently.
