### PR TITLE
Fix Ariadne Middleware Testing

### DIFF
--- a/tests/framework_ariadne/test_application.py
+++ b/tests/framework_ariadne/test_application.py
@@ -21,6 +21,7 @@ from testing_support.validators.validate_transaction_count import validate_trans
 
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
+from newrelic.common.package_version_utils import get_package_version_tuple
 
 
 @pytest.fixture(scope="session")
@@ -193,8 +194,9 @@ def test_middleware(app, graphql_run, is_graphql_2):
     @background_task()
     def _test():
         from graphql import MiddlewareManager
+        middleware = [example_middleware] if get_package_version_tuple("ariadne") >= (0, 18) else MiddlewareManager(example_middleware)
 
-        ok, response = graphql_run(app, "{ hello }", middleware=MiddlewareManager(example_middleware))
+        ok, response = graphql_run(app, "{ hello }", middleware=middleware)
         assert ok and not response.get("errors")
         assert "Hello!" in str(response["data"])
 
@@ -243,8 +245,9 @@ def test_exception_in_middleware(app, graphql_run):
     @background_task()
     def _test():
         from graphql import MiddlewareManager
+        middleware = [error_middleware] if get_package_version_tuple("ariadne") >= (0, 18) else MiddlewareManager(error_middleware)
 
-        _, response = graphql_run(app, query, middleware=MiddlewareManager(error_middleware))
+        _, response = graphql_run(app, query, middleware=middleware)
         assert response["errors"]
 
     _test()


### PR DESCRIPTION
# Overview

* Fixes ariadne on versions >=v0.18.0 where middleware input types changed.
