### PR TITLE
Reduce number of spans in Starlette

### DIFF
--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -165,6 +165,10 @@ async def wrap_exception_handler_async(coro, exc):
 
 
 def wrap_exception_handler(wrapped, instance, args, kwargs):
+    transaction = current_transaction()
+    if transaction:
+        transaction.set_transaction_name(callable_name(wrapped), priority=1)
+
     if is_coroutine_function(wrapped):
         return wrap_exception_handler_async(FunctionTraceWrapper(wrapped)(*args, **kwargs), bind_exc(*args, **kwargs))
     else:

--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -250,7 +250,6 @@ def instrument_starlette_exceptions(module):
     # ExceptionMiddleware was moved to starlette.middleware.exceptions, need to check
     # that it isn't being imported through a deprecation and double wrapped.
     if not hasattr(module, "__deprecated__"):
-
         wrap_function_wrapper(module, "ExceptionMiddleware.__call__", error_middleware_wrapper)
 
         wrap_function_wrapper(module, "ExceptionMiddleware.http_exception", wrap_exception_handler)

--- a/tests/framework_starlette/test_application.py
+++ b/tests/framework_starlette/test_application.py
@@ -83,25 +83,23 @@ version_tweak_string = ".middleware" if starlette_version >= (0, 20, 1) else ""
 middleware_test = (
     (
         "no_error_handler",
-        "_test_application:middleware_factory.<locals>.middleware",
         "starlette.middleware.exceptions:ExceptionMiddleware.http_exception",
     ),
     (
         "non_async_error_handler_no_middleware",
-        "starlette.applications:Starlette.__call__",
         "_test_application:missing_route_handler",
     ),
 )
 
 
 @pytest.mark.parametrize(
-    "app_name, transaction_name, metric_name",
+    "app_name, transaction_name",
     middleware_test,
 )
-def test_application_nonexistent_route(target_application, app_name, transaction_name, metric_name):
+def test_application_nonexistent_route(target_application, app_name, transaction_name):
     @validate_transaction_metrics(
         transaction_name,
-        scoped_metrics=[("Function/" + metric_name, 1)],
+        scoped_metrics=[("Function/" + transaction_name, 1)],
         rollup_metrics=[FRAMEWORK_METRIC],
     )
     def _test():
@@ -130,8 +128,8 @@ def test_exception_in_middleware(target_application, app_name):
         exc_type = ValueError
 
     @validate_transaction_metrics(
-        "_test_application:middleware_factory.<locals>.middleware",
-        scoped_metrics=[("Function/_test_application:middleware_factory.<locals>.middleware", 1)],
+        "starlette.middleware.errors:ServerErrorMiddleware.error_response",
+        scoped_metrics=[("Function/starlette.middleware.errors:ServerErrorMiddleware.error_response", 1)],
         rollup_metrics=[FRAMEWORK_METRIC],
     )
     @validate_transaction_errors(errors=[callable_name(exc_type)])

--- a/tests/framework_starlette/test_application.py
+++ b/tests/framework_starlette/test_application.py
@@ -128,9 +128,9 @@ def test_exception_in_middleware(target_application, app_name):
         exc_type = ValueError
 
     expected_transaction = (
-        "starlette.middleware.errors:ServerErrorMiddleware.error_response"
-        if starlette_version >= (0, 16, 0)
-        else "_test_application:middleware_factory.<locals>.middleware"
+        "_test_application:middleware_factory.<locals>.middleware"
+        if (0, 15) <= starlette_version < (0, 16)
+        else "starlette.middleware.errors:ServerErrorMiddleware.error_response"
     )
 
     @validate_transaction_metrics(

--- a/tests/framework_starlette/test_application.py
+++ b/tests/framework_starlette/test_application.py
@@ -124,14 +124,11 @@ def test_exception_in_middleware(target_application, app_name):
         from anyio._backends._asyncio import ExceptionGroup
 
         exc_type = ExceptionGroup
+        expected_transaction = "_test_application:middleware_factory.<locals>.middleware"
     else:
         exc_type = ValueError
 
-    expected_transaction = (
-        "_test_application:middleware_factory.<locals>.middleware"
-        if (0, 15) <= starlette_version < (0, 16)
-        else "starlette.middleware.errors:ServerErrorMiddleware.error_response"
-    )
+        expected_transaction = "starlette.middleware.errors:ServerErrorMiddleware.error_response"
 
     @validate_transaction_metrics(
         expected_transaction,


### PR DESCRIPTION
# Overview
This removes the following middleware from being instrumented in an effort to reduce the number of spans created when instrumenting starlette:
* `ServerErrorMiddleware.__call__`

# Related Github Issue
[Spike DT Improvements](https://issues.newrelic.com/browse/NR-91358)