### PR TITLE
Guard GraphQL Settings Lookup

### DIFF
--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -105,7 +105,6 @@ def bind_operation_v2(exe_context, operation, root_value):
 def wrap_execute_operation(wrapped, instance, args, kwargs):
     transaction = current_transaction()
     trace = current_trace()
-    settings = transaction.settings
 
     if not transaction:
         return wrapped(*args, **kwargs)
@@ -136,7 +135,8 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
     if operation.selection_set is not None:
         fields = operation.selection_set.selections
         # Ignore transactions for introspection queries
-        if not settings.instrumentation.graphql.capture_introspection_queries:
+        capture_introspection_queries = transaction and transaction.settings and transaction.settings.instrumentation and transaction.settings.instrumentation.graphql and transaction.settings.instrumentation.graphql.capture_introspection_queries
+        if not capture_introspection_queries:
             # If all selected fields are introspection fields
             if all(get_node_value(field, "name") in GRAPHQL_INTROSPECTION_FIELDS for field in fields):
                 ignore_transaction()

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -135,14 +135,7 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
     if operation.selection_set is not None:
         fields = operation.selection_set.selections
         # Ignore transactions for introspection queries
-        capture_introspection_queries = (
-            transaction
-            and transaction.settings
-            and transaction.settings.instrumentation
-            and transaction.settings.instrumentation.graphql
-            and transaction.settings.instrumentation.graphql.capture_introspection_queries
-        )
-        if not capture_introspection_queries:
+        if not (transaction.settings and transaction.settings.instrumentation.graphql.capture_introspection_queries):
             # If all selected fields are introspection fields
             if all(get_node_value(field, "name") in GRAPHQL_INTROSPECTION_FIELDS for field in fields):
                 ignore_transaction()

--- a/newrelic/hooks/framework_graphql.py
+++ b/newrelic/hooks/framework_graphql.py
@@ -135,7 +135,13 @@ def wrap_execute_operation(wrapped, instance, args, kwargs):
     if operation.selection_set is not None:
         fields = operation.selection_set.selections
         # Ignore transactions for introspection queries
-        capture_introspection_queries = transaction and transaction.settings and transaction.settings.instrumentation and transaction.settings.instrumentation.graphql and transaction.settings.instrumentation.graphql.capture_introspection_queries
+        capture_introspection_queries = (
+            transaction
+            and transaction.settings
+            and transaction.settings.instrumentation
+            and transaction.settings.instrumentation.graphql
+            and transaction.settings.instrumentation.graphql.capture_introspection_queries
+        )
         if not capture_introspection_queries:
             # If all selected fields are introspection fields
             if all(get_node_value(field, "name") in GRAPHQL_INTROSPECTION_FIELDS for field in fields):

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -79,6 +79,14 @@ def error_middleware(next, root, info, **args):
     raise RuntimeError("Runtime Error!")
 
 
+def test_no_harm_no_transaction(app, graphql_run):
+    def _test():
+        response = graphql_run(app, "{ __schema { types { name } } }")
+        assert not response.errors
+
+    _test()
+
+
 _runtime_error_name = callable_name(RuntimeError)
 _test_runtime_error = [(_runtime_error_name, "Runtime Error!")]
 _graphql_base_rollup_metrics = [


### PR DESCRIPTION
# Overview

* A bug was introduced in GraphQL instrumentation when not running within a transaction in v8.7.1.
* Adds a settings lookup guard to address this crash.

# Related Github Issue

Closes #786
