### PR TITLE
Fix Redis Instance Info

### DIFF
--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -472,7 +472,7 @@ def _conn_attrs_to_dict(connection):
 
 def _instance_info(kwargs):
     host = kwargs.get("host") or "localhost"
-    port_path_or_id = str(kwargs.get("port") or kwargs.get("path", "unknown"))
+    port_path_or_id = str(kwargs.get("path") or kwargs.get("port", "unknown"))
     db = str(kwargs.get("db") or 0)
 
     return (host, port_path_or_id, db)

--- a/tests/datastore_redis/test_instance_info.py
+++ b/tests/datastore_redis/test_instance_info.py
@@ -100,7 +100,6 @@ _instance_info_from_url_tests = [
 if (3, 5, 3) >= REDIS_PY_VERSION >= (2, 7, 5):
     _instance_info_from_url_tests.append((("redis://127.0.0.1",), {}, ("127.0.0.1", "6379", "0")))
 
-
 if REDIS_PY_VERSION >= (2, 10):
     _instance_info_from_url_tests.extend(
         [
@@ -115,13 +114,6 @@ if REDIS_PY_VERSION >= (2, 10):
             (("unix:///path/to/socket.sock",), {"db": 2}, ("localhost", "/path/to/socket.sock", "2")),
         ]
     )
-
-if REDIS_PY_VERSION >= (4, 5, 2):
-    _instance_info_from_url_tests_4_5_2 = _instance_info_from_url_tests[:-3] + [
-        (("unix:///path/to/socket.sock",), {}, ("localhost", "6379", "0")),
-        (("unix:///path/to/socket.sock?db=2",), {}, ("localhost", "6379", "2")),
-        (("unix:///path/to/socket.sock",), {"db": 2}, ("localhost", "6379", "2")),
-    ]
 
 
 @pytest.mark.skipif(REDIS_PY_VERSION < (2, 6), reason="from_url not yet implemented in this redis-py version")
@@ -141,10 +133,7 @@ def test_strict_redis_client_from_url(args, kwargs, expected):
 
 
 @pytest.mark.skipif(REDIS_PY_VERSION < (2, 6), reason="from_url not yet implemented in this redis-py version")
-@pytest.mark.parametrize(
-    "args,kwargs,expected",
-    _instance_info_from_url_tests if REDIS_PY_VERSION < (4, 5, 2) else _instance_info_from_url_tests_4_5_2,
-)
+@pytest.mark.parametrize("args,kwargs,expected", _instance_info_from_url_tests)
 def test_redis_connection_from_url(args, kwargs, expected):
     r = redis.Redis.from_url(*args, **kwargs)
     if r.connection_pool.connection_class is redis.Connection:
@@ -164,10 +153,7 @@ def test_redis_connection_from_url(args, kwargs, expected):
 
 
 @pytest.mark.skipif(REDIS_PY_VERSION < (2, 6), reason="from_url not yet implemented in this redis-py version")
-@pytest.mark.parametrize(
-    "args,kwargs,expected",
-    _instance_info_from_url_tests if REDIS_PY_VERSION < (4, 5, 2) else _instance_info_from_url_tests_4_5_2,
-)
+@pytest.mark.parametrize("args,kwargs,expected", _instance_info_from_url_tests)
 def test_strict_redis_connection_from_url(args, kwargs, expected):
     r = redis.StrictRedis.from_url(*args, **kwargs)
     if r.connection_pool.connection_class is redis.Connection:


### PR DESCRIPTION
# Overview

* Latest version of redis changed defaults values for connections. Fix logic to handle this.
  * connection.port now has a default value while connection.path does not. Reorder detection of socket path vs port for `port_path_or_id` attribute to fix this.
  * Reverts #784 which changed the tests to assert the new behavior, which was incorrect.
