### PR TITLE
Fix Loguru Instrumentation for v0.7.0

### DIFF
--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -17,9 +17,9 @@ from newrelic.packages import six
 if six.PY3:
     from inspect import Signature
 
-    def bind_args(func, args, kwargs, unwrap=False):
+    def bind_args(func, args, kwargs):
         """Bind arguments and apply defaults to missing arugments for a callable."""
-        bound_args = Signature.from_callable(func, follow_wrapped=unwrap).bind(*args, **kwargs)
+        bound_args = Signature.from_callable(func).bind(*args, **kwargs)
         bound_args.apply_defaults()
         return bound_args.arguments
 

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -29,5 +29,5 @@ else:
         if unwrap:
             while hasattr(func, "__wrapped__"):
                 func = func.__wrapped__
-        
+
         return getcallargs(func, *args, **kwargs)

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -33,7 +33,7 @@ else:
         """
         Bind arguments and apply defaults to missing arugments for a callable.
         Calling with unwrap=True will follow the __wrapped__ chain to the underlying function.
-        
+
         Note: Python 2 does not include a __wrapped__ attribute for functools.wraps decorators.
         Only wrapt decorators will be handled when called with unwrap=True.
         """

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -1,0 +1,33 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from newrelic.packages import six
+
+if six.PY3:
+    from inspect import Signature
+
+    def bind_args(func, args, kwargs, unwrap=False):
+        bound_args = Signature.from_callable(func, follow_wrapped=unwrap).bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        return bound_args.arguments
+
+else:
+    from inspect import getcallargs
+
+    def bind_args(func, args, kwargs, unwrap=False):
+        if unwrap:
+            while hasattr(func, "__wrapped__"):
+                func = func.__wrapped__
+        
+        return getcallargs(func, *args, **kwargs)

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -18,27 +18,10 @@ if six.PY3:
     from inspect import Signature
 
     def bind_args(func, args, kwargs, unwrap=False):
-        """
-        Bind arguments and apply defaults to missing arugments for a callable.
-        Calling with unwrap=True will follow the __wrapped__ chain to the underlying function.
-        """
+        """Bind arguments and apply defaults to missing arugments for a callable."""
         bound_args = Signature.from_callable(func, follow_wrapped=unwrap).bind(*args, **kwargs)
         bound_args.apply_defaults()
         return bound_args.arguments
 
 else:
-    from inspect import getcallargs
-
-    def bind_args(func, args, kwargs, unwrap=False):
-        """
-        Bind arguments and apply defaults to missing arugments for a callable.
-        Calling with unwrap=True will follow the __wrapped__ chain to the underlying function.
-
-        Note: Python 2 does not include a __wrapped__ attribute for functools.wraps decorators.
-        Only wrapt decorators will be handled when called with unwrap=True.
-        """
-        if unwrap:
-            while hasattr(func, "__wrapped__"):
-                func = func.__wrapped__
-
-        return getcallargs(func, *args, **kwargs)
+    from inspect import getcallargs as bind_args

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -18,6 +18,10 @@ if six.PY3:
     from inspect import Signature
 
     def bind_args(func, args, kwargs, unwrap=False):
+        """
+        Bind arguments and apply defaults to missing arugments for a callable.
+        Calling with unwrap=True will follow the __wrapped__ chain to the underlying function.
+        """
         bound_args = Signature.from_callable(func, follow_wrapped=unwrap).bind(*args, **kwargs)
         bound_args.apply_defaults()
         return bound_args.arguments
@@ -26,6 +30,13 @@ else:
     from inspect import getcallargs
 
     def bind_args(func, args, kwargs, unwrap=False):
+        """
+        Bind arguments and apply defaults to missing arugments for a callable.
+        Calling with unwrap=True will follow the __wrapped__ chain to the underlying function.
+        
+        Note: Python 2 does not include a __wrapped__ attribute for functools.wraps decorators.
+        Only wrapt decorators will be handled when called with unwrap=True.
+        """
         if unwrap:
             while hasattr(func, "__wrapped__"):
                 func = func.__wrapped__

--- a/newrelic/common/signature.py
+++ b/newrelic/common/signature.py
@@ -24,4 +24,8 @@ if six.PY3:
         return bound_args.arguments
 
 else:
-    from inspect import getcallargs as bind_args
+    from inspect import getcallargs
+
+    def bind_args(func, args, kwargs):
+        """Bind arguments and apply defaults to missing arugments for a callable."""
+        return getcallargs(func, *args, **kwargs)

--- a/newrelic/hooks/logger_loguru.py
+++ b/newrelic/hooks/logger_loguru.py
@@ -23,11 +23,13 @@ from newrelic.core.config import global_settings
 from newrelic.hooks.logger_logging import add_nr_linking_metadata
 from newrelic.packages import six
 
-_logger = logging.getLogger(__name__) 
+_logger = logging.getLogger(__name__)
 is_pypy = hasattr(sys, "pypy_version_info")
+
 
 def loguru_version():
     from loguru import __version__
+
     return tuple(int(x) for x in __version__.split("."))
 
 
@@ -55,7 +57,7 @@ def _nr_log_forwarder(message_instance):
                 if application and application.enabled:
                     application.record_custom_metric("Logging/lines", {"count": 1})
                     application.record_custom_metric("Logging/lines/%s" % level_name, {"count": 1})
-            
+
         if settings.application_logging.forwarding and settings.application_logging.forwarding.enabled:
             try:
                 record_log_event(message, level_name, int(record["time"].timestamp()))
@@ -64,6 +66,7 @@ def _nr_log_forwarder(message_instance):
 
 
 ALLOWED_LOGURU_OPTIONS_LENGTHS = frozenset((8, 9))
+
 
 def wrap_log(wrapped, instance, args, kwargs):
     try:
@@ -93,7 +96,7 @@ def nr_log_patcher(original_patcher=None):
     def _nr_log_patcher(record):
         if original_patcher:
             record = original_patcher(record)
-        
+
         transaction = current_transaction()
 
         if transaction:

--- a/tests/agent_unittests/test_siganture.py
+++ b/tests/agent_unittests/test_siganture.py
@@ -1,0 +1,50 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import pytest
+
+from newrelic.common.signature import bind_args
+
+@pytest.mark.parametrize("func,args,kwargs,expected", [
+    (lambda x, y: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
+    (lambda x=1, y=2: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
+    (lambda x=1: None, (), {}, {"x": 1}),
+], ids=("posargs", "kwargs", "defaults"))
+def test_signature_binding(func, args, kwargs, expected):
+    bound_args = bind_args(func, args, kwargs)
+    assert bound_args == expected
+
+
+def decorator(f):
+    @functools.wraps(f)
+    def _decorator(*args, **kwargs):
+        return f(*args, **kwargs)
+    return _decorator
+
+@decorator
+def func(x, y=None):
+    pass
+
+
+@pytest.mark.parametrize("unwrap,args,kwargs,expected", [
+    (True, (1,), {"y": 2}, {"x": 1, "y": 2}),
+    (False, (1,), {"y": 2}, {"args": (1,), "kwargs": {"y": 2}}),
+    (True, (1,), {}, {"x": 1, "y": None}),
+    (False, (1,), {}, {"args": (1,), "kwargs": {}}),
+], ids=("unwrapped_standard", "wrapped_standard", "unwrapped_default", "wrapped_default"))
+def test_wrapped_signature_binding(unwrap, args, kwargs, expected):
+    bound_args = bind_args(func, args, kwargs, unwrap=unwrap)
+    assert bound_args == expected

--- a/tests/agent_unittests/test_siganture.py
+++ b/tests/agent_unittests/test_siganture.py
@@ -18,11 +18,16 @@ import pytest
 
 from newrelic.common.signature import bind_args
 
-@pytest.mark.parametrize("func,args,kwargs,expected", [
-    (lambda x, y: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
-    (lambda x=1, y=2: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
-    (lambda x=1: None, (), {}, {"x": 1}),
-], ids=("posargs", "kwargs", "defaults"))
+
+@pytest.mark.parametrize(
+    "func,args,kwargs,expected",
+    [
+        (lambda x, y: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
+        (lambda x=1, y=2: None, (1,), {"y": 2}, {"x": 1, "y": 2}),
+        (lambda x=1: None, (), {}, {"x": 1}),
+    ],
+    ids=("posargs", "kwargs", "defaults"),
+)
 def test_signature_binding(func, args, kwargs, expected):
     bound_args = bind_args(func, args, kwargs)
     assert bound_args == expected
@@ -32,19 +37,25 @@ def decorator(f):
     @functools.wraps(f)
     def _decorator(*args, **kwargs):
         return f(*args, **kwargs)
+
     return _decorator
+
 
 @decorator
 def func(x, y=None):
     pass
 
 
-@pytest.mark.parametrize("unwrap,args,kwargs,expected", [
-    (True, (1,), {"y": 2}, {"x": 1, "y": 2}),
-    (False, (1,), {"y": 2}, {"args": (1,), "kwargs": {"y": 2}}),
-    (True, (1,), {}, {"x": 1, "y": None}),
-    (False, (1,), {}, {"args": (1,), "kwargs": {}}),
-], ids=("unwrapped_standard", "wrapped_standard", "unwrapped_default", "wrapped_default"))
+@pytest.mark.parametrize(
+    "unwrap,args,kwargs,expected",
+    [
+        (True, (1,), {"y": 2}, {"x": 1, "y": 2}),
+        (False, (1,), {"y": 2}, {"args": (1,), "kwargs": {"y": 2}}),
+        (True, (1,), {}, {"x": 1, "y": None}),
+        (False, (1,), {}, {"args": (1,), "kwargs": {}}),
+    ],
+    ids=("unwrapped_standard", "wrapped_standard", "unwrapped_default", "wrapped_default"),
+)
 def test_wrapped_signature_binding(unwrap, args, kwargs, expected):
     bound_args = bind_args(func, args, kwargs, unwrap=unwrap)
     assert bound_args == expected

--- a/tests/agent_unittests/test_signature.py
+++ b/tests/agent_unittests/test_signature.py
@@ -32,31 +32,3 @@ from newrelic.packages import six
 def test_signature_binding(func, args, kwargs, expected):
     bound_args = bind_args(func, args, kwargs)
     assert bound_args == expected
-
-
-def decorator(f):
-    @functools.wraps(f)
-    def _decorator(*args, **kwargs):
-        return f(*args, **kwargs)
-
-    return _decorator
-
-
-@decorator
-def func(x, y=None):
-    pass
-
-
-@pytest.mark.parametrize(
-    "unwrap,args,kwargs,expected",
-    [
-        (True, (1,), {"y": 2}, {"x": 1, "y": 2} if six.PY3 else {"args": (1,), "kwargs": {"y": 2}}),
-        (False, (1,), {"y": 2}, {"args": (1,), "kwargs": {"y": 2}}),
-        (True, (1,), {}, {"x": 1, "y": None} if six.PY3 else {"args": (1,), "kwargs": {}}),
-        (False, (1,), {}, {"args": (1,), "kwargs": {}}),
-    ],
-    ids=("unwrapped_standard", "wrapped_standard", "unwrapped_default", "wrapped_default"),
-)
-def test_wrapped_signature_binding(unwrap, args, kwargs, expected):
-    bound_args = bind_args(func, args, kwargs, unwrap=unwrap)
-    assert bound_args == expected

--- a/tests/agent_unittests/test_signature.py
+++ b/tests/agent_unittests/test_signature.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 import pytest
 
 from newrelic.common.signature import bind_args
-from newrelic.packages import six
 
 
 @pytest.mark.parametrize(

--- a/tests/agent_unittests/test_signature.py
+++ b/tests/agent_unittests/test_signature.py
@@ -17,6 +17,7 @@ import functools
 import pytest
 
 from newrelic.common.signature import bind_args
+from newrelic.packages import six
 
 
 @pytest.mark.parametrize(
@@ -49,9 +50,9 @@ def func(x, y=None):
 @pytest.mark.parametrize(
     "unwrap,args,kwargs,expected",
     [
-        (True, (1,), {"y": 2}, {"x": 1, "y": 2}),
+        (True, (1,), {"y": 2}, {"x": 1, "y": 2} if six.PY3 else {"args": (1,), "kwargs": {"y": 2}}),
         (False, (1,), {"y": 2}, {"args": (1,), "kwargs": {"y": 2}}),
-        (True, (1,), {}, {"x": 1, "y": None}),
+        (True, (1,), {}, {"x": 1, "y": None} if six.PY3 else {"args": (1,), "kwargs": {}}),
         (False, (1,), {}, {"args": (1,), "kwargs": {}}),
     ],
     ids=("unwrapped_standard", "wrapped_standard", "unwrapped_default", "wrapped_default"),


### PR DESCRIPTION
# Overview

* Signatures changed in loguru v0.7.0 breaking local decorating and call stack adjustments. Fixed with auto-signature implementation.
