### PR TITLE
Pin virtualenv, fix pip arg deprecation & disable kafka tests

### DIFF
--- a/.github/actions/setup-python-matrix/action.yml
+++ b/.github/actions/setup-python-matrix/action.yml
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         python3.10 -m pip install -U pip
-        python3.10 -m pip install -U wheel setuptools 'tox<4' virtualenv!=20.0.24
+        python3.10 -m pip install -U wheel setuptools 'tox<4' 'virtualenv<20.21.1'

--- a/.github/actions/setup-python-matrix/action.yml
+++ b/.github/actions/setup-python-matrix/action.yml
@@ -47,4 +47,4 @@ runs:
       shell: bash
       run: |
         python3.10 -m pip install -U pip
-        python3.10 -m pip install -U wheel setuptools 'tox<4' 'virtualenv<20.21.1'
+        python3.10 -m pip install -U wheel setuptools 'tox<4' 'virtualenv<20.22.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - elasticsearchserver08
       - gearman
       - grpc
-      - kafka
+      #- kafka
       - libcurl
       - memcached
       - mongodb
@@ -534,77 +534,77 @@ jobs:
           path: ./**/.coverage.*
           retention-days: 1
 
-  kafka:
-    env:
-      TOTAL_GROUPS: 4
+  #kafka:
+  #  env:
+  #    TOTAL_GROUPS: 4
 
-    strategy:
-      fail-fast: false
-      matrix:
-        group-number: [1, 2, 3, 4]
+  #  strategy:
+  #    fail-fast: false
+  #    matrix:
+  #      group-number: [1, 2, 3, 4]
 
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
+  #  runs-on: ubuntu-20.04
+  #  timeout-minutes: 30
 
-    services:
-      zookeeper:
-        image: bitnami/zookeeper:3.7
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
+  #  services:
+  #    zookeeper:
+  #      image: bitnami/zookeeper:3.7
+  #      env:
+  #        ALLOW_ANONYMOUS_LOGIN: yes
 
-        ports:
-          - 2181:2181
+  #      ports:
+  #        - 2181:2181
 
-      kafka:
-        image: bitnami/kafka:3.2
-        ports:
-          - 8080:8080
-          - 8081:8081
-        env:
-          ALLOW_PLAINTEXT_LISTENER: yes
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: true
-          KAFKA_CFG_LISTENERS: L1://:8080,L2://:8081
-          KAFKA_CFG_ADVERTISED_LISTENERS: L1://127.0.0.1:8080,L2://kafka:8081,
-          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: L1:PLAINTEXT,L2:PLAINTEXT
-          KAFKA_CFG_INTER_BROKER_LISTENER_NAME: L2
+  #    kafka:
+  #      image: bitnami/kafka:3.2
+  #      ports:
+  #        - 8080:8080
+  #        - 8081:8081
+  #      env:
+  #        ALLOW_PLAINTEXT_LISTENER: yes
+  #        KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+  #        KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: true
+  #        KAFKA_CFG_LISTENERS: L1://:8080,L2://:8081
+  #        KAFKA_CFG_ADVERTISED_LISTENERS: L1://127.0.0.1:8080,L2://kafka:8081,
+  #        KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: L1:PLAINTEXT,L2:PLAINTEXT
+  #        KAFKA_CFG_INTER_BROKER_LISTENER_NAME: L2
 
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-python-matrix
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: ./.github/actions/setup-python-matrix
 
-      # Special case packages
-      - name: Install librdkafka-dev
-        run: |
-          # Use lsb-release to find the codename of Ubuntu to use to install the correct library name
-          sudo apt-get update
-          sudo ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
-          sudo apt-get install -y wget gnupg2 software-properties-common
-          sudo wget -qO - https://packages.confluent.io/deb/7.2/archive.key | sudo apt-key add -
-          sudo add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
-          sudo apt-get update
-          sudo apt-get install -y librdkafka-dev/$(lsb_release -c | cut -f 2)
+  #    # Special case packages
+  #    - name: Install librdkafka-dev
+  #      run: |
+  #        # Use lsb-release to find the codename of Ubuntu to use to install the correct library name
+  #        sudo apt-get update
+  #        sudo ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+  #        sudo apt-get install -y wget gnupg2 software-properties-common
+  #        sudo wget -qO - https://packages.confluent.io/deb/7.2/archive.key | sudo apt-key add -
+  #        sudo add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+  #        sudo apt-get update
+  #        sudo apt-get install -y librdkafka-dev/$(lsb_release -c | cut -f 2)
 
-      - name: Get Environments
-        id: get-envs
-        run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
-        env:
-          GROUP_NUMBER: ${{ matrix.group-number }}
+  #    - name: Get Environments
+  #      id: get-envs
+  #      run: |
+  #        echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+  #      env:
+  #        GROUP_NUMBER: ${{ matrix.group-number }}
 
-      - name: Test
-        run: |
-          tox -vv -e ${{ steps.get-envs.outputs.envs }}
-        env:
-          TOX_PARALLEL_NO_SPINNER: 1
-          PY_COLORS: 0
+  #    - name: Test
+  #      run: |
+  #        tox -vv -e ${{ steps.get-envs.outputs.envs }}
+  #      env:
+  #        TOX_PARALLEL_NO_SPINNER: 1
+  #        PY_COLORS: 0
 
-      - name: Upload Coverage Artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-${{ github.job }}-${{ strategy.job-index }}
-          path: ./**/.coverage.*
-          retention-days: 1
+  #    - name: Upload Coverage Artifacts
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: coverage-${{ github.job }}-${{ strategy.job-index }}
+  #        path: ./**/.coverage.*
+  #        retention-days: 1
 
   mongodb:
     env:

--- a/tox.ini
+++ b/tox.ini
@@ -397,7 +397,7 @@ commands =
     framework_grpc:     --grpc_python_out={toxinidir}/tests/framework_grpc/sample_application \
     framework_grpc:     /{toxinidir}/tests/framework_grpc/sample_application/sample_application.proto
 
-    libcurl: pip install --ignore-installed --install-option="--with-openssl" pycurl
+    libcurl: pip install --ignore-installed --config-settings="--build-option=--with-openssl" pycurl
 
     py.test -v []
 


### PR DESCRIPTION
# Overview
Pin virtualenv to the last version before they stopped supporting Python 2.7 (f strings are now used, which are only supported in Python 3)
Pin pip because install-options was deprecated (we use this to install pycurl with openssl).
