### PR TITLE
Added separate instrumentation for redis.asyncio.client

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2675,9 +2675,19 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "redis.asyncio.client", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
+    )
+
+    _process_module_definition(
+        "redis.asyncio.commands", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
+    )
+
+    # Redis v4.2+
+    _process_module_definition(
         "redis.asyncio.client", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
     )
 
+    # Redis v4.2+
     _process_module_definition(
         "redis.asyncio.commands", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
     )

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2675,11 +2675,11 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
-        "redis.asyncio.client", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
+        "redis.asyncio.client", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
     )
 
     _process_module_definition(
-        "redis.asyncio.commands", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
+        "redis.asyncio.commands", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
     )
 
     _process_module_definition(

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2674,14 +2674,6 @@ def _process_module_builtin_defaults():
         "aioredis.connection", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_connection"
     )
 
-    _process_module_definition(
-        "redis.asyncio.client", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
-    )
-
-    _process_module_definition(
-        "redis.asyncio.commands", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_client"
-    )
-
     # Redis v4.2+
     _process_module_definition(
         "redis.asyncio.client", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"

--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -72,8 +72,6 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
             # AioRedis v2 uses a Pipeline object for a client and internally queues up pipeline commands
             if aioredis_version:
                 from aioredis.client import Pipeline
-            else:
-                from redis.asyncio.client import Pipeline
             if isinstance(instance, Pipeline):
                 return wrapped(*args, **kwargs)
 

--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -16,8 +16,8 @@ import re
 
 from newrelic.api.datastore_trace import DatastoreTrace
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_wrapper import function_wrapper
-from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
+
 
 _redis_client_methods = {
     "acl_cat",

--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -16,6 +16,7 @@ import re
 
 from newrelic.api.datastore_trace import DatastoreTrace
 from newrelic.api.transaction import current_transaction
+from newrelic.common.object_wrapper import function_wrapper
 from newrelic.common.object_wrapper import wrap_function_wrapper
 
 _redis_client_methods = {
@@ -504,6 +505,29 @@ def _wrap_Redis_method_wrapper_(module, instance_class_name, operation):
     wrap_function_wrapper(module, name, _nr_wrapper_Redis_method_)
 
 
+def _wrap_asyncio_Redis_method_wrapper(module, instance_class_name, operation):
+
+    @function_wrapper
+    async def _nr_wrapper_asyncio_Redis_async_method_(wrapped, instance, args, kwargs):
+        transaction = current_transaction()
+        if transaction is None:
+            return await wrapped(*args, **kwargs)
+
+        with DatastoreTrace(product="Redis", target=None, operation=operation):
+            return await wrapped(*args, **kwargs)
+
+    def _nr_wrapper_asyncio_Redis_method_(wrapped, instance, args, kwargs):
+        from redis.asyncio.client import Pipeline
+        if isinstance(instance, Pipeline):
+            return wrapped(*args, **kwargs)
+
+        # Method should be run when awaited, therefore we wrap in an async wrapper.
+        return _nr_wrapper_asyncio_Redis_async_method_(wrapped)(*args, **kwargs)
+
+    name = "%s.%s" % (instance_class_name, operation)
+    wrap_function_wrapper(module, name, _nr_wrapper_asyncio_Redis_method_)
+
+
 def _nr_Connection_send_command_wrapper_(wrapped, instance, args, kwargs):
     transaction = current_transaction()
 
@@ -564,6 +588,13 @@ def instrument_redis_client(module):
             if name in vars(module.Redis):
                 _wrap_Redis_method_wrapper_(module, "Redis", name)
 
+
+def instrument_asyncio_redis_client(module):
+    if hasattr(module, "Redis"):
+        class_ = getattr(module, "Redis")
+        for operation in _redis_client_methods:
+            if hasattr(class_, operation):
+                _wrap_asyncio_Redis_method_wrapper(module, "Redis", operation)
 
 def instrument_redis_commands_core(module):
     _instrument_redis_commands_module(module, "CoreCommands")

--- a/tox.ini
+++ b/tox.ini
@@ -94,11 +94,9 @@ envlist =
     mssql-datastore_pymssql-{py37,py38,py39,py310,py311},
     mysql-datastore_pymysql-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
     solr-datastore_pysolr-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
-    redis-datastore_redis-{py27,py37,py38,pypy27,pypy38}-redis03,
     redis-datastore_redis-{py37,py38,py39,py310,py311,pypy38}-redis{0400,latest},
-    redis-datastore_aioredis-{py37,py38,py39,py310,pypy38}-aioredislatest,
-    redis-datastore_aioredis-{py37,py38,py39,py310,py311,pypy38}-redislatest,
-    redis-datastore_aredis-{py37,py38,py39,pypy38}-aredislatest,
+    redis-datastore_aioredis-{py37,py38,py39,py310,pypy38}-redis0401,
+    redis-datastore_aredis-{py37,py38,py39,pypy38}-redis0401,
     solr-datastore_solrpy-{py27,pypy27}-solrpy{00,01},
     python-datastore_sqlite-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
     python-external_boto3-{py27,py37,py38,py39,py310,py311}-boto01,
@@ -255,11 +253,11 @@ deps =
     datastore_pysolr: pysolr<4.0
     datastore_redis-redislatest: redis
     datastore_redis-redis0400: redis<4.1
-    datastore_redis-redis03: redis<4.0
     datastore_redis-{py27,pypy27}: rb
-    datastore_aioredis-redislatest: redis
-    datastore_aioredis-aioredislatest: aioredis
-    datastore_aredis-aredislatest: aredis
+    datastore_aioredis-redis0401: redis<4.2
+    datastore_aioredis-redis0401: aioredis
+    datastore_aredis-redis0401: redis<4.2
+    datastore_aredis-redis0401: aredis
     datastore_solrpy-solrpy00: solrpy<1.0
     datastore_solrpy-solrpy01: solrpy<2.0
     external_boto3-boto01: boto3<2.0


### PR DESCRIPTION
# Overview
This PR will add a new instrumentation for redis.asyncio.client and remove aioredis' intrumentation dependency

## This PR creates a separate instrumentation for `redis.asyncio.client` initially, instrumentation of aioredis was used which is a different package to add async support to redis. Since async support is now directly added in `redis`  as `redis.asyncio` we can directly use a new instrumentation.


# Related Github Issue
Closes the issue https://github.com/newrelic/newrelic-python-agent/issues/807