### PR TITLE
Cache _get_package_version to avoid heavy CPU load

### DIFF
--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from functools import lru_cache
 
 # Need to account for 4 possible variations of version declaration specified in (rejected) PEP 396
 VERSION_ATTRS = ("__version__", "version", "__version_tuple__", "version_tuple")  # nosec
@@ -67,6 +68,7 @@ def get_package_version_tuple(name):
     return version
 
 
+@lru_cache
 def _get_package_version(name):
     module = sys.modules.get(name, None)
     version = None


### PR DESCRIPTION
# Overview
Changed introduced in [this](https://github.com/newrelic/newrelic-python-agent/pull/750) PR was a reason why our service ran out of CPU after the NR update. 
![image](https://github.com/newrelic/newrelic-python-agent/assets/29122694/52985af2-8f7f-4548-bb0f-2eb9f7123bb1)

If you have [redis-py](https://github.com/redis/redis-py) installed, but don't have [aioredis](https://github.com/aio-libs/aioredis-py), NewRelic tries to find a version of aioredis anyway every time you call your Redis client. Instead of a quick check based on importing the library, NR now uses pkg_resources to find a lib. And pkg_resources is slow :( 
Because we use Redis a lot, it heavily affected the performance. 

The easiest solution is to add a global cache for package versions - they won't change in runtime anyway 

# Related Github Issue
Include a link to the related GitHub issue, if applicable

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
