### PR TITLE
Fix pytest test filtering when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -406,7 +406,7 @@ commands =
     framework_grpc:     /{toxinidir}/tests/framework_grpc/sample_application/sample_application.proto
 
     libcurl: pip install --ignore-installed --config-settings="--build-option=--with-openssl" pycurl
-    coverage run -m pytest -v
+    coverage run -m pytest -v []
 
 allowlist_externals={toxinidir}/.github/scripts/*
 


### PR DESCRIPTION
# Overview
Removing the `[]` broke pytest filtering when I switched the tests to wrap pytest in coverage. This reverts that change.
Before fix this would not filter the tests:
`tox -e python-cross_agent-pypy-without_extensions -- -k test_collector_hostname`
With this fix now it does.