### PR TITLE
Fix Testing Failures

### DIFF
--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 
 from newrelic.common.package_version_utils import get_package_version_tuple
@@ -67,3 +68,7 @@ def client(request, loop):
             pytest.skip("StrictRedis not implemented.")
         else:
             raise NotImplementedError()
+
+@pytest.fixture(scope="session")
+def key():
+    return "AIOREDIS-TEST-" + str(os.getpid())

--- a/tests/datastore_aioredis/test_get_and_set.py
+++ b/tests/datastore_aioredis/test_get_and_set.py
@@ -64,9 +64,9 @@ _enable_rollup_metrics.append((_instance_metric_name, 2))
 _disable_rollup_metrics.append((_instance_metric_name, None))
 
 
-async def exercise_redis(client):
-    await client.set("key", "value")
-    await client.get("key")
+async def exercise_redis(client, key):
+    await client.set(key, "value")
+    await client.get(key)
 
 
 @override_application_settings(_enable_instance_settings)
@@ -77,8 +77,8 @@ async def exercise_redis(client):
     background_task=True,
 )
 @background_task()
-def test_redis_client_operation_enable_instance(client, loop):
-    loop.run_until_complete(exercise_redis(client))
+def test_redis_client_operation_enable_instance(client, loop, key):
+    loop.run_until_complete(exercise_redis(client, key))
 
 
 @override_application_settings(_disable_instance_settings)
@@ -89,5 +89,5 @@ def test_redis_client_operation_enable_instance(client, loop):
     background_task=True,
 )
 @background_task()
-def test_redis_client_operation_disable_instance(client, loop):
-    loop.run_until_complete(exercise_redis(client))
+def test_redis_client_operation_disable_instance(client, loop, key):
+    loop.run_until_complete(exercise_redis(client, key))

--- a/tox.ini
+++ b/tox.ini
@@ -221,6 +221,7 @@ deps =
     component_tastypie-tastypie0143: django-tastypie<0.14.4
     component_tastypie-{py27,pypy}-tastypie0143: django<1.12
     component_tastypie-{py37,py38,py39,py310,py311,pypy37}-tastypie0143: django<3.0.1
+    component_tastypie-{py37,py38,py39,py310,py311,pypy37}-tastypie0143: asgiref<3.7.1  # asgiref==3.7.1 only suppport Python 3.10+
     component_tastypie-tastypielatest: django-tastypie
     component_tastypie-tastypielatest: django<4.1
     component_tastypie-tastypielatest: asgiref<3.7.1  # asgiref==3.7.1 only suppport Python 3.10+

--- a/tox.ini
+++ b/tox.ini
@@ -223,7 +223,7 @@ deps =
     component_tastypie-{py37,py38,py39,py310,py311,pypy37}-tastypie0143: django<3.0.1
     component_tastypie-tastypielatest: django-tastypie
     component_tastypie-tastypielatest: django<4.1
-    component_tastypie-tastypielatest: asgiref<3.7.2  # asgiref==3.7.2 only suppport Python 3.10+
+    component_tastypie-tastypielatest: asgiref<3.7.1  # asgiref==3.7.1 only suppport Python 3.10+
     coroutines_asyncio-{py37,py38,py39,py310,py311}: uvloop
     cross_agent: mock==1.0.1
     cross_agent: requests

--- a/tox.ini
+++ b/tox.ini
@@ -223,6 +223,7 @@ deps =
     component_tastypie-{py37,py38,py39,py310,py311,pypy37}-tastypie0143: django<3.0.1
     component_tastypie-tastypielatest: django-tastypie
     component_tastypie-tastypielatest: django<4.1
+    component_tastypie-tastypielatest: asgiref<3.7.2  # asgiref==3.7.2 only suppport Python 3.10+
     coroutines_asyncio-{py37,py38,py39,py310,py311}: uvloop
     cross_agent: mock==1.0.1
     cross_agent: requests


### PR DESCRIPTION
# Overview
* Pin asgiref to fix failing tastypie tests.
  * asgiref==3.7.1 seems to have broken support for Python <3.10. 
* Fix concurrency based aioredis failures with PID unique keys.