### PR TITLE
Defensively check GQL path parts in framework_graphql

### DIFF
--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -494,6 +494,11 @@ _test_queries = [
         "{ library(index: 0) { book { ...MyFragment } magazine { ...MagFragment } } } fragment MyFragment on Book { author { first_name } } fragment MagFragment on Magazine { name }",
         "/library",
     ),
+    # fragement on type union
+    (
+        '{ search(contains: "A") { ...MyFragment } fragment MyFragment on Item { __typename ... on Book { name } } }',
+        "/search<Book>.name",
+    ),
 ]
 
 


### PR DESCRIPTION
# Overview
When constructing deepest path, removes None values from path parts and fields

# Related Github Issue
#814 

# Testing
The agent includes a suite of tests which should be used to
verify your changes don't break existing functionality. These tests will run with
Github Actions when a pull request is made. More details on running the tests locally can be found
[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.rst#testing-guidelines),
For most contributions it is strongly recommended to add additional tests which
exercise your changes.
