### PR TITLE
Fix set output warning using new GHA syntax

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -163,7 +163,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -206,7 +206,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -266,7 +266,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -321,7 +321,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -371,7 +371,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -423,7 +423,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -473,7 +473,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -524,7 +524,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -596,7 +596,7 @@ jobs:
   #    - name: Get Environments
   #      id: get-envs
   #      run: |
-  #        echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+  #        echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
   #      env:
   #        GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -646,7 +646,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -698,7 +698,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -751,7 +751,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -800,7 +800,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -163,7 +163,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -206,7 +206,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -266,7 +266,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -321,7 +321,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -371,7 +371,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -423,7 +423,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -473,7 +473,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -524,7 +524,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -596,7 +596,7 @@ jobs:
   #    - name: Get Environments
   #      id: get-envs
   #      run: |
-  #        echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+  #        echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
   #      env:
   #        GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -646,7 +646,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -698,7 +698,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -751,7 +751,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 
@@ -800,7 +800,7 @@ jobs:
       - name: Get Environments
         id: get-envs
         run: |
-          echo "::set-output name=envs::$(tox -l | grep "^${{ github.job }}\-" | ./.github/workflows/get-envs.py)"
+          echo "envs=$(tox -l | grep \"^${{ github.job }}\-\" | ./.github/workflows/get-envs.py)" >> $GITHUB_OUTPUT
         env:
           GROUP_NUMBER: ${{ matrix.group-number }}
 


### PR DESCRIPTION
# Overview

* Changes previous `set-output` syntax to newer environment files for Github Actions.
