### PR TITLE
Fix CI Image Tagging

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -74,7 +74,7 @@ RUN echo 'eval "$(pyenv init -)"' >>$HOME/.bashrc && \
     pyenv update
 
 # Install Python
-ARG PYTHON_VERSIONS="3.10 3.9 3.8 3.7 3.11 2.7 pypy2.7 pypy3.7"
+ARG PYTHON_VERSIONS="3.10 3.9 3.8 3.7 3.11 2.7 pypy2.7-7.3.11 pypy3.7"
 COPY --chown=1000:1000 --chmod=+x ./install-python.sh /tmp/install-python.sh
 COPY ./requirements.txt /requirements.txt
 RUN /tmp/install-python.sh && \

--- a/.github/containers/Makefile
+++ b/.github/containers/Makefile
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 # Repository root for mounting into container.
-REPO_ROOT:=$(realpath $(dir $(realpath $(firstword $(MAKEFILE_LIST))))../../)
+MAKEFILE_DIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+REPO_ROOT:=$(realpath $(MAKEFILE_DIR)../../)
 
 .PHONY: default
 default: test
@@ -21,7 +22,7 @@ default: test
 .PHONY: build
 build:
 	@# Perform a shortened build for testing
-	@docker build --build-arg='PYTHON_VERSIONS=3.10 2.7' . -t ghcr.io/newrelic/python-agent-ci:local
+	@docker build --build-arg='PYTHON_VERSIONS=3.10 2.7' $(MAKEFILE_DIR) -t ghcr.io/newrelic/newrelic-python-agent-ci:local
 
 .PHONY: test
 test: build
@@ -40,4 +41,4 @@ run: build
 		-e NEW_RELIC_HOST="${NEW_RELIC_HOST}" \
 		-e NEW_RELIC_LICENSE_KEY="${NEW_RELIC_LICENSE_KEY}" \
 		-e NEW_RELIC_DEVELOPER_MODE="${NEW_RELIC_DEVELOPER_MODE}" \
-		ghcr.io/newrelic/python-agent-ci:local /bin/bash
+		ghcr.io/newrelic/newrelic-python-agent-ci:local /bin/bash

--- a/.github/containers/install-python.sh
+++ b/.github/containers/install-python.sh
@@ -15,8 +15,6 @@
 
 set -e
 
-SED=$(which gsed || which sed)
-
 SCRIPT_DIR=$(dirname "$0")
 PIP_REQUIREMENTS=$(cat /requirements.txt)
 
@@ -34,7 +32,7 @@ main() {
     # Find all latest pyenv supported versions for requested python versions
     PYENV_VERSIONS=()
     for v in "${PYTHON_VERSIONS[@]}"; do
-        LATEST=$(pyenv latest -k "$v" || get_latest_patch_version "$v")
+        LATEST=$(pyenv latest -k "$v" || pyenv latest -k "$v-dev")
         if [[ -z "$LATEST" ]]; then
             echo "Latest version could not be found for ${v}." 1>&2
             exit 1
@@ -53,17 +51,6 @@ main() {
     
     # Install dependencies for main python installation
     pyenv exec pip install --upgrade $PIP_REQUIREMENTS
-}
-
-get_latest_patch_version() {
-    pyenv install --list |  # Get all python versions
-        $SED 's/^ *//g' |  # Remove leading whitespace
-        grep -E "^$1" |  # Find specified version by matching start of line
-        grep -v -- "-c-jit-latest" |  # Filter out pypy JIT versions
-        $SED -E '/(-[a-zA-Z]+$)|(a[0-9]+)|(b[0-9]+)|(rc[0-9]+)/!{s/$/_/}' |  # Append trailing _ to any non development versions to place them lower when sorted
-        sort -V |  # Sort using version sorting
-        $SED 's/_$//' |  # Remove any added trailing underscores to correct version names
-        tail -1  # Grab last result as latest version
 }
 
 main

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}-ci
           flavor: |
             prefix=
             suffix=

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     steps:
@@ -155,7 +155,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     steps:
@@ -193,7 +193,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -246,7 +246,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -302,7 +302,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -353,7 +353,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -406,7 +406,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -457,7 +457,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -581,7 +581,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -632,7 +632,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -685,7 +685,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:
@@ -739,7 +739,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/python-agent-ci:latest
+      image: ghcr.io/${{ github.repository }}-ci
     timeout-minutes: 30
 
     services:


### PR DESCRIPTION
# Overview

* Fixed and standardized the following
  * CI Image was tagged with the repository name instead of adding `-ci`. 
  * Workflows used a hardcoded image name that didn't include `newrelic-` in the image name. 
* Cleaned up scripting logic to be simpler.
* Pinned pypy2.7, as `pyenv latest -k pypy2.7` incorrectly returns `pypy2.7-5.10.0` instead of the correct `pypy2.7-7.3.11`. No new releases for pypy2.7 are expected, so this shouldn't affect anything.
