### PR TITLE
Fix attribute name mismatches from mlops sdk

### DIFF
--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -234,7 +234,7 @@ def find_type_category(data_set, row_index, column_index):
 
 def categorize_data_type(python_type):
     if "int" in python_type or "float" in python_type or "complex" in python_type:
-        return "numerical"
+        return "numeric"
     if "bool" in python_type:
         return "bool"
     if "str" in python_type or "unicode" in python_type:

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -203,7 +203,7 @@ def create_label_event(transaction, _class, inference_id, instance, return_val):
                 # Don't include the raw value when inference_event_value is disabled.
                 if settings and settings.machine_learning.inference_events_value.enabled:
                     event["label_value"] = str(value)
-                transaction.record_custom_event("ML Model Label Event", event)
+                transaction.record_custom_event("inferenceData", event)
 
 
 def _get_label_names(user_defined_label_names, prediction_array):
@@ -298,7 +298,7 @@ def create_feature_event(transaction, _class, inference_id, instance, args, kwar
             # Don't include the raw value when inference_event_value is disabled.
             if settings and settings.machine_learning and settings.machine_learning.inference_events_value.enabled:
                 event["feature_value"] = str(value)
-            transaction.record_custom_event("ML Model Feature Event", event)
+            transaction.record_custom_event("inferenceData", event)
 
 
 def _nr_instrument_model(module, model_class):

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -194,15 +194,15 @@ def create_label_event(transaction, _class, inference_id, instance, return_val):
 
                 event = {
                     "inference_id": inference_id,
-                    "model_name": model_name,
                     "model_version": model_version,
                     "label_name": str(label_names_list[index]),
-                    "type": value_type,
-                    "value": str(value),
+                    "label_type": value_type,
+                    # The following are used for entity synthesis.
+                    "modelName": model_name,
                 }
                 # Don't include the raw value when inference_event_value is disabled.
                 if settings and settings.machine_learning.inference_events_value.enabled:
-                    event["value"] = str(value)
+                    event["label_value"] = str(value)
                 transaction.record_custom_event("ML Model Label Event", event)
 
 
@@ -289,14 +289,15 @@ def create_feature_event(transaction, _class, inference_id, instance, args, kwar
             value_type = find_type_category(data_set, row_index, col_index)
             event = {
                 "inference_id": inference_id,
-                "model_name": model_name,
                 "model_version": model_version,
                 "feature_name": str(final_feature_names[row_index]),
-                "type": value_type,
+                "feature_type": value_type,
+                # The following are used for entity synthesis.
+                "modelName": model_name,
             }
             # Don't include the raw value when inference_event_value is disabled.
             if settings and settings.machine_learning and settings.machine_learning.inference_events_value.enabled:
-                event["value"] = str(value)
+                event["feature_value"] = str(value)
             transaction.record_custom_event("ML Model Feature Event", event)
 
 

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -52,7 +52,7 @@ pandas_df_category_recorded_custom_events = [
             "model_name": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "27.0",
         }
     },
@@ -79,7 +79,7 @@ def test_pandas_df_categorical_feature_event():
     _test()
 
 
-label_type = "bool" if sys.version_info < (3, 8) else "numerical"
+label_type = "bool" if sys.version_info < (3, 8) else "numeric"
 true_label_value = "True" if sys.version_info < (3, 8) else "1.0"
 false_label_value = "False" if sys.version_info < (3, 8) else "0.0"
 pandas_df_bool_recorded_custom_events = [
@@ -145,7 +145,7 @@ pandas_df_float_recorded_custom_events = [
             "model_name": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "col1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "100.0",
         }
     },
@@ -155,7 +155,7 @@ pandas_df_float_recorded_custom_events = [
             "model_name": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "col2",
-            "type": "numerical",
+            "type": "numeric",
             "value": "300.0",
         }
     },
@@ -165,7 +165,7 @@ pandas_df_float_recorded_custom_events = [
             "model_name": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "345.6",
         }
     },
@@ -201,7 +201,7 @@ int_list_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1",
         }
     },
@@ -211,7 +211,7 @@ int_list_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "2",
         }
     },
@@ -221,7 +221,7 @@ int_list_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1.0",
         }
     },
@@ -256,7 +256,7 @@ numpy_int_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "12",
         }
     },
@@ -266,7 +266,7 @@ numpy_int_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "13",
         }
     },
@@ -276,7 +276,7 @@ numpy_int_recorded_custom_events = [
             "model_name": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "11.0",
         }
     },
@@ -476,7 +476,7 @@ multilabel_output_label_events = [
             "model_name": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1",
         }
     },
@@ -486,7 +486,7 @@ multilabel_output_label_events = [
             "model_name": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "0",
         }
     },
@@ -496,7 +496,7 @@ multilabel_output_label_events = [
             "model_name": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "2",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1",
         }
     },

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -29,31 +29,31 @@ pandas_df_category_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "col1",
-            "type": "categorical",
-            "value": "2.0",
+            "feature_type": "categorical",
+            "feature_value": "2.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "col2",
-            "type": "categorical",
-            "value": "4.0",
+            "feature_type": "categorical",
+            "feature_value": "4.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numeric",
-            "value": "27.0",
+            "label_type": "numeric",
+            "label_value": "27.0",
         }
     },
 ]
@@ -86,31 +86,31 @@ pandas_df_bool_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "col1",
-            "type": "bool",
-            "value": "True",
+            "feature_type": "bool",
+            "feature_value": "True",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "col2",
-            "type": "bool",
-            "value": "True",
+            "feature_type": "bool",
+            "feature_value": "True",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": label_type,
-            "value": true_label_value,
+            "label_type": label_type,
+            "label_value": true_label_value,
         }
     },
 ]
@@ -142,31 +142,31 @@ pandas_df_float_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeRegressor",
+            "modelName": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "col1",
-            "type": "numeric",
-            "value": "100.0",
+            "feature_type": "numeric",
+            "feature_value": "100.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeRegressor",
+            "modelName": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "col2",
-            "type": "numeric",
-            "value": "300.0",
+            "feature_type": "numeric",
+            "feature_value": "300.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeRegressor",
+            "modelName": "DecisionTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numeric",
-            "value": "345.6",
+            "label_type": "numeric",
+            "label_value": "345.6",
         }
     },
 ]
@@ -198,31 +198,31 @@ int_list_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "numeric",
-            "value": "1",
+            "feature_type": "numeric",
+            "feature_value": "1",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "numeric",
-            "value": "2",
+            "feature_type": "numeric",
+            "feature_value": "2",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numeric",
-            "value": "1.0",
+            "label_type": "numeric",
+            "label_value": "1.0",
         }
     },
 ]
@@ -253,31 +253,31 @@ numpy_int_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "numeric",
-            "value": "12",
+            "feature_type": "numeric",
+            "feature_value": "12",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "numeric",
-            "value": "13",
+            "feature_type": "numeric",
+            "feature_value": "13",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "ExtraTreeRegressor",
+            "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numeric",
-            "value": "11.0",
+            "label_type": "numeric",
+            "label_value": "11.0",
         }
     },
 ]
@@ -308,41 +308,41 @@ numpy_str_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "str",
-            "value": "20",
+            "feature_type": "str",
+            "feature_value": "20",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "str",
-            "value": "21",
+            "feature_type": "str",
+            "feature_value": "21",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "str",
-            "value": "22",
+            "feature_type": "str",
+            "feature_value": "22",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "str",
-            "value": "23",
+            "feature_type": "str",
+            "feature_value": "23",
         }
     },
 ]
@@ -373,28 +373,28 @@ numpy_str_recorded_custom_events_no_value = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "0",
-            "type": "str",
+            "feature_type": "str",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "feature_name": "1",
-            "type": "str",
+            "feature_type": "str",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "DecisionTreeClassifier",
+            "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "str",
+            "label_type": "str",
         }
     },
 ]
@@ -473,31 +473,31 @@ multilabel_output_label_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "MultiOutputClassifier",
+            "modelName": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "0",
-            "type": "numeric",
-            "value": "1",
+            "label_type": "numeric",
+            "label_value": "1",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MultiOutputClassifier",
+            "modelName": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "1",
-            "type": "numeric",
-            "value": "0",
+            "label_type": "numeric",
+            "label_value": "0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MultiOutputClassifier",
+            "modelName": "MultiOutputClassifier",
             "model_version": "0.0.0",
             "label_name": "2",
-            "type": "numeric",
-            "value": "1",
+            "label_type": "numeric",
+            "label_value": "1",
         }
     },
 ]

--- a/tests/mlmodel_sklearn/test_ml_model.py
+++ b/tests/mlmodel_sklearn/test_ml_model.py
@@ -121,7 +121,7 @@ int_list_recorded_custom_events = [
             "model_name": "MyCustomModel",
             "model_version": "1.2.3",
             "feature_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1.0",
         }
     },
@@ -131,7 +131,7 @@ int_list_recorded_custom_events = [
             "model_name": "MyCustomModel",
             "model_version": "1.2.3",
             "feature_name": "1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "2.0",
         }
     },
@@ -141,7 +141,7 @@ int_list_recorded_custom_events = [
             "model_name": "MyCustomModel",
             "model_version": "1.2.3",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": label_value,
         }
     },
@@ -205,7 +205,7 @@ pandas_df_recorded_custom_events = [
             "model_name": "PandasTestModel",
             "model_version": "1.5.0b1",
             "label_name": "label1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "0.5" if six.PY3 else "0.0",
         }
     },
@@ -243,7 +243,7 @@ pandas_df_recorded_builtin_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "feature1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "12",
         }
     },
@@ -253,7 +253,7 @@ pandas_df_recorded_builtin_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "feature2",
-            "type": "numerical",
+            "type": "numeric",
             "value": "14",
         }
     },
@@ -263,7 +263,7 @@ pandas_df_recorded_builtin_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "label_name": "label1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "0",
         }
     },
@@ -306,7 +306,7 @@ pandas_df_mismatched_custom_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col1",
-            "type": "numerical",
+            "type": "numeric",
             "value": "12",
         }
     },
@@ -316,7 +316,7 @@ pandas_df_mismatched_custom_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col2",
-            "type": "numerical",
+            "type": "numeric",
             "value": "14",
         }
     },
@@ -326,7 +326,7 @@ pandas_df_mismatched_custom_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col3",
-            "type": "numerical",
+            "type": "numeric",
             "value": "16",
         }
     },
@@ -336,7 +336,7 @@ pandas_df_mismatched_custom_events = [
             "model_name": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "label_name": "0",
-            "type": "numerical",
+            "type": "numeric",
             "value": "1",
         }
     },

--- a/tests/mlmodel_sklearn/test_ml_model.py
+++ b/tests/mlmodel_sklearn/test_ml_model.py
@@ -118,31 +118,31 @@ int_list_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyCustomModel",
+            "modelName": "MyCustomModel",
             "model_version": "1.2.3",
             "feature_name": "0",
-            "type": "numeric",
-            "value": "1.0",
+            "feature_type": "numeric",
+            "feature_value": "1.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyCustomModel",
+            "modelName": "MyCustomModel",
             "model_version": "1.2.3",
             "feature_name": "1",
-            "type": "numeric",
-            "value": "2.0",
+            "feature_type": "numeric",
+            "feature_value": "2.0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyCustomModel",
+            "modelName": "MyCustomModel",
             "model_version": "1.2.3",
             "label_name": "0",
-            "type": "numeric",
-            "value": label_value,
+            "label_type": "numeric",
+            "label_value": label_value,
         }
     },
 ]
@@ -172,41 +172,41 @@ pandas_df_recorded_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "PandasTestModel",
+            "modelName": "PandasTestModel",
             "model_version": "1.5.0b1",
             "feature_name": "feature1",
-            "type": "categorical",
-            "value": "0",
+            "feature_type": "categorical",
+            "feature_value": "0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "PandasTestModel",
+            "modelName": "PandasTestModel",
             "model_version": "1.5.0b1",
             "feature_name": "feature2",
-            "type": "categorical",
-            "value": "0",
+            "feature_type": "categorical",
+            "feature_value": "0",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "PandasTestModel",
+            "modelName": "PandasTestModel",
             "model_version": "1.5.0b1",
             "feature_name": "feature3",
-            "type": "categorical",
-            "value": "1",
+            "feature_type": "categorical",
+            "feature_value": "1",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "PandasTestModel",
+            "modelName": "PandasTestModel",
             "model_version": "1.5.0b1",
             "label_name": "label1",
-            "type": "numeric",
-            "value": "0.5" if six.PY3 else "0.0",
+            "label_type": "numeric",
+            "label_value": "0.5" if six.PY3 else "0.0",
         }
     },
 ]
@@ -240,31 +240,31 @@ pandas_df_recorded_builtin_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "feature1",
-            "type": "numeric",
-            "value": "12",
+            "feature_type": "numeric",
+            "feature_value": "12",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "feature2",
-            "type": "numeric",
-            "value": "14",
+            "feature_type": "numeric",
+            "feature_value": "14",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "label_name": "label1",
-            "type": "numeric",
-            "value": "0",
+            "label_type": "numeric",
+            "label_value": "0",
         }
     },
 ]
@@ -303,41 +303,41 @@ pandas_df_mismatched_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col1",
-            "type": "numeric",
-            "value": "12",
+            "feature_type": "numeric",
+            "feature_value": "12",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col2",
-            "type": "numeric",
-            "value": "14",
+            "feature_type": "numeric",
+            "feature_value": "14",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "feature_name": "col3",
-            "type": "numeric",
-            "value": "16",
+            "feature_type": "numeric",
+            "feature_value": "16",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
             "label_name": "0",
-            "type": "numeric",
-            "value": "1",
+            "label_type": "numeric",
+            "label_value": "1",
         }
     },
 ]
@@ -375,31 +375,31 @@ numpy_str_mismatched_custom_events = [
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "0.0.1",
             "feature_name": "0",
-            "type": "str",
-            "value": "20",
+            "feature_type": "str",
+            "feature_value": "20",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "0.0.1",
             "feature_name": "1",
-            "type": "str",
-            "value": "21",
+            "feature_type": "str",
+            "feature_value": "21",
         }
     },
     {
         "users": {
             "inference_id": None,
-            "model_name": "MyDecisionTreeClassifier",
+            "modelName": "MyDecisionTreeClassifier",
             "model_version": "0.0.1",
             "label_name": "0",
-            "type": "str",
-            "value": "21",
+            "label_type": "str",
+            "label_value": "21",
         }
     },
 ]


### PR DESCRIPTION
# Overview
* Fix some name mismatches between the mlops sdk and the agent:
   * model_name -> modelName
   * numerical -> numeric
   * type -> feature_/label_type
   * value -> feature_/label_value
   * event name -> inferenceData