### PR TITLE
Ignore patched hooks files from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,10 @@
 ignore:
   - "newrelic/packages/**/*"
   - "newrelic/packages/*"
+  - "newreilc/hooks/component_sentry.py"
   - "newrelic/hooks/adapter_meinheld.py"
   - "newrelic/hooks/adapter_flup.py"
+  - "newrelic/hooks/adapter_paste.py"
   - "newrelic/hooks/component_piston.py"
   - "newrelic/hooks/datastore_pyelasticsearch.py"
   - "newrelic/hooks/external_pywapi.py"
@@ -13,6 +15,7 @@ ignore:
   - "newrelic/hooks/framework_web2py.py"
   - "newrelic/hooks/middleware_weberror.py"
   - "newrelic/hooks/framework_webpy.py"
+  - "newrelic/hooks/datastore_motor.py"
   - "newrelic/hooks/database_oursql.py"
   - "newrelic/hooks/database_psycopg2ct.py"
   - "newrelic/hooks/datastore_umemcache.py"


### PR DESCRIPTION
This PR adds multiple files to be ignored by coverage:
- `component_sentry.py`: not fully featured instrumentation in the agent
- `datastore_motor.py`: not fully featured instrumentation in the agent
- `adapter_paste.py`: no longer being actively supported - on[ maintenance mode only](https://pypi.org/project/Paste/)
