### PR TITLE
Use Dimensional Metrics in SKLearn

### DIFF
--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -158,7 +158,7 @@ def _record_stats(data, column_names, class_, column_type, tags):
                 ("%s/%s" % (metric_name, "StandardDeviation"), float(standard_deviation[index]), tags),
                 ("%s/%s" % (metric_name, "Min"), float(_min[index]), tags),
                 ("%s/%s" % (metric_name, "Max"), float(_max[index]), tags),
-                ("%s/%s" % (metric_name, "Count"), {_count}, tags),
+                ("%s/%s" % (metric_name, "Count"), _count, tags),
             ]
         )
 

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -54,7 +54,7 @@ class PredictReturnTypeProxy(ObjectProxy):
         self._nr_training_step = training_step
 
 
-def _wrap_method_trace(module, _class, method, name=None, group=None):
+def _wrap_method_trace(module, class_, method, name=None, group=None):
     def _nr_wrapper_method(wrapped, instance, args, kwargs):
         transaction = current_transaction()
         trace = current_trace()
@@ -96,15 +96,15 @@ def _wrap_method_trace(module, _class, method, name=None, group=None):
         if method in ("predict", "fit_predict"):
             training_step = getattr(instance, "_nr_wrapped_training_step", "Unknown")
             inference_id = uuid.uuid4()
-            create_feature_event(transaction, _class, inference_id, instance, args, kwargs)
-            create_label_event(transaction, _class, inference_id, instance, return_val)
-            return PredictReturnTypeProxy(return_val, model_name=_class, training_step=training_step)
+            create_feature_event(transaction, class_, inference_id, instance, args, kwargs)
+            create_label_event(transaction, class_, inference_id, instance, return_val)
+            return PredictReturnTypeProxy(return_val, model_name=class_, training_step=training_step)
         return return_val
 
-    wrap_function_wrapper(module, "%s.%s" % (_class, method), _nr_wrapper_method)
+    wrap_function_wrapper(module, "%s.%s" % (class_, method), _nr_wrapper_method)
 
 
-def _calc_prediction_feature_stats(prediction_input, _class, feature_column_names, tags):
+def _calc_prediction_feature_stats(prediction_input, class_, feature_column_names, tags):
     import numpy as np
 
     # Drop any feature columns that are not numeric since we can't compute stats
@@ -126,10 +126,10 @@ def _calc_prediction_feature_stats(prediction_input, _class, feature_column_name
         features = np.reshape(numeric_features, (len(numeric_features) // num_cols, num_cols))
         features = features.astype(dtype=np.float64)
 
-        _record_stats(features, feature_column_names, _class, "Feature", tags)
+        _record_stats(features, feature_column_names, class_, "Feature", tags)
 
 
-def _record_stats(data, column_names, _class, column_type, tags):
+def _record_stats(data, column_names, class_, column_type, tags):
     import numpy as np
 
     mean = np.mean(data, axis=0)
@@ -147,7 +147,7 @@ def _record_stats(data, column_names, _class, column_type, tags):
     # to upload them one at a time instead of as a dictionary of stats per
     # feature column.
     for index, col_name in enumerate(column_names):
-        metric_name = "MLModel/Sklearn/Named/%s/Predict/%s/%s" % (_class, column_type, col_name)
+        metric_name = "MLModel/Sklearn/Named/%s/Predict/%s/%s" % (class_, column_type, col_name)
 
         transaction.record_dimensional_metrics(
             [
@@ -163,15 +163,15 @@ def _record_stats(data, column_names, _class, column_type, tags):
         )
 
 
-def _calc_prediction_label_stats(labels, _class, label_column_names, tags):
+def _calc_prediction_label_stats(labels, class_, label_column_names, tags):
     import numpy as np
 
     labels = np.array(labels, dtype=np.float64)
-    _record_stats(labels, label_column_names, _class, "Label", tags)
+    _record_stats(labels, label_column_names, class_, "Label", tags)
 
 
-def create_label_event(transaction, _class, inference_id, instance, return_val):
-    model_name = getattr(instance, "_nr_wrapped_name", _class)
+def create_label_event(transaction, class_, inference_id, instance, return_val):
+    model_name = getattr(instance, "_nr_wrapped_name", class_)
     model_version = getattr(instance, "_nr_wrapped_version", "0.0.0")
     label_names = getattr(instance, "_nr_wrapped_label_names", None)
 
@@ -187,7 +187,7 @@ def create_label_event(transaction, _class, inference_id, instance, return_val):
             labels = np.reshape(labels, (len(labels) // 1, 1))
 
         label_names_list = _get_label_names(label_names, labels)
-        _calc_prediction_label_stats(labels, _class, label_names_list, tags={
+        _calc_prediction_label_stats(labels, class_, label_names_list, tags={
             "inference_id": inference_id,
             "model_version": model_version,
             # The following are used for entity synthesis.
@@ -278,18 +278,18 @@ def bind_predict(X, *args, **kwargs):
     return X
 
 
-def create_feature_event(transaction, _class, inference_id, instance, args, kwargs):
+def create_feature_event(transaction, class_, inference_id, instance, args, kwargs):
     import numpy as np
 
     data_set = bind_predict(*args, **kwargs)
-    model_name = getattr(instance, "_nr_wrapped_name", _class)
+    model_name = getattr(instance, "_nr_wrapped_name", class_)
     model_version = getattr(instance, "_nr_wrapped_version", "0.0.0")
     user_provided_feature_names = getattr(instance, "_nr_wrapped_feature_names", None)
     settings = transaction.settings if transaction.settings is not None else global_settings()
 
     final_feature_names = _get_feature_column_names(user_provided_feature_names, data_set)
     np_casted_data_set = np.array(data_set)
-    _calc_prediction_feature_stats(data_set, _class, final_feature_names, tags={
+    _calc_prediction_feature_stats(data_set, class_, final_feature_names, tags={
         "inference_id": inference_id,
         "model_version": model_version,
         # The following are used for entity synthesis.

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -104,7 +104,7 @@ def _wrap_method_trace(module, _class, method, name=None, group=None):
     wrap_function_wrapper(module, "%s.%s" % (_class, method), _nr_wrapper_method)
 
 
-def _calc_prediction_feature_stats(prediction_input, _class, feature_column_names):
+def _calc_prediction_feature_stats(prediction_input, _class, feature_column_names, tags):
     import numpy as np
 
     # Drop any feature columns that are not numeric since we can't compute stats
@@ -126,10 +126,10 @@ def _calc_prediction_feature_stats(prediction_input, _class, feature_column_name
         features = np.reshape(numeric_features, (len(numeric_features) // num_cols, num_cols))
         features = features.astype(dtype=np.float64)
 
-        _record_stats(features, feature_column_names, _class, "Feature")
+        _record_stats(features, feature_column_names, _class, "Feature", tags)
 
 
-def _record_stats(data, column_names, _class, column_type):
+def _record_stats(data, column_names, _class, column_type, tags):
     import numpy as np
 
     mean = np.mean(data, axis=0)
@@ -148,25 +148,26 @@ def _record_stats(data, column_names, _class, column_type):
     # feature column.
     for index, col_name in enumerate(column_names):
         metric_name = "MLModel/Sklearn/Named/%s/Predict/%s/%s" % (_class, column_type, col_name)
-        transaction.record_custom_metrics(
+
+        transaction.record_dimensional_metrics(
             [
-                ("%s/%s" % (metric_name, "Mean"), float(mean[index])),
-                ("%s/%s" % (metric_name, "Percentile25"), float(percentile25[index])),
-                ("%s/%s" % (metric_name, "Percentile50"), float(percentile50[index])),
-                ("%s/%s" % (metric_name, "Percentile75"), float(percentile75[index])),
-                ("%s/%s" % (metric_name, "StandardDeviation"), float(standard_deviation[index])),
-                ("%s/%s" % (metric_name, "Min"), float(_min[index])),
-                ("%s/%s" % (metric_name, "Max"), float(_max[index])),
-                ("%s/%s" % (metric_name, "Count"), _count),
+                ("%s/%s" % (metric_name, "Mean"), float(mean[index]), tags),
+                ("%s/%s" % (metric_name, "Percentile25"), float(percentile25[index]), tags),
+                ("%s/%s" % (metric_name, "Percentile50"), float(percentile50[index]), tags),
+                ("%s/%s" % (metric_name, "Percentile75"), float(percentile75[index]), tags),
+                ("%s/%s" % (metric_name, "StandardDeviation"), float(standard_deviation[index]), tags),
+                ("%s/%s" % (metric_name, "Min"), float(_min[index]), tags),
+                ("%s/%s" % (metric_name, "Max"), float(_max[index]), tags),
+                ("%s/%s" % (metric_name, "Count"), {_count}, tags),
             ]
         )
 
 
-def _calc_prediction_label_stats(labels, _class, label_column_names):
+def _calc_prediction_label_stats(labels, _class, label_column_names, tags):
     import numpy as np
 
     labels = np.array(labels, dtype=np.float64)
-    _record_stats(labels, label_column_names, _class, "Label")
+    _record_stats(labels, label_column_names, _class, "Label", tags)
 
 
 def create_label_event(transaction, _class, inference_id, instance, return_val):
@@ -186,7 +187,12 @@ def create_label_event(transaction, _class, inference_id, instance, return_val):
             labels = np.reshape(labels, (len(labels) // 1, 1))
 
         label_names_list = _get_label_names(label_names, labels)
-        _calc_prediction_label_stats(labels, _class, label_names_list)
+        _calc_prediction_label_stats(labels, _class, label_names_list, tags={
+            "inference_id": inference_id,
+            "model_version": model_version,
+            # The following are used for entity synthesis.
+            "modelName": model_name,
+        })
         for prediction in labels:
             for index, value in enumerate(prediction):
                 python_value_type = str(type(value))
@@ -283,7 +289,12 @@ def create_feature_event(transaction, _class, inference_id, instance, args, kwar
 
     final_feature_names = _get_feature_column_names(user_provided_feature_names, data_set)
     np_casted_data_set = np.array(data_set)
-    _calc_prediction_feature_stats(data_set, _class, final_feature_names)
+    _calc_prediction_feature_stats(data_set, _class, final_feature_names, tags={
+        "inference_id": inference_id,
+        "model_version": model_version,
+        # The following are used for entity synthesis.
+        "modelName": model_name,
+    })
     for col_index, feature in enumerate(np_casted_data_set):
         for row_index, value in enumerate(feature):
             value_type = find_type_category(data_set, row_index, col_index)

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -187,12 +187,17 @@ def create_label_event(transaction, class_, inference_id, instance, return_val):
             labels = np.reshape(labels, (len(labels) // 1, 1))
 
         label_names_list = _get_label_names(label_names, labels)
-        _calc_prediction_label_stats(labels, class_, label_names_list, tags={
-            "inference_id": inference_id,
-            "model_version": model_version,
-            # The following are used for entity synthesis.
-            "modelName": model_name,
-        })
+        _calc_prediction_label_stats(
+            labels,
+            class_,
+            label_names_list,
+            tags={
+                "inference_id": inference_id,
+                "model_version": model_version,
+                # The following are used for entity synthesis.
+                "modelName": model_name,
+            },
+        )
         for prediction in labels:
             for index, value in enumerate(prediction):
                 python_value_type = str(type(value))
@@ -289,12 +294,17 @@ def create_feature_event(transaction, class_, inference_id, instance, args, kwar
 
     final_feature_names = _get_feature_column_names(user_provided_feature_names, data_set)
     np_casted_data_set = np.array(data_set)
-    _calc_prediction_feature_stats(data_set, class_, final_feature_names, tags={
-        "inference_id": inference_id,
-        "model_version": model_version,
-        # The following are used for entity synthesis.
-        "modelName": model_name,
-    })
+    _calc_prediction_feature_stats(
+        data_set,
+        class_,
+        final_feature_names,
+        tags={
+            "inference_id": inference_id,
+            "model_version": model_version,
+            # The following are used for entity synthesis.
+            "modelName": model_name,
+        },
+    )
     for col_index, feature in enumerate(np_casted_data_set):
         for row_index, value in enumerate(feature):
             value_type = find_type_category(data_set, row_index, col_index)

--- a/tests/mlmodel_sklearn/test_prediction_stats.py
+++ b/tests/mlmodel_sklearn/test_prediction_stats.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import pandas as pd
+import uuid
 import pytest
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
@@ -23,6 +24,15 @@ from newrelic.api.background_task import background_task
 from newrelic.packages import six
 
 
+ML_METRIC_FORCED_UUID = '0b59992f-2349-4a46-8de1-696d3fe1088b'
+
+
+@pytest.fixture(scope="function")
+def force_uuid(monkeypatch):
+    monkeypatch.setattr(uuid, "uuid4", lambda *a, **k: ML_METRIC_FORCED_UUID)
+
+
+_test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inference_id', ML_METRIC_FORCED_UUID), ('model_version', '0.0.0')})
 @pytest.mark.parametrize(
     "x_train,y_train,x_test,metrics",
     [
@@ -31,30 +41,30 @@ from newrelic.packages import six
             [0, 1],
             [[2.0, 2.0], [0, 0.5]],
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
         (
@@ -62,30 +72,30 @@ from newrelic.packages import six
             [0, 1],
             np.array([[2.0, 2.0], [0, 0.5]]),
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
         (
@@ -93,30 +103,30 @@ from newrelic.packages import six
             [0, 1],
             np.array([["a", 2.0, 3], ["b", 0.5, 4]], dtype="<U4"),
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
         (
@@ -124,30 +134,30 @@ from newrelic.packages import six
             [0, 1],
             pd.DataFrame({"col1": [2.0, 2.0], "col2": [0, 0.5]}),
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
         (
@@ -155,30 +165,30 @@ from newrelic.packages import six
             [0, 1],
             pd.DataFrame({"col1": ["a", "b"], "col2": [0, 0.5]}, dtype="<U4"),
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
         (
@@ -186,42 +196,42 @@ from newrelic.packages import six
             [0, 1],
             pd.DataFrame({"col1": ["a", "c"], "col2": [True, False]}, dtype="<U4"),
             [
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, None),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Mean", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
+                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
             ],
         ),
     ],
 )
-def test_prediction_stats(run_model, x_train, y_train, x_test, metrics):
+def test_prediction_stats(run_model, x_train, y_train, x_test, metrics, force_uuid):
     expected_transaction_name = (
         "test_prediction_stats:test_prediction_stats.<locals>._test" if six.PY3 else "test_prediction_stats:_test"
     )
 
     @validate_transaction_metrics(
         expected_transaction_name,
-        custom_metrics=metrics,
+        dimensional_metrics=metrics,
         background_task=True,
     )
     @background_task()
@@ -231,7 +241,8 @@ def test_prediction_stats(run_model, x_train, y_train, x_test, metrics):
     _test()
 
 
-def test_prediction_stats_multilabel_output():
+_test_prediction_stats_multilabel_output_tags = frozenset({('modelName', 'MultiOutputClassifier'), ('inference_id', ML_METRIC_FORCED_UUID), ('model_version', '0.0.0')})
+def test_prediction_stats_multilabel_output(force_uuid):
     expected_transaction_name = (
         "test_prediction_stats:test_prediction_stats_multilabel_output.<locals>._test"
         if six.PY3
@@ -239,13 +250,13 @@ def test_prediction_stats_multilabel_output():
     )
     stats = ["Mean", "Percentile25", "Percentile50", "Percentile75", "StandardDeviation", "Min", "Max", "Count"]
     metrics = [
-        ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Feature/%s/%s" % (feature_col, stat_name), 1)
+        ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Feature/%s/%s" % (feature_col, stat_name), _test_prediction_stats_multilabel_output_tags, 1)
         for feature_col in range(20)
         for stat_name in stats
     ]
     metrics.extend(
         [
-            ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Label/%s/%s" % (label_col, stat_name), 1)
+            ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Label/%s/%s" % (label_col, stat_name), _test_prediction_stats_multilabel_output_tags, 1)
             for label_col in range(3)
             for stat_name in stats
         ]
@@ -253,7 +264,7 @@ def test_prediction_stats_multilabel_output():
 
     @validate_transaction_metrics(
         expected_transaction_name,
-        custom_metrics=metrics,
+        dimensional_metrics=metrics,
         background_task=True,
     )
     @background_task()

--- a/tests/mlmodel_sklearn/test_prediction_stats.py
+++ b/tests/mlmodel_sklearn/test_prediction_stats.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import uuid
+
 import numpy as np
 import pandas as pd
-import uuid
 import pytest
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
@@ -23,8 +24,7 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.packages import six
 
-
-ML_METRIC_FORCED_UUID = '0b59992f-2349-4a46-8de1-696d3fe1088b'
+ML_METRIC_FORCED_UUID = "0b59992f-2349-4a46-8de1-696d3fe1088b"
 
 
 @pytest.fixture(scope="function")
@@ -32,7 +32,11 @@ def force_uuid(monkeypatch):
     monkeypatch.setattr(uuid, "uuid4", lambda *a, **k: ML_METRIC_FORCED_UUID)
 
 
-_test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inference_id', ML_METRIC_FORCED_UUID), ('model_version', '0.0.0')})
+_test_prediction_stats_tags = frozenset(
+    {("modelName", "DummyClassifier"), ("inference_id", ML_METRIC_FORCED_UUID), ("model_version", "0.0.0")}
+)
+
+
 @pytest.mark.parametrize(
     "x_train,y_train,x_test,metrics",
     [
@@ -42,18 +46,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             [[2.0, 2.0], [0, 0.5]],
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
@@ -61,7 +97,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -73,18 +113,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             np.array([[2.0, 2.0], [0, 0.5]]),
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
@@ -92,7 +164,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -104,18 +180,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             np.array([["a", 2.0, 3], ["b", 0.5, 4]], dtype="<U4"),
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Mean", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation", _test_prediction_stats_tags, None),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile25",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile50",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Percentile75",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Min", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Max", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/0/Count", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/1/Count", _test_prediction_stats_tags, 1),
@@ -123,7 +231,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -135,18 +247,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             pd.DataFrame({"col1": [2.0, 2.0], "col2": [0, 0.5]}),
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, 1),
@@ -154,7 +298,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -166,18 +314,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             pd.DataFrame({"col1": ["a", "b"], "col2": [0, 0.5]}, dtype="<U4"),
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, None),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, 1),
@@ -185,7 +365,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -197,18 +381,50 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
             pd.DataFrame({"col1": ["a", "c"], "col2": [True, False]}, dtype="<U4"),
             [
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Mean", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation", _test_prediction_stats_tags, None),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile25",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile50",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Percentile75",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Min", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Max", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col1/Count", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Mean", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75", _test_prediction_stats_tags, None),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation", _test_prediction_stats_tags, None),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile25",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile50",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Percentile75",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    None,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Min", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Max", _test_prediction_stats_tags, None),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Feature/col2/Count", _test_prediction_stats_tags, None),
@@ -216,7 +432,11 @@ _test_prediction_stats_tags = frozenset({('modelName', 'DummyClassifier'), ('inf
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile25", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile50", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Percentile75", _test_prediction_stats_tags, 1),
-                ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation", _test_prediction_stats_tags, 1),
+                (
+                    "MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/StandardDeviation",
+                    _test_prediction_stats_tags,
+                    1,
+                ),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Min", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Max", _test_prediction_stats_tags, 1),
                 ("MLModel/Sklearn/Named/DummyClassifier/Predict/Label/0/Count", _test_prediction_stats_tags, 1),
@@ -241,7 +461,11 @@ def test_prediction_stats(run_model, x_train, y_train, x_test, metrics, force_uu
     _test()
 
 
-_test_prediction_stats_multilabel_output_tags = frozenset({('modelName', 'MultiOutputClassifier'), ('inference_id', ML_METRIC_FORCED_UUID), ('model_version', '0.0.0')})
+_test_prediction_stats_multilabel_output_tags = frozenset(
+    {("modelName", "MultiOutputClassifier"), ("inference_id", ML_METRIC_FORCED_UUID), ("model_version", "0.0.0")}
+)
+
+
 def test_prediction_stats_multilabel_output(force_uuid):
     expected_transaction_name = (
         "test_prediction_stats:test_prediction_stats_multilabel_output.<locals>._test"
@@ -250,13 +474,21 @@ def test_prediction_stats_multilabel_output(force_uuid):
     )
     stats = ["Mean", "Percentile25", "Percentile50", "Percentile75", "StandardDeviation", "Min", "Max", "Count"]
     metrics = [
-        ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Feature/%s/%s" % (feature_col, stat_name), _test_prediction_stats_multilabel_output_tags, 1)
+        (
+            "MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Feature/%s/%s" % (feature_col, stat_name),
+            _test_prediction_stats_multilabel_output_tags,
+            1,
+        )
         for feature_col in range(20)
         for stat_name in stats
     ]
     metrics.extend(
         [
-            ("MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Label/%s/%s" % (label_col, stat_name), _test_prediction_stats_multilabel_output_tags, 1)
+            (
+                "MLModel/Sklearn/Named/MultiOutputClassifier/Predict/Label/%s/%s" % (label_col, stat_name),
+                _test_prediction_stats_multilabel_output_tags,
+                1,
+            )
             for label_col in range(3)
             for stat_name in stats
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -196,7 +196,7 @@ deps =
     mlmodel_sklearn: pandas
     mlmodel_sklearn: protobuf
     mlmodel_sklearn: numpy
-    mlmodel_sklearn-scikitlearnlatest: scikit-learn
+    mlmodel_sklearn-scikitlearnlatest: scikit-learn<1.11.0
     mlmodel_sklearn-scikitlearn0101: scikit-learn<1.1
     component_djangorestframework-djangorestframework0300: Django<1.9
     component_djangorestframework-djangorestframework0300: djangorestframework<3.1


### PR DESCRIPTION
# Overview

* Swap custom metrics for dimensional metrics in SKLearn instrumentation.
* Adjust variable naming in SKLearn instrumentation to match PEP8.
