### PR TITLE
Exclude command line functionality from test coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,3 +22,5 @@ ignore:
   # Temporarily disable kafka
   - "newrelic/hooks/messagebroker_kafkapython.py"
   - "newrelic/hooks/messagebroker_confluentkafka.py"
+  - "newrelic/admin/*"
+  - "newrelic/console.py"


### PR DESCRIPTION
This PR essentially is ignoring false negatives for coverage.  The functionality excluded is something that is tested but is not registered as being covered because it is called through the command line (a separate process).