### PR TITLE
Only send 1 event per prediction & fix tests

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -26,7 +26,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         freetds-common \
         freetds-dev \
         gcc \
-        gfortran \
         git \
         libbz2-dev \
         libcurl4-openssl-dev \
@@ -44,7 +43,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         make \
         odbc-postgresql \
         openssl \
-        pkg-config \
         python2-dev \
         python3-dev \
         python3-pip \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -164,7 +164,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -209,7 +209,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -269,7 +269,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -332,7 +332,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -395,7 +395,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -453,7 +453,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -513,7 +513,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -571,7 +571,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -630,7 +630,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -700,7 +700,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -758,7 +758,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -818,7 +818,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
@@ -879,7 +879,7 @@ jobs:
 
     runs-on: ubuntu-20.04
     container:
-      image: ghcr.io/newrelic/newrelic-python-agent-ci:sha-7f0fb125e22d5350dc5c775316e513af17f0e693@sha256:e4d5d68559e7637e090305d07498f6fa37f75eac2b61c2558fac7e54e4af8a7c
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30

--- a/newrelic/hooks/mlmodel_sklearn.py
+++ b/newrelic/hooks/mlmodel_sklearn.py
@@ -285,6 +285,7 @@ def create_prediction_event(transaction, class_, inference_id, instance, args, k
         event = {
             "inference_id": inference_id,
             "model_version": model_version,
+            "new_relic_data_schema_version": 2,
             # The following are used for entity synthesis.
             "modelName": model_name,
         }

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -32,31 +32,9 @@ pandas_df_category_recorded_custom_events = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
-            "feature_name": "col1",
-            "feature_type": "categorical",
-            "feature_value": "2.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "feature_name": "col2",
-            "feature_type": "categorical",
-            "feature_value": "4.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "27.0",
+            "feature.col1": "2.0",
+            "feature.col2": "4.0",
+            "label.0": "27.0",
         },
     ),
 ]
@@ -65,7 +43,7 @@ pandas_df_category_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_pandas_df_categorical_feature_event():
     @validate_ml_events(pandas_df_category_recorded_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -92,31 +70,9 @@ pandas_df_bool_recorded_custom_events = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
-            "feature_name": "col1",
-            "feature_type": "bool",
-            "feature_value": "True",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "feature_name": "col2",
-            "feature_type": "bool",
-            "feature_value": "True",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": label_type,
-            "label_value": true_label_value,
+            "feature.col1": "True",
+            "feature.col2": "True",
+            "label.0": true_label_value,
         },
     ),
 ]
@@ -125,7 +81,7 @@ pandas_df_bool_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_pandas_df_bool_feature_event():
     @validate_ml_events(pandas_df_bool_recorded_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -151,31 +107,9 @@ pandas_df_float_recorded_custom_events = [
             "inference_id": None,
             "modelName": "DecisionTreeRegressor",
             "model_version": "0.0.0",
-            "feature_name": "col1",
-            "feature_type": "numeric",
-            "feature_value": "100.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeRegressor",
-            "model_version": "0.0.0",
-            "feature_name": "col2",
-            "feature_type": "numeric",
-            "feature_value": "300.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeRegressor",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "345.6",
+            "feature.col1": "100.0",
+            "feature.col2": "300.0",
+            "label.0": "345.6",
         },
     ),
 ]
@@ -184,7 +118,7 @@ pandas_df_float_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_pandas_df_float_feature_event():
     @validate_ml_events(pandas_df_float_recorded_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -210,31 +144,9 @@ int_list_recorded_custom_events = [
             "inference_id": None,
             "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
-            "feature_name": "0",
-            "feature_type": "numeric",
-            "feature_value": "1",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "ExtraTreeRegressor",
-            "model_version": "0.0.0",
-            "feature_name": "1",
-            "feature_type": "numeric",
-            "feature_value": "2",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "ExtraTreeRegressor",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "1.0",
+            "feature.0": "1",
+            "feature.1": "2",
+            "label.0": "1.0",
         },
     ),
 ]
@@ -243,7 +155,7 @@ int_list_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_int_list():
     @validate_ml_events(int_list_recorded_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -268,31 +180,9 @@ numpy_int_recorded_custom_events = [
             "inference_id": None,
             "modelName": "ExtraTreeRegressor",
             "model_version": "0.0.0",
-            "feature_name": "0",
-            "feature_type": "numeric",
-            "feature_value": "12",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "ExtraTreeRegressor",
-            "model_version": "0.0.0",
-            "feature_name": "1",
-            "feature_type": "numeric",
-            "feature_value": "13",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "ExtraTreeRegressor",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "11.0",
+            "feature.0": "12",
+            "feature.1": "13",
+            "label.0": "11.0",
         },
     ),
 ]
@@ -301,7 +191,7 @@ numpy_int_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_numpy_int_array():
     @validate_ml_events(numpy_int_recorded_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -326,9 +216,9 @@ numpy_str_recorded_custom_events = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
-            "feature_name": "0",
-            "feature_type": "str",
-            "feature_value": "20",
+            "feature.0": "20",
+            "feature.1": "21",
+            "label.0": "21",
         },
     ),
     (
@@ -337,31 +227,9 @@ numpy_str_recorded_custom_events = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
-            "feature_name": "1",
-            "feature_type": "str",
-            "feature_value": "21",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "feature_name": "0",
-            "feature_type": "str",
-            "feature_value": "22",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "feature_name": "1",
-            "feature_type": "str",
-            "feature_value": "23",
+            "feature.0": "22",
+            "feature.1": "23",
+            "label.0": "21",
         },
     ),
 ]
@@ -370,7 +238,7 @@ numpy_str_recorded_custom_events = [
 @reset_core_stats_engine()
 def test_numpy_str_array_multiple_features():
     @validate_ml_events(numpy_str_recorded_custom_events)
-    @validate_ml_event_count(count=6)
+    @validate_ml_event_count(count=2)
     @background_task()
     def _test():
         import sklearn.tree
@@ -395,28 +263,6 @@ numpy_str_recorded_custom_events_no_value = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
-            "feature_name": "0",
-            "feature_type": "str",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "feature_name": "1",
-            "feature_type": "str",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "DecisionTreeClassifier",
-            "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "str",
         },
     ),
 ]
@@ -426,7 +272,7 @@ numpy_str_recorded_custom_events_no_value = [
 @override_application_settings({"machine_learning.inference_events_value.enabled": False})
 def test_does_not_include_value_when_inference_event_value_enabled_is_false():
     @validate_ml_events(numpy_str_recorded_custom_events_no_value)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import sklearn.tree
@@ -498,31 +344,29 @@ multilabel_output_label_events = [
             "inference_id": None,
             "modelName": "MultiOutputClassifier",
             "model_version": "0.0.0",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "1",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MultiOutputClassifier",
-            "model_version": "0.0.0",
-            "label_name": "1",
-            "label_type": "numeric",
-            "label_value": "0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MultiOutputClassifier",
-            "model_version": "0.0.0",
-            "label_name": "2",
-            "label_type": "numeric",
-            "label_value": "1",
+            "label.0": "1",
+            "label.1": "0",
+            "label.2": "1",
+            "feature.0": "3.0",
+            "feature.1": "5.0",
+            "feature.2": "3.0",
+            "feature.3": "0.0",
+            "feature.4": "0.0",
+            "feature.5": "2.0",
+            "feature.6": "2.0",
+            "feature.7": "0.0",
+            "feature.8": "4.0",
+            "feature.9": "3.0",
+            "feature.10": "2.0",
+            "feature.11": "5.0",
+            "feature.12": "2.0",
+            "feature.13": "3.0",
+            "feature.14": "3.0",
+            "feature.15": "4.0",
+            "feature.16": "3.0",
+            "feature.17": "1.0",
+            "feature.18": "2.0",
+            "feature.19": "4.0",
         },
     ),
 ]
@@ -531,8 +375,7 @@ multilabel_output_label_events = [
 @reset_core_stats_engine()
 def test_custom_event_count_multilabel_output():
     @validate_ml_events(multilabel_output_label_events)
-    # The expected count of 23 comes from 20 feature events + 3 label events to be generated
-    @validate_ml_event_count(count=23)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         from sklearn.datasets import make_multilabel_classification

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -35,6 +35,7 @@ pandas_df_category_recorded_custom_events = [
             "feature.col1": "2.0",
             "feature.col2": "4.0",
             "label.0": "27.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -73,6 +74,7 @@ pandas_df_bool_recorded_custom_events = [
             "feature.col1": "True",
             "feature.col2": "True",
             "label.0": true_label_value,
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -110,6 +112,7 @@ pandas_df_float_recorded_custom_events = [
             "feature.col1": "100.0",
             "feature.col2": "300.0",
             "label.0": "345.6",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -147,6 +150,7 @@ int_list_recorded_custom_events = [
             "feature.0": "1",
             "feature.1": "2",
             "label.0": "1.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -183,6 +187,7 @@ numpy_int_recorded_custom_events = [
             "feature.0": "12",
             "feature.1": "13",
             "label.0": "11.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -219,6 +224,7 @@ numpy_str_recorded_custom_events = [
             "feature.0": "20",
             "feature.1": "21",
             "label.0": "21",
+            "new_relic_data_schema_version": 2,
         },
     ),
     (
@@ -230,6 +236,7 @@ numpy_str_recorded_custom_events = [
             "feature.0": "22",
             "feature.1": "23",
             "label.0": "21",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -263,6 +270,7 @@ numpy_str_recorded_custom_events_no_value = [
             "inference_id": None,
             "modelName": "DecisionTreeClassifier",
             "model_version": "0.0.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -367,6 +375,7 @@ multilabel_output_label_events = [
             "feature.17": "1.0",
             "feature.18": "2.0",
             "feature.19": "4.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]

--- a/tests/mlmodel_sklearn/test_ml_model.py
+++ b/tests/mlmodel_sklearn/test_ml_model.py
@@ -127,31 +127,9 @@ int_list_recorded_custom_events = [
             "inference_id": None,
             "modelName": "MyCustomModel",
             "model_version": "1.2.3",
-            "feature_name": "0",
-            "feature_type": "numeric",
-            "feature_value": "1.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyCustomModel",
-            "model_version": "1.2.3",
-            "feature_name": "1",
-            "feature_type": "numeric",
-            "feature_value": "2.0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyCustomModel",
-            "model_version": "1.2.3",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": label_value,
+            "feature.0": "1.0",
+            "feature.1": "2.0",
+            "label.0": label_value,
         },
     ),
 ]
@@ -159,7 +137,7 @@ int_list_recorded_custom_events = [
 
 @reset_core_stats_engine()
 def test_custom_model_int_list_no_features_and_labels():
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @validate_ml_events(int_list_recorded_custom_events)
     @background_task()
     def _test():
@@ -184,42 +162,10 @@ pandas_df_recorded_custom_events = [
             "inference_id": None,
             "modelName": "PandasTestModel",
             "model_version": "1.5.0b1",
-            "feature_name": "feature1",
-            "feature_type": "categorical",
-            "feature_value": "0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "PandasTestModel",
-            "model_version": "1.5.0b1",
-            "feature_name": "feature2",
-            "feature_type": "categorical",
-            "feature_value": "0",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "PandasTestModel",
-            "model_version": "1.5.0b1",
-            "feature_name": "feature3",
-            "feature_type": "categorical",
-            "feature_value": "1",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "PandasTestModel",
-            "model_version": "1.5.0b1",
-            "label_name": "label1",
-            "label_type": "numeric",
-            "label_value": "0.5" if six.PY3 else "0.0",
+            "feature.feature1": "0",
+            "feature.feature2": "0",
+            "feature.feature3": "1",
+            "label.label1": "0.5" if six.PY3 else "0.0",
         },
     ),
 ]
@@ -227,7 +173,7 @@ pandas_df_recorded_custom_events = [
 
 @reset_core_stats_engine()
 def test_wrapper_attrs_custom_model_pandas_df():
-    @validate_ml_event_count(count=4)
+    @validate_ml_event_count(count=1)
     @validate_ml_events(pandas_df_recorded_custom_events)
     @background_task()
     def _test():
@@ -256,31 +202,9 @@ pandas_df_recorded_builtin_events = [
             "inference_id": None,
             "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
-            "feature_name": "feature1",
-            "feature_type": "numeric",
-            "feature_value": "12",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "1.5.0b1",
-            "feature_name": "feature2",
-            "feature_type": "numeric",
-            "feature_value": "14",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "1.5.0b1",
-            "label_name": "label1",
-            "label_type": "numeric",
-            "label_value": "0",
+            "feature.feature1": "12",
+            "feature.feature2": "14",
+            "label.label1": "0",
         },
     ),
 ]
@@ -288,7 +212,7 @@ pandas_df_recorded_builtin_events = [
 
 @reset_core_stats_engine()
 def test_wrapper_attrs_builtin_model():
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @validate_ml_events(pandas_df_recorded_builtin_events)
     @background_task()
     def _test():
@@ -322,42 +246,10 @@ pandas_df_mismatched_custom_events = [
             "inference_id": None,
             "modelName": "MyDecisionTreeClassifier",
             "model_version": "1.5.0b1",
-            "feature_name": "col1",
-            "feature_type": "numeric",
-            "feature_value": "12",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "1.5.0b1",
-            "feature_name": "col2",
-            "feature_type": "numeric",
-            "feature_value": "14",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "1.5.0b1",
-            "feature_name": "col3",
-            "feature_type": "numeric",
-            "feature_value": "16",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "1.5.0b1",
-            "label_name": "0",
-            "label_type": "numeric",
-            "label_value": "1",
+            "feature.col1": "12",
+            "feature.col2": "14",
+            "feature.col3": "16",
+            "label.0": "1",
         },
     ),
 ]
@@ -365,7 +257,7 @@ pandas_df_mismatched_custom_events = [
 
 @reset_core_stats_engine()
 def test_wrapper_mismatched_features_and_labels_df():
-    @validate_ml_event_count(count=4)
+    @validate_ml_event_count(count=1)
     @validate_ml_events(pandas_df_mismatched_custom_events)
     @background_task()
     def _test():
@@ -398,31 +290,9 @@ numpy_str_mismatched_custom_events = [
             "inference_id": None,
             "modelName": "MyDecisionTreeClassifier",
             "model_version": "0.0.1",
-            "feature_name": "0",
-            "feature_type": "str",
-            "feature_value": "20",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "0.0.1",
-            "feature_name": "1",
-            "feature_type": "str",
-            "feature_value": "21",
-        },
-    ),
-    (
-        {"type": "InferenceData"},
-        {
-            "inference_id": None,
-            "modelName": "MyDecisionTreeClassifier",
-            "model_version": "0.0.1",
-            "label_name": "0",
-            "label_type": "str",
-            "label_value": "21",
+            "feature.0": "20",
+            "feature.1": "21",
+            "label.0": "21",
         },
     ),
 ]
@@ -431,7 +301,7 @@ numpy_str_mismatched_custom_events = [
 @reset_core_stats_engine()
 def test_wrapper_mismatched_features_and_labels_np_array():
     @validate_ml_events(numpy_str_mismatched_custom_events)
-    @validate_ml_event_count(count=3)
+    @validate_ml_event_count(count=1)
     @background_task()
     def _test():
         import numpy as np

--- a/tests/mlmodel_sklearn/test_ml_model.py
+++ b/tests/mlmodel_sklearn/test_ml_model.py
@@ -130,6 +130,7 @@ int_list_recorded_custom_events = [
             "feature.0": "1.0",
             "feature.1": "2.0",
             "label.0": label_value,
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -166,6 +167,7 @@ pandas_df_recorded_custom_events = [
             "feature.feature2": "0",
             "feature.feature3": "1",
             "label.label1": "0.5" if six.PY3 else "0.0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -205,6 +207,7 @@ pandas_df_recorded_builtin_events = [
             "feature.feature1": "12",
             "feature.feature2": "14",
             "label.label1": "0",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -250,6 +253,7 @@ pandas_df_mismatched_custom_events = [
             "feature.col2": "14",
             "feature.col3": "16",
             "label.0": "1",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]
@@ -293,6 +297,7 @@ numpy_str_mismatched_custom_events = [
             "feature.0": "20",
             "feature.1": "21",
             "label.0": "21",
+            "new_relic_data_schema_version": 2,
         },
     ),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ envlist =
     python-agent_unittests-{pypy27,pypy38}-without_extensions,
     python-application_celery-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
     gearman-application_gearman-{py27,pypy27},
-    python-mlmodel_sklearn-{pypy38,py38,py39,py310,py311}-scikitlearnlatest,
+    python-mlmodel_sklearn-{py38,py39,py310,py311}-scikitlearnlatest,
     python-mlmodel_sklearn-{py37}-scikitlearn0101,
     python-component_djangorestframework-py27-djangorestframework0300,
     python-component_djangorestframework-{py37,py38,py39,py310,py311}-djangorestframeworklatest,


### PR DESCRIPTION
# Overview
1. This changes from sending 1 event per feature/label value to 1 event per prediction (Also referred to as a change in "schema").
    * Replace feature_name & feature_value and label_name & label_value to `feature.<name> = <value>` and `label.<name> = <value>`.
    * Remove feature_type and label_type.
    * Add a new schema attribute.
1. Remove pypy38 from test suite and remove compile dependencies from Dockerfile. Scipy wasn't able to compile consistently regardless of installing the necessary dependencies and adding these extra dependencies broke the kafka compile.