### PR TITLE
Add giveup_early to get_package_version functions

### DIFF
--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -19,10 +19,12 @@ VERSION_ATTRS = ("__version__", "version", "__version_tuple__", "version_tuple")
 NULL_VERSIONS = frozenset((None, "", "0", "0.0", "0.0.0", "0.0.0.0", (0,), (0, 0), (0, 0, 0), (0, 0, 0, 0)))  # nosec
 
 
-def get_package_version(name):
+def get_package_version(name, giveup_early=False):
     """Gets the version string of the library.
     :param name: The name of library.
     :type name: str
+    :param giveup_early: If True, stops search for version after checking version attributes on module. This is a performance optimization.
+    :type giveup_early: bool
     :return: The version of the library. Returns None if can't determine version.
     :type return: str or None
 
@@ -31,7 +33,7 @@ def get_package_version(name):
                 "1.1.0"
     """
 
-    version = _get_package_version(name)
+    version = _get_package_version(name, giveup_early)
 
     # Coerce iterables into a string
     if isinstance(version, tuple):
@@ -40,10 +42,12 @@ def get_package_version(name):
     return version
 
 
-def get_package_version_tuple(name):
+def get_package_version_tuple(name, giveup_early=False):
     """Gets the version tuple of the library.
     :param name: The name of library.
     :type name: str
+    :param giveup_early: If True, stops search for version after checking version attributes on module. This is a performance optimization.
+    :type giveup_early: bool
     :return: The version of the library. Returns None if can't determine version.
     :type return: tuple or None
 
@@ -58,7 +62,7 @@ def get_package_version_tuple(name):
         except Exception:
             return str(value)
 
-    version = _get_package_version(name)
+    version = _get_package_version(name, giveup_early)
 
     # Split "." separated strings and cast fields to ints
     if isinstance(version, str):
@@ -67,7 +71,7 @@ def get_package_version_tuple(name):
     return version
 
 
-def _get_package_version(name):
+def _get_package_version(name, giveup_early=False):
     module = sys.modules.get(name, None)
     version = None
     for attr in VERSION_ATTRS:
@@ -83,6 +87,9 @@ def _get_package_version(name):
                 return version
         except Exception:
             pass
+
+    if giveup_early:
+        return None
 
     # importlib was introduced into the standard library starting in Python3.8.
     if "importlib" in sys.modules and hasattr(sys.modules["importlib"], "metadata"):

--- a/newrelic/hooks/datastore_aioredis.py
+++ b/newrelic/hooks/datastore_aioredis.py
@@ -23,6 +23,8 @@ from newrelic.hooks.datastore_redis import (
     _redis_operation_re,
 )
 
+AIOREDIS_VERSION = get_package_version_tuple("aioredis", giveup_early=True)
+
 
 def _conn_attrs_to_dict(connection):
     host = getattr(connection, "host", None)
@@ -59,8 +61,8 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
         # Check for transaction and return early if found.
         # Method will return synchronously without executing,
         # it will be added to the command stack and run later.
-        aioredis_version = get_package_version_tuple("aioredis")
-        if aioredis_version and aioredis_version < (2,):
+
+        if AIOREDIS_VERSION and AIOREDIS_VERSION < (2,):
             # AioRedis v1 uses a RedisBuffer instead of a real connection for queueing up pipeline commands
             from aioredis.commands.transaction import _RedisBuffer
 
@@ -70,7 +72,7 @@ def _wrap_AioRedis_method_wrapper(module, instance_class_name, operation):
                 return wrapped(*args, **kwargs)
         else:
             # AioRedis v2 uses a Pipeline object for a client and internally queues up pipeline commands
-            if aioredis_version:
+            if AIOREDIS_VERSION:
                 from aioredis.client import Pipeline
             else:
                 from redis.asyncio.client import Pipeline

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -33,6 +33,8 @@ HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 
+CONFLUENT_KAFKA_VERSION = get_package_version("confluent-kafka")
+
 
 def wrap_Producer_produce(wrapped, instance, args, kwargs):
     transaction = current_transaction()
@@ -57,7 +59,7 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
     else:
         topic = kwargs.pop("topic", None)
 
-    transaction.add_messagebroker_info("Confluent-Kafka", get_package_version("confluent-kafka"))
+    transaction.add_messagebroker_info("Confluent-Kafka", CONFLUENT_KAFKA_VERSION)
 
     with MessageTrace(
         library="Kafka",
@@ -164,7 +166,7 @@ def wrap_Consumer_poll(wrapped, instance, args, kwargs):
             name = "Named/%s" % destination_name
             transaction.record_custom_metric("%s/%s/Received/Bytes" % (group, name), received_bytes)
             transaction.record_custom_metric("%s/%s/Received/Messages" % (group, name), message_count)
-            transaction.add_messagebroker_info("Confluent-Kafka", get_package_version("confluent-kafka"))
+            transaction.add_messagebroker_info("Confluent-Kafka", CONFLUENT_KAFKA_VERSION)
 
     return record
 

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -35,6 +35,8 @@ HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 
+KAFKA_PYTHON_VERSION = get_package_version("kafka-python")
+
 
 def _bind_send(topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
     return topic, value, key, headers, partition, timestamp_ms
@@ -49,7 +51,7 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
     topic, value, key, headers, partition, timestamp_ms = _bind_send(*args, **kwargs)
     headers = list(headers) if headers else []
 
-    transaction.add_messagebroker_info("Kafka-Python", get_package_version("kafka-python"))
+    transaction.add_messagebroker_info("Kafka-Python", KAFKA_PYTHON_VERSION)
 
     with MessageTrace(
         library="Kafka",
@@ -147,7 +149,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             name = "Named/%s" % destination_name
             transaction.record_custom_metric("%s/%s/Received/Bytes" % (group, name), received_bytes)
             transaction.record_custom_metric("%s/%s/Received/Messages" % (group, name), message_count)
-            transaction.add_messagebroker_info("Kafka-Python", get_package_version("kafka-python"))
+            transaction.add_messagebroker_info("Kafka-Python", KAFKA_PYTHON_VERSION)
 
     return record
 


### PR DESCRIPTION
# Overview
Add giveup_early to get_package_version functions and only get version once at import time.

# Related Github Issue
This is a fix for https://github.com/newrelic/newrelic-python-agent/pull/817.