### PR TITLE
Add full version for pypy3.8 to tox

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -91,7 +91,7 @@ RUN echo 'eval "$(pyenv init -)"' >>$HOME/.bashrc && \
     pyenv update
 
 # Install Python
-ARG PYTHON_VERSIONS="3.10 3.9 3.8 3.7 3.11 2.7 pypy2.7-7.3.11 pypy3.8"
+ARG PYTHON_VERSIONS="3.10 3.9 3.8 3.7 3.11 2.7 pypy2.7-7.3.12 pypy3.8-7.3.11"
 COPY --chown=1000:1000 --chmod=+x ./install-python.sh /tmp/install-python.sh
 COPY ./requirements.txt /requirements.txt
 RUN /tmp/install-python.sh && \

--- a/tox.ini
+++ b/tox.ini
@@ -199,6 +199,7 @@ deps =
     adapter_uvicorn-uvicorn03: uvicorn<0.4
     adapter_uvicorn-uvicorn014: uvicorn<0.15
     adapter_uvicorn-uvicornlatest: uvicorn
+    adapter_uvicorn: typing-extensions
     adapter_waitress: WSGIProxy2
     adapter_waitress-waitress010404: waitress<1.4.5
     adapter_waitress-waitress02: waitress<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,6 @@ envlist =
     redis-datastore_aioredis-{py37,py38,py39,py310,pypy38}-aioredislatest,
     redis-datastore_aioredis-{py37,py38,py39,py310,py311,pypy38}-redislatest,
     redis-datastore_aredis-{py37,py38,py39,pypy38}-aredislatest,
-    solr-datastore_solrpy-{py27,pypy27}-solrpy{00,01},
     python-datastore_sqlite-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
     python-external_boto3-{py27,py37,py38,py39,py310,py311}-boto01,
     python-external_botocore-{py37,py38,py39,py310,py311}-botocorelatest,
@@ -261,8 +260,6 @@ deps =
     datastore_aioredis-redislatest: redis
     datastore_aioredis-aioredislatest: aioredis
     datastore_aredis-aredislatest: aredis
-    datastore_solrpy-solrpy00: solrpy<1.0
-    datastore_solrpy-solrpy01: solrpy<2.0
     external_boto3-boto01: boto3<2.0
     external_boto3-boto01: moto<2.0
     external_boto3-py27: rsa<4.7.1
@@ -462,7 +459,6 @@ changedir =
     datastore_redis: tests/datastore_redis
     datastore_aioredis: tests/datastore_aioredis
     datastore_aredis: tests/datastore_aredis
-    datastore_solrpy: tests/datastore_solrpy
     datastore_sqlite: tests/datastore_sqlite
     external_boto3: tests/external_boto3
     external_botocore: tests/external_botocore


### PR DESCRIPTION
This PR does several things:

1. Adds the typing-extensions package as a dependency for uvicorn
2. Adds the full version of pypy3.8 to the Docker container setup.  This fix does not break the existing script that is setup to find the latest install of the specified Python version
3. Removes solrpy from tests (this framework was last released May 12, 2020 and is (at the time of this PR creation) outside New Relic's support window)