### PR TITLE
Update datastore_trace wrapper to take instance info

### DIFF
--- a/newrelic/api/datastore_trace.py
+++ b/newrelic/api/datastore_trace.py
@@ -287,7 +287,9 @@ def datastore_trace(product, target, operation, host=None, port_path_or_id=None,
     )
 
 
-def wrap_datastore_trace(module, object_path, product, target, operation, host=None, port_path_or_id=None, database_name=None):
+def wrap_datastore_trace(
+    module, object_path, product, target, operation, host=None, port_path_or_id=None, database_name=None
+):
     """Method applies custom timing to datastore query.
 
     :param module: Module containing the method to be instrumented.

--- a/newrelic/api/datastore_trace.py
+++ b/newrelic/api/datastore_trace.py
@@ -135,7 +135,7 @@ class DatastoreTrace(TimeTrace):
         )
 
 
-def DatastoreTraceWrapper(wrapped, product, target, operation, host, port_path_or_id, database_name):
+def DatastoreTraceWrapper(wrapped, product, target, operation, host=None, port_path_or_id=None, database_name=None):
     """Wraps a method to time datastore queries.
 
     :param wrapped: The function to apply the trace to.
@@ -242,7 +242,7 @@ def DatastoreTraceWrapper(wrapped, product, target, operation, host, port_path_o
     return FunctionWrapper(wrapped, _nr_datastore_trace_wrapper_)
 
 
-def datastore_trace(product, target, operation, host, port_path_or_id, database_name):
+def datastore_trace(product, target, operation, host=None, port_path_or_id=None, database_name=None):
     """Decorator allows datastore query to be timed.
 
     :param product: The name of the vendor.
@@ -287,7 +287,7 @@ def datastore_trace(product, target, operation, host, port_path_or_id, database_
     )
 
 
-def wrap_datastore_trace(module, object_path, product, target, operation, host, port_path_or_id, database_name):
+def wrap_datastore_trace(module, object_path, product, target, operation, host=None, port_path_or_id=None, database_name=None):
     """Method applies custom timing to datastore query.
 
     :param module: Module containing the method to be instrumented.

--- a/newrelic/api/datastore_trace.py
+++ b/newrelic/api/datastore_trace.py
@@ -95,7 +95,14 @@ class DatastoreTrace(TimeTrace):
         return "<%s object at 0x%x %s>" % (
             self.__class__.__name__,
             id(self),
-            dict(product=self.product, target=self.target, operation=self.operation, host=self.host, port_path_or_id=self.port_path_or_id, database_name=self.database_name),
+            dict(
+                product=self.product,
+                target=self.target,
+                operation=self.operation,
+                host=self.host,
+                port_path_or_id=self.port_path_or_id,
+                database_name=self.database_name,
+            ),
         )
 
     def finalize_data(self, transaction, exc=None, value=None, tb=None):
@@ -222,7 +229,9 @@ def DatastoreTraceWrapper(wrapped, product, target, operation, host, port_path_o
         else:
             _database_name = database_name
 
-        trace = DatastoreTrace(_product, _target, _operation, _host, _port_path_or_id, _database_name, parent=parent, source=wrapped)
+        trace = DatastoreTrace(
+            _product, _target, _operation, _host, _port_path_or_id, _database_name, parent=parent, source=wrapped
+        )
 
         if wrapper:  # pylint: disable=W0125,W0126
             return wrapper(wrapped, trace)(*args, **kwargs)
@@ -267,7 +276,15 @@ def datastore_trace(product, target, operation, host, port_path_or_id, database_
         ...     time.sleep(*args, **kwargs)
 
     """
-    return functools.partial(DatastoreTraceWrapper, product=product, target=target, operation=operation, host=host, port_path_or_id=port_path_or_id, database_name=database_name)
+    return functools.partial(
+        DatastoreTraceWrapper,
+        product=product,
+        target=target,
+        operation=operation,
+        host=host,
+        port_path_or_id=port_path_or_id,
+        database_name=database_name,
+    )
 
 
 def wrap_datastore_trace(module, object_path, product, target, operation, host, port_path_or_id, database_name):
@@ -307,4 +324,6 @@ def wrap_datastore_trace(module, object_path, product, target, operation, host, 
         ...        'sleep')
 
     """
-    wrap_object(module, object_path, DatastoreTraceWrapper, (product, target, operation, host, port_path_or_id, database_name))
+    wrap_object(
+        module, object_path, DatastoreTraceWrapper, (product, target, operation, host, port_path_or_id, database_name)
+    )

--- a/tests/agent_features/test_datastore_trace.py
+++ b/tests/agent_features/test_datastore_trace.py
@@ -1,0 +1,58 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from newrelic.api.background_task import background_task
+from newrelic.api.datastore_trace import DatastoreTrace, DatastoreTraceWrapper
+from testing_support.validators.validate_datastore_trace_inputs import (
+    validate_datastore_trace_inputs,
+)
+
+
+@validate_datastore_trace_inputs(operation='test_operation', target='test_target', host='test_host', port_path_or_id='test_port', database_name='test_db_name')
+def test_dt_trace_all_args():
+    with DatastoreTrace(product='Agent Features', target='test_target', operation='test_operation', host='test_host', port_path_or_id='test_port', database_name='test_db_name'):
+        pass
+
+
+@validate_datastore_trace_inputs(operation=None, target=None, host=None, port_path_or_id=None, database_name=None)
+def test_dt_trace_empty():
+    with DatastoreTrace(product=None, target=None, operation=None):
+        pass
+
+
+@background_task()
+def test_dt_trace_callable_args():
+    def product_callable():
+        return "Agent Features"
+
+    def target_callable():
+        return 'test_target'
+
+    def operation_callable():
+        return "test_operation"
+
+    def host_callable():
+        return 'test_host'
+
+    def port_path_id_callable():
+        return 'test_port'
+
+    def db_name_callable():
+        return 'test_db_name'
+
+    @validate_datastore_trace_inputs(operation='test_operation', target='test_target', host='test_host', port_path_or_id='test_port', database_name='test_db_name')
+    def _test():
+        pass
+    wrapped_fn = DatastoreTraceWrapper(_test, product=product_callable, target=target_callable, operation=operation_callable, host=host_callable, port_path_or_id=port_path_id_callable, database_name=db_name_callable)
+    wrapped_fn()

--- a/tests/agent_features/test_datastore_trace.py
+++ b/tests/agent_features/test_datastore_trace.py
@@ -20,12 +20,14 @@ from testing_support.validators.validate_datastore_trace_inputs import (
 
 
 @validate_datastore_trace_inputs(operation='test_operation', target='test_target', host='test_host', port_path_or_id='test_port', database_name='test_db_name')
+@background_task()
 def test_dt_trace_all_args():
     with DatastoreTrace(product='Agent Features', target='test_target', operation='test_operation', host='test_host', port_path_or_id='test_port', database_name='test_db_name'):
         pass
 
 
 @validate_datastore_trace_inputs(operation=None, target=None, host=None, port_path_or_id=None, database_name=None)
+@background_task()
 def test_dt_trace_empty():
     with DatastoreTrace(product=None, target=None, operation=None):
         pass

--- a/tests/agent_features/test_datastore_trace.py
+++ b/tests/agent_features/test_datastore_trace.py
@@ -12,17 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.background_task import background_task
-from newrelic.api.datastore_trace import DatastoreTrace, DatastoreTraceWrapper
 from testing_support.validators.validate_datastore_trace_inputs import (
     validate_datastore_trace_inputs,
 )
 
+from newrelic.api.background_task import background_task
+from newrelic.api.datastore_trace import DatastoreTrace, DatastoreTraceWrapper
 
-@validate_datastore_trace_inputs(operation='test_operation', target='test_target', host='test_host', port_path_or_id='test_port', database_name='test_db_name')
+
+@validate_datastore_trace_inputs(
+    operation="test_operation",
+    target="test_target",
+    host="test_host",
+    port_path_or_id="test_port",
+    database_name="test_db_name",
+)
 @background_task()
 def test_dt_trace_all_args():
-    with DatastoreTrace(product='Agent Features', target='test_target', operation='test_operation', host='test_host', port_path_or_id='test_port', database_name='test_db_name'):
+    with DatastoreTrace(
+        product="Agent Features",
+        target="test_target",
+        operation="test_operation",
+        host="test_host",
+        port_path_or_id="test_port",
+        database_name="test_db_name",
+    ):
         pass
 
 
@@ -39,22 +53,37 @@ def test_dt_trace_callable_args():
         return "Agent Features"
 
     def target_callable():
-        return 'test_target'
+        return "test_target"
 
     def operation_callable():
         return "test_operation"
 
     def host_callable():
-        return 'test_host'
+        return "test_host"
 
     def port_path_id_callable():
-        return 'test_port'
+        return "test_port"
 
     def db_name_callable():
-        return 'test_db_name'
+        return "test_db_name"
 
-    @validate_datastore_trace_inputs(operation='test_operation', target='test_target', host='test_host', port_path_or_id='test_port', database_name='test_db_name')
+    @validate_datastore_trace_inputs(
+        operation="test_operation",
+        target="test_target",
+        host="test_host",
+        port_path_or_id="test_port",
+        database_name="test_db_name",
+    )
     def _test():
         pass
-    wrapped_fn = DatastoreTraceWrapper(_test, product=product_callable, target=target_callable, operation=operation_callable, host=host_callable, port_path_or_id=port_path_id_callable, database_name=db_name_callable)
+
+    wrapped_fn = DatastoreTraceWrapper(
+        _test,
+        product=product_callable,
+        target=target_callable,
+        operation=operation_callable,
+        host=host_callable,
+        port_path_or_id=port_path_id_callable,
+        database_name=db_name_callable,
+    )
     wrapped_fn()

--- a/tests/testing_support/validators/validate_datastore_trace_inputs.py
+++ b/tests/testing_support/validators/validate_datastore_trace_inputs.py
@@ -45,7 +45,7 @@ def validate_datastore_trace_inputs(operation=None, target=None, host=None, port
         if operation is not None:
             assert captured_operation == operation, "%s didn't match expected %s" % (captured_operation, operation)
         if host is not None:
-            assert host == host, "%s didn't match expected %s" % (captured_host, host)
+            assert captured_host == host, "%s didn't match expected %s" % (captured_host, host)
         if port_path_or_id is not None:
             assert captured_port_path_or_id == port_path_or_id, "%s didn't match expected %s" % (
                 captured_port_path_or_id,

--- a/tests/testing_support/validators/validate_datastore_trace_inputs.py
+++ b/tests/testing_support/validators/validate_datastore_trace_inputs.py
@@ -23,7 +23,7 @@ target: search argument
 """
 
 
-def validate_datastore_trace_inputs(operation=None, target=None):
+def validate_datastore_trace_inputs(operation=None, target=None, host=None, port_path_or_id=None, database_name=None):
     @transient_function_wrapper("newrelic.api.datastore_trace", "DatastoreTrace.__init__")
     @catch_background_exceptions
     def _validate_datastore_trace_inputs(wrapped, instance, args, kwargs):
@@ -44,6 +44,13 @@ def validate_datastore_trace_inputs(operation=None, target=None):
             assert captured_target == target, "%s didn't match expected %s" % (captured_target, target)
         if operation is not None:
             assert captured_operation == operation, "%s didn't match expected %s" % (captured_operation, operation)
+        if host is not None:
+            assert host == host, "%s didn't match expected %s" % (captured_host, host)
+        if port_path_or_id is not None:
+            assert captured_port_path_or_id == port_path_or_id, "%s didn't match expected %s" % (captured_port_path_or_id, port_path_or_id)
+        if database_name is not None:
+            assert captured_database_name == database_name, "%s didn't match expected %s" % (captured_database_name, database_name)
+
 
         return wrapped(*args, **kwargs)
 

--- a/tests/testing_support/validators/validate_datastore_trace_inputs.py
+++ b/tests/testing_support/validators/validate_datastore_trace_inputs.py
@@ -47,10 +47,15 @@ def validate_datastore_trace_inputs(operation=None, target=None, host=None, port
         if host is not None:
             assert host == host, "%s didn't match expected %s" % (captured_host, host)
         if port_path_or_id is not None:
-            assert captured_port_path_or_id == port_path_or_id, "%s didn't match expected %s" % (captured_port_path_or_id, port_path_or_id)
+            assert captured_port_path_or_id == port_path_or_id, "%s didn't match expected %s" % (
+                captured_port_path_or_id,
+                port_path_or_id,
+            )
         if database_name is not None:
-            assert captured_database_name == database_name, "%s didn't match expected %s" % (captured_database_name, database_name)
-
+            assert captured_database_name == database_name, "%s didn't match expected %s" % (
+                captured_database_name,
+                database_name,
+            )
 
         return wrapped(*args, **kwargs)
 


### PR DESCRIPTION
This PR updates the `datastore_trace` wrapper to take in `host`, `port_path_or_id`, and `database_name`.