### PR TITLE
Trace Async Wrapper Argument

### DIFF
--- a/newrelic/api/database_trace.py
+++ b/newrelic/api/database_trace.py
@@ -16,7 +16,7 @@ import functools
 import logging
 
 from newrelic.api.time_trace import TimeTrace, current_trace
-from newrelic.common.async_wrapper import async_wrapper
+from newrelic.common.async_wrapper import async_wrapper as get_async_wrapper
 from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 from newrelic.core.database_node import DatabaseNode
 from newrelic.core.stack_trace import current_stack
@@ -244,9 +244,9 @@ class DatabaseTrace(TimeTrace):
         )
 
 
-def DatabaseTraceWrapper(wrapped, sql, dbapi2_module=None):
+def DatabaseTraceWrapper(wrapped, sql, dbapi2_module=None, async_wrapper=None):
     def _nr_database_trace_wrapper_(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -273,9 +273,9 @@ def DatabaseTraceWrapper(wrapped, sql, dbapi2_module=None):
     return FunctionWrapper(wrapped, _nr_database_trace_wrapper_)
 
 
-def database_trace(sql, dbapi2_module=None):
-    return functools.partial(DatabaseTraceWrapper, sql=sql, dbapi2_module=dbapi2_module)
+def database_trace(sql, dbapi2_module=None, async_wrapper=None):
+    return functools.partial(DatabaseTraceWrapper, sql=sql, dbapi2_module=dbapi2_module, async_wrapper=async_wrapper)
 
 
-def wrap_database_trace(module, object_path, sql, dbapi2_module=None):
-    wrap_object(module, object_path, DatabaseTraceWrapper, (sql, dbapi2_module))
+def wrap_database_trace(module, object_path, sql, dbapi2_module=None, async_wrapper=None):
+    wrap_object(module, object_path, DatabaseTraceWrapper, (sql, dbapi2_module, async_wrapper))

--- a/newrelic/api/datastore_trace.py
+++ b/newrelic/api/datastore_trace.py
@@ -288,12 +288,12 @@ def datastore_trace(product, target, operation, host=None, port_path_or_id=None,
         host=host,
         port_path_or_id=port_path_or_id,
         database_name=database_name,
-        async_wrapper=None,
+        async_wrapper=async_wrapper,
     )
 
 
 def wrap_datastore_trace(
-    module, object_path, product, target, operation, host=None, port_path_or_id=None, database_name=None
+    module, object_path, product, target, operation, host=None, port_path_or_id=None, database_name=None, async_wrapper=None
 ):
     """Method applies custom timing to datastore query.
 

--- a/newrelic/api/function_trace.py
+++ b/newrelic/api/function_trace.py
@@ -15,7 +15,7 @@
 import functools
 
 from newrelic.api.time_trace import TimeTrace, current_trace
-from newrelic.common.async_wrapper import async_wrapper
+from newrelic.common.async_wrapper import async_wrapper as get_async_wrapper
 from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 from newrelic.core.function_node import FunctionNode
@@ -89,9 +89,9 @@ class FunctionTrace(TimeTrace):
         )
 
 
-def FunctionTraceWrapper(wrapped, name=None, group=None, label=None, params=None, terminal=False, rollup=None):
+def FunctionTraceWrapper(wrapped, name=None, group=None, label=None, params=None, terminal=False, rollup=None, async_wrapper=None):
     def dynamic_wrapper(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -147,7 +147,7 @@ def FunctionTraceWrapper(wrapped, name=None, group=None, label=None, params=None
             return wrapped(*args, **kwargs)
 
     def literal_wrapper(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -171,13 +171,13 @@ def FunctionTraceWrapper(wrapped, name=None, group=None, label=None, params=None
     return FunctionWrapper(wrapped, literal_wrapper)
 
 
-def function_trace(name=None, group=None, label=None, params=None, terminal=False, rollup=None):
+def function_trace(name=None, group=None, label=None, params=None, terminal=False, rollup=None, async_wrapper=None):
     return functools.partial(
-        FunctionTraceWrapper, name=name, group=group, label=label, params=params, terminal=terminal, rollup=rollup
+        FunctionTraceWrapper, name=name, group=group, label=label, params=params, terminal=terminal, rollup=rollup, async_wrapper=async_wrapper
     )
 
 
 def wrap_function_trace(
-    module, object_path, name=None, group=None, label=None, params=None, terminal=False, rollup=None
+    module, object_path, name=None, group=None, label=None, params=None, terminal=False, rollup=None, async_wrapper=None
 ):
-    return wrap_object(module, object_path, FunctionTraceWrapper, (name, group, label, params, terminal, rollup))
+    return wrap_object(module, object_path, FunctionTraceWrapper, (name, group, label, params, terminal, rollup, async_wrapper))

--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -16,7 +16,7 @@ import functools
 
 from newrelic.api.time_trace import TimeTrace, current_trace
 from newrelic.api.transaction import current_transaction
-from newrelic.common.async_wrapper import async_wrapper
+from newrelic.common.async_wrapper import async_wrapper as get_async_wrapper
 from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 from newrelic.core.graphql_node import GraphQLOperationNode, GraphQLResolverNode
 
@@ -109,9 +109,9 @@ class GraphQLOperationTrace(TimeTrace):
             transaction.set_transaction_name(name, "GraphQL", priority=priority)
 
 
-def GraphQLOperationTraceWrapper(wrapped):
+def GraphQLOperationTraceWrapper(wrapped, async_wrapper=None):
     def _nr_graphql_trace_wrapper_(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -130,12 +130,12 @@ def GraphQLOperationTraceWrapper(wrapped):
     return FunctionWrapper(wrapped, _nr_graphql_trace_wrapper_)
 
 
-def graphql_operation_trace():
-    return functools.partial(GraphQLOperationTraceWrapper)
+def graphql_operation_trace(async_wrapper=None):
+    return functools.partial(GraphQLOperationTraceWrapper, async_wrapper=async_wrapper)
 
 
-def wrap_graphql_operation_trace(module, object_path):
-    wrap_object(module, object_path, GraphQLOperationTraceWrapper)
+def wrap_graphql_operation_trace(module, object_path, async_wrapper=None):
+    wrap_object(module, object_path, GraphQLOperationTraceWrapper, (async_wrapper,))
 
 
 class GraphQLResolverTrace(TimeTrace):
@@ -193,9 +193,9 @@ class GraphQLResolverTrace(TimeTrace):
         )
 
 
-def GraphQLResolverTraceWrapper(wrapped):
+def GraphQLResolverTraceWrapper(wrapped, async_wrapper=None):
     def _nr_graphql_trace_wrapper_(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -214,9 +214,9 @@ def GraphQLResolverTraceWrapper(wrapped):
     return FunctionWrapper(wrapped, _nr_graphql_trace_wrapper_)
 
 
-def graphql_resolver_trace():
-    return functools.partial(GraphQLResolverTraceWrapper)
+def graphql_resolver_trace(async_wrapper=None):
+    return functools.partial(GraphQLResolverTraceWrapper, async_wrapper=async_wrapper)
 
 
-def wrap_graphql_resolver_trace(module, object_path):
-    wrap_object(module, object_path, GraphQLResolverTraceWrapper)
+def wrap_graphql_resolver_trace(module, object_path, async_wrapper=None):
+    wrap_object(module, object_path, GraphQLResolverTraceWrapper, (async_wrapper,))

--- a/newrelic/api/memcache_trace.py
+++ b/newrelic/api/memcache_trace.py
@@ -15,7 +15,7 @@
 import functools
 
 from newrelic.api.time_trace import TimeTrace, current_trace
-from newrelic.common.async_wrapper import async_wrapper
+from newrelic.common.async_wrapper import async_wrapper as get_async_wrapper
 from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 from newrelic.core.memcache_node import MemcacheNode
 
@@ -51,9 +51,9 @@ class MemcacheTrace(TimeTrace):
         )
 
 
-def MemcacheTraceWrapper(wrapped, command):
+def MemcacheTraceWrapper(wrapped, command, async_wrapper=None):
     def _nr_wrapper_memcache_trace_(wrapped, instance, args, kwargs):
-        wrapper = async_wrapper(wrapped)
+        wrapper = async_wrapper if async_wrapper is not None else get_async_wrapper(wrapped)
         if not wrapper:
             parent = current_trace()
             if not parent:
@@ -80,9 +80,9 @@ def MemcacheTraceWrapper(wrapped, command):
     return FunctionWrapper(wrapped, _nr_wrapper_memcache_trace_)
 
 
-def memcache_trace(command):
-    return functools.partial(MemcacheTraceWrapper, command=command)
+def memcache_trace(command, async_wrapper=None):
+    return functools.partial(MemcacheTraceWrapper, command=command, async_wrapper=async_wrapper)
 
 
-def wrap_memcache_trace(module, object_path, command):
-    wrap_object(module, object_path, MemcacheTraceWrapper, (command,))
+def wrap_memcache_trace(module, object_path, command, async_wrapper=None):
+    wrap_object(module, object_path, MemcacheTraceWrapper, (command, async_wrapper))

--- a/tests/agent_features/test_async_wrapper_detection.py
+++ b/tests/agent_features/test_async_wrapper_detection.py
@@ -1,0 +1,102 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import functools
+import time
+
+from newrelic.api.background_task import background_task
+from newrelic.api.database_trace import database_trace
+from newrelic.api.datastore_trace import datastore_trace
+from newrelic.api.external_trace import external_trace
+from newrelic.api.function_trace import function_trace
+from newrelic.api.graphql_trace import graphql_operation_trace, graphql_resolver_trace
+from newrelic.api.memcache_trace import memcache_trace
+from newrelic.api.message_trace import message_trace
+
+from newrelic.common.async_wrapper import generator_wrapper
+
+from testing_support.fixtures import capture_transaction_metrics
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+trace_metric_cases = [
+    (functools.partial(function_trace, name="simple_gen"), "Function/simple_gen"),
+    (functools.partial(external_trace, library="lib", url="http://foo.com"), "External/foo.com/lib/"),
+    (functools.partial(database_trace, "select * from foo"), "Datastore/statement/None/foo/select"),
+    (functools.partial(datastore_trace, "lib", "foo", "bar"), "Datastore/statement/lib/foo/bar"),
+    (functools.partial(message_trace, "lib", "op", "typ", "name"), "MessageBroker/lib/typ/op/Named/name"),
+    (functools.partial(memcache_trace, "cmd"), "Memcache/cmd"),
+    (functools.partial(graphql_operation_trace), "GraphQL/operation/GraphQL/<unknown>/<anonymous>/<unknown>"),
+    (functools.partial(graphql_resolver_trace), "GraphQL/resolve/GraphQL/<unknown>"),
+]
+
+
+@pytest.mark.parametrize("trace,metric", trace_metric_cases)
+def test_automatic_generator_trace_wrapper(trace, metric):
+    metrics = []
+    full_metrics = {}
+
+    @capture_transaction_metrics(metrics, full_metrics)
+    @validate_transaction_metrics(
+        "test_automatic_generator_trace_wrapper", background_task=True, scoped_metrics=[(metric, 1)], rollup_metrics=[(metric, 1)]
+    )
+    @background_task(name="test_automatic_generator_trace_wrapper")
+    def _test():
+        @trace()
+        def gen():
+            time.sleep(0.1)
+            yield
+            time.sleep(0.1)
+
+        for _ in gen():
+            pass
+
+    _test()
+
+    # Check that generators time the total call time (including pauses)
+    metric_key = (metric, "")
+    assert full_metrics[metric_key].total_call_time >= 0.2
+
+
+@pytest.mark.parametrize("trace,metric", trace_metric_cases)
+def test_manual_generator_trace_wrapper(trace, metric):
+    metrics = []
+    full_metrics = {}
+
+    @capture_transaction_metrics(metrics, full_metrics)
+    @validate_transaction_metrics(
+        "test_automatic_generator_trace_wrapper", background_task=True, scoped_metrics=[(metric, 1)], rollup_metrics=[(metric, 1)]
+    )
+    @background_task(name="test_automatic_generator_trace_wrapper")
+    def _test():
+        @trace(async_wrapper=generator_wrapper)
+        def wrapper_func():
+            """Function that returns a generator object, obscuring the automatic introspection of async_wrapper()"""
+            def gen():
+                time.sleep(0.1)
+                yield
+                time.sleep(0.1)
+            return gen()
+
+        for _ in wrapper_func():
+            pass
+
+    _test()
+
+    # Check that generators time the total call time (including pauses)
+    metric_key = (metric, "")
+    assert full_metrics[metric_key].total_call_time >= 0.2


### PR DESCRIPTION
# Overview

* Add `async_wrapper` as an argument to all trace APIs to allow manual overrides of the async wrapper when introspection is not possible, but the return type is known.
  * Includes tests on a generator, and generator obscured by a wrapper function.