### PR TITLE
Add check for both path and file

### DIFF
--- a/newrelic/common/agent_http.py
+++ b/newrelic/common/agent_http.py
@@ -263,7 +263,7 @@ class HttpClient(BaseClient):
 
                 # If there is no resolved cafile, assume the bundled certs are
                 # required and report this condition as a supportability metric.
-                if not verify_path.cafile:
+                if not verify_path.cafile and not verify_path.capath:
                     ca_bundle_path = certs.where()
                     internal_metric(
                         "Supportability/Python/Certificate/BundleRequired", 1

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -565,6 +565,7 @@ def test_ca_bundle_path(monkeypatch, ca_bundle_path):
     # Pretend CA certificates are not available
     class DefaultVerifyPaths(object):
         cafile = None
+        capath = None
 
         def __init__(self, *args, **kwargs):
             pass

--- a/tests/agent_unittests/test_http_client.py
+++ b/tests/agent_unittests/test_http_client.py
@@ -325,7 +325,7 @@ def test_http_payload_compression(server, client_cls, method, threshold):
             # Verify the compressed payload length is recorded
             assert internal_metrics["Supportability/Python/Collector/method1/ZLIB/Bytes"][:2] == [1, payload_byte_len]
             assert internal_metrics["Supportability/Python/Collector/ZLIB/Bytes"][:2] == [2, payload_byte_len*2]
-            
+
             assert len(internal_metrics) == 8
         else:
             # Verify no ZLIB compression metrics were sent
@@ -366,11 +366,14 @@ def test_cert_path(server):
 def test_default_cert_path(monkeypatch, system_certs_available):
     if system_certs_available:
         cert_file = "foo"
+        ca_path = "/usr/certs"
     else:
         cert_file = None
+        ca_path = None
 
     class DefaultVerifyPaths(object):
         cafile = cert_file
+        capath = ca_path
 
         def __init__(self, *args, **kwargs):
             pass


### PR DESCRIPTION
# Overview
Fix an issue in the certificate fallback logic. Only use fallback NR certificates if both the ca file and ca path are None.

# Related Github Issue
This fixes https://github.com/newrelic/newrelic-python-agent/issues/906.
