### PR TITLE
Pin anyio version to below 4.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -340,6 +340,12 @@ deps =
     framework_sanic-saniclatest: sanic
     framework_sanic-sanic{1812,190301,1906}: aiohttp
     framework_sanic-sanic{1812,190301,1906,1912,200904,210300,2109,2112,2203,2290}: websockets<11
+    ; For test_exception_in_middleware test, anyio is used:
+    ; https://github.com/encode/starlette/pull/1157
+    ; but anyiolatest creates breaking changes to our tests 
+    ; (but not the instrumentation):
+    ; https://github.com/agronholm/anyio/releases/tag/4.0.0
+    framework_starlette: anyio<4
     framework_starlette-starlette0014: starlette<0.15
     framework_starlette-starlette0015: starlette<0.16
     framework_starlette-starlette0019: starlette<0.20


### PR DESCRIPTION
This PR pins framework_starlette: anyio to < v4.0.0

`anyio` is used for `test_exception_in_middleware` test in Starlette: https://github.com/encode/starlette/pull/1157
However, v4.0.0 of `anyio` creates breaking changes to our tests (but not the instrumentation): https://github.com/agronholm/anyio/releases/tag/4.0.0

This should be kept in our tests until Starlette v0.17.0 is no longer within New Relic's support window (January 23, 2024)
