### PR TITLE
Skip flaky Kafka tests (for now)

### DIFF
--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -38,7 +38,7 @@ from newrelic.packages import six
 
 
 # Flaky test for client_type==cimpl
-# @pytest.mark.skip(reason="cimpl test is flaky")
+@pytest.mark.skip(reason="cimpl test is flaky")
 def test_custom_metrics(get_consumer_record, topic):
     custom_metrics = [
         ("Message/Kafka/Topic/Named/%s/Received/Bytes" % topic, 1),

--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -36,7 +36,8 @@ from newrelic.api.transaction import end_of_transaction
 from newrelic.common.object_names import callable_name
 from newrelic.packages import six
 
-
+# Flaky test for client_type==cimpl
+# @pytest.mark.skip(reason="cimpl test is flaky") 
 def test_custom_metrics(get_consumer_record, topic):
     custom_metrics = [
         ("Message/Kafka/Topic/Named/%s/Received/Bytes" % topic, 1),
@@ -64,7 +65,8 @@ def test_multiple_transactions(get_consumer_record, topic):
 
     _test()
 
-
+# Flaky test for client_type==cimpl
+@pytest.mark.skip(reason="cimpl test is flaky")
 def test_custom_metrics_on_existing_transaction(get_consumer_record, topic):
     from confluent_kafka import __version__ as version
 

--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -36,8 +36,9 @@ from newrelic.api.transaction import end_of_transaction
 from newrelic.common.object_names import callable_name
 from newrelic.packages import six
 
+
 # Flaky test for client_type==cimpl
-# @pytest.mark.skip(reason="cimpl test is flaky") 
+# @pytest.mark.skip(reason="cimpl test is flaky")
 def test_custom_metrics(get_consumer_record, topic):
     custom_metrics = [
         ("Message/Kafka/Topic/Named/%s/Received/Bytes" % topic, 1),
@@ -64,6 +65,7 @@ def test_multiple_transactions(get_consumer_record, topic):
         get_consumer_record()
 
     _test()
+
 
 # Flaky test for client_type==cimpl
 @pytest.mark.skip(reason="cimpl test is flaky")


### PR DESCRIPTION
This PR skips the flaky ConfluentKafka tests (for now).  The `cimpl` client type is what is causing the false negative in the tests.