### PR TITLE
Add redis.asyncio.Connection instrumentation

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2760,20 +2760,6 @@ def _process_module_builtin_defaults():
         "aioredis.connection", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_connection"
     )
 
-    # Redis v4.2+
-    _process_module_definition(
-        "redis.asyncio.client", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
-    )
-
-    # Redis v4.2+
-    _process_module_definition(
-        "redis.asyncio.commands", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
-    )
-
-    _process_module_definition(
-        "redis.asyncio.connection", "newrelic.hooks.datastore_aioredis", "instrument_aioredis_connection"
-    )
-
     # v7 and below
     _process_module_definition(
         "elasticsearch.client",
@@ -2928,6 +2914,21 @@ def _process_module_builtin_defaults():
         "pymongo.collection",
         "newrelic.hooks.datastore_pymongo",
         "instrument_pymongo_collection",
+    )
+
+    # Redis v4.2+
+    _process_module_definition(
+        "redis.asyncio.client", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
+    )
+
+    # Redis v4.2+
+    _process_module_definition(
+        "redis.asyncio.commands", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_client"
+    )
+
+    # Redis v4.2+
+    _process_module_definition(
+        "redis.asyncio.connection", "newrelic.hooks.datastore_redis", "instrument_asyncio_redis_connection"
     )
 
     _process_module_definition(

--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -189,7 +189,6 @@ def _nr_wrapper_Flask_register_error_handler_(wrapped, instance, args, kwargs):
 
 
 def _nr_wrapper_Flask_try_trigger_before_first_request_functions_(wrapped, instance, args, kwargs):
-
     transaction = current_transaction()
 
     if transaction is None:
@@ -355,7 +354,6 @@ def _nr_wrapper_Blueprint_endpoint_(wrapped, instance, args, kwargs):
 
 @function_wrapper
 def _nr_wrapper_Blueprint_before_request_wrapped_(wrapped, instance, args, kwargs):
-
     transaction = current_transaction()
 
     if transaction is None:

--- a/newrelic/hooks/framework_flask.py
+++ b/newrelic/hooks/framework_flask.py
@@ -166,7 +166,7 @@ def _nr_wrapper_error_handler_(wrapped, instance, args, kwargs):
     return FunctionTraceWrapper(wrapped, name=name)(*args, **kwargs)
 
 
-def _nr_wrapper_Flask__register_error_handler_(wrapped, instance, args, kwargs):
+def _nr_wrapper_Flask__register_error_handler_(wrapped, instance, args, kwargs):  # pragma: no cover
     def _bind_params(key, code_or_exception, f):
         return key, code_or_exception, f
 

--- a/tests/datastore_redis/test_asyncio.py
+++ b/tests/datastore_redis/test_asyncio.py
@@ -30,14 +30,16 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 DB_SETTINGS = redis_settings()[0]
 REDIS_PY_VERSION = get_package_version_tuple("redis")
 
-# Metrics
+# Metrics for publish test
+
+datastore_all_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
 
 _base_scoped_metrics = [("Datastore/operation/Redis/publish", 3)]
 
 if REDIS_PY_VERSION >= (5, 0):
-    _base_scoped_metrics.append(('Datastore/operation/Redis/client_setinfo', 2),)
-
-datastore_all_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
+    _base_scoped_metrics.append(
+        ("Datastore/operation/Redis/client_setinfo", 2),
+    )
 
 _base_rollup_metrics = [
     ("Datastore/all", datastore_all_metric_count),
@@ -45,10 +47,36 @@ _base_rollup_metrics = [
     ("Datastore/Redis/all", datastore_all_metric_count),
     ("Datastore/Redis/allOther", datastore_all_metric_count),
     ("Datastore/operation/Redis/publish", 3),
-    ("Datastore/instance/Redis/%s/%s" % (instance_hostname(DB_SETTINGS["host"]), DB_SETTINGS["port"]), datastore_all_metric_count),
+    (
+        "Datastore/instance/Redis/%s/%s" % (instance_hostname(DB_SETTINGS["host"]), DB_SETTINGS["port"]),
+        datastore_all_metric_count,
+    ),
 ]
 if REDIS_PY_VERSION >= (5, 0):
-    _base_rollup_metrics.append(('Datastore/operation/Redis/client_setinfo', 2),)
+    _base_rollup_metrics.append(
+        ("Datastore/operation/Redis/client_setinfo", 2),
+    )
+
+
+# Metrics for connection pool test
+
+_base_pool_scoped_metrics = [
+    ("Datastore/operation/Redis/get", 1),
+    ("Datastore/operation/Redis/set", 1),
+    ("Datastore/operation/Redis/client_list", 1),
+]
+
+_base_pool_rollup_metrics = [
+    ("Datastore/all", 3),
+    ("Datastore/allOther", 3),
+    ("Datastore/Redis/all", 3),
+    ("Datastore/Redis/allOther", 3),
+    ("Datastore/operation/Redis/get", 1),
+    ("Datastore/operation/Redis/set", 1),
+    ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/instance/Redis/%s/%s" % (instance_hostname(DB_SETTINGS["host"]), DB_SETTINGS["port"]), 3),
+]
+
 
 # Tests
 
@@ -58,6 +86,31 @@ def client(loop):  # noqa
     import redis.asyncio
 
     return loop.run_until_complete(redis.asyncio.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0))
+
+
+@pytest.fixture()
+def client_pool(loop):  # noqa
+    import redis.asyncio
+
+    connection_pool = redis.asyncio.ConnectionPool(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
+    return loop.run_until_complete(redis.asyncio.Redis(connection_pool=connection_pool))
+
+
+@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")
+@validate_transaction_metrics(
+    "test_asyncio:test_async_connection_pool",
+    scoped_metrics=_base_pool_scoped_metrics,
+    rollup_metrics=_base_pool_rollup_metrics,
+    background_task=True,
+)
+@background_task()
+def test_async_connection_pool(client_pool, loop):  # noqa
+    async def _test_async_pool(client_pool):
+        await client_pool.set("key1", "value1")
+        await client_pool.get("key1")
+        await client_pool.execute_command("CLIENT", "LIST")
+
+    loop.run_until_complete(_test_async_pool(client_pool))
 
 
 @pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")

--- a/tox.ini
+++ b/tox.ini
@@ -300,8 +300,6 @@ deps =
     framework_flask: markupsafe<2.1
     framework_flask: jinja2<3.1
     framework_flask: Flask-Compress
-    framework_flask-flask0012: flask<0.13
-    framework_flask-flask0101: flask<1.2
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
     framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]

--- a/tox.ini
+++ b/tox.ini
@@ -128,8 +128,6 @@ envlist =
     # Falcon master branch failing on 3.11 currently.
     python-framework_falcon-py311-falcon0200,
     python-framework_fastapi-{py37,py38,py39,py310,py311},
-    python-framework_flask-{pypy27,py27}-flask0012,
-    python-framework_flask-{pypy27,py27,py37,py38,py39,py310,py311,pypy38}-flask0101,
     ; temporarily disabling flaskmaster tests
     python-framework_flask-{py37,py38,py39,py310,py311,pypy38}-flasklatest,
     python-framework_graphene-{py37,py38,py39,py310,py311}-graphenelatest,


### PR DESCRIPTION
This PR 

- Adds instrumentation for redis.asyncio.Connection
- Drops Flask support for Python 2.7 since the last version of Flask to support Python 2.7 (v1.1.2) is outside New Relic's supportability window (Since April 2022)

