### PR TITLE
Pin flask version for flask restx tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -208,6 +208,8 @@ deps =
     component_flask_rest: jinja2
     component_flask_rest: itsdangerous
     component_flask_rest-flaskrestxlatest: flask-restx
+    ; Pin Flask version until flask-restx is updated to support v3
+    component_flask_rest-flaskrestxlatest: flask<3.0
     component_flask_rest-flaskrestx051: flask-restx<1.0
     component_graphqlserver: graphql-server[sanic,flask]==3.0.0b5
     component_graphqlserver: sanic>20


### PR DESCRIPTION
This PR pins the flask version being installed for flask-restx tests until v3 support is added: https://github.com/python-restx/flask-restx/pull/572
