### PR TITLE
Cache Package Version Lookups

### DIFF
--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -13,7 +13,43 @@
 # limitations under the License.
 
 import sys
-from functools import lru_cache
+
+try:
+    from functools import cache as _cache_package_versions
+except ImportError:
+    from functools import wraps
+    from threading import Lock
+
+    _package_version_cache = {}
+    _package_version_cache_lock = Lock()
+    def _cache_package_versions(wrapped):
+        """
+        Threadsafe implementation of caching for _get_package_version.
+        
+        Python 2.7 does not have the @functools.cache decorator, and 
+        must be reimplemented with support for clearing the cache.
+        """
+
+        @wraps(wrapped)
+        def _wrapper(name):
+            if name in _package_version_cache:
+                return _package_version_cache[name]
+            
+            with _package_version_cache_lock:
+                if name in _package_version_cache:
+                    return _package_version_cache[name]
+
+                version = _package_version_cache[name] = wrapped(name)
+                return version
+        
+        def cache_clear():
+            """Cache clear function to mimic @functools.cache"""
+            with _package_version_cache_lock:
+                _package_version_cache.clear()
+
+        _wrapper.cache_clear = cache_clear
+        return _wrapper
+
 
 # Need to account for 4 possible variations of version declaration specified in (rejected) PEP 396
 VERSION_ATTRS = ("__version__", "version", "__version_tuple__", "version_tuple")  # nosec
@@ -69,7 +105,6 @@ def get_package_version_tuple(name):
 
 
 @_cache_package_versions
-@lru_cache
 def _get_package_version(name):
     module = sys.modules.get(name, None)
     version = None

--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from functools import lru_cache
 
 # Need to account for 4 possible variations of version declaration specified in (rejected) PEP 396
 VERSION_ATTRS = ("__version__", "version", "__version_tuple__", "version_tuple")  # nosec
@@ -67,6 +68,8 @@ def get_package_version_tuple(name):
     return version
 
 
+@_cache_package_versions
+@lru_cache
 def _get_package_version(name):
     module = sys.modules.get(name, None)
     version = None

--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -22,11 +22,12 @@ except ImportError:
 
     _package_version_cache = {}
     _package_version_cache_lock = Lock()
+
     def _cache_package_versions(wrapped):
         """
         Threadsafe implementation of caching for _get_package_version.
-        
-        Python 2.7 does not have the @functools.cache decorator, and 
+
+        Python 2.7 does not have the @functools.cache decorator, and
         must be reimplemented with support for clearing the cache.
         """
 
@@ -34,14 +35,14 @@ except ImportError:
         def _wrapper(name):
             if name in _package_version_cache:
                 return _package_version_cache[name]
-            
+
             with _package_version_cache_lock:
                 if name in _package_version_cache:
                     return _package_version_cache[name]
 
                 version = _package_version_cache[name] = wrapped(name)
                 return version
-        
+
         def cache_clear():
             """Cache clear function to mimic @functools.cache"""
             with _package_version_cache_lock:
@@ -113,7 +114,7 @@ def _get_package_version(name):
     if "importlib" in sys.modules and hasattr(sys.modules["importlib"], "metadata"):
         try:
             # In Python3.10+ packages_distribution can be checked for as well
-            if hasattr(sys.modules["importlib"].metadata, "packages_distributions"):    # pylint: disable=E1101
+            if hasattr(sys.modules["importlib"].metadata, "packages_distributions"):  # pylint: disable=E1101
                 distributions = sys.modules["importlib"].metadata.packages_distributions()  # pylint: disable=E1101
                 distribution_name = distributions.get(name, name)
             else:

--- a/tests/agent_unittests/test_package_version_utils.py
+++ b/tests/agent_unittests/test_package_version_utils.py
@@ -20,9 +20,9 @@ from testing_support.validators.validate_function_called import validate_functio
 from newrelic.common.package_version_utils import (
     NULL_VERSIONS,
     VERSION_ATTRS,
+    _get_package_version,
     get_package_version,
     get_package_version_tuple,
-    _get_package_version,
 )
 
 # Notes:
@@ -32,7 +32,7 @@ from newrelic.common.package_version_utils import (
 # such as distribution_packages and removed pkg_resources.
 
 IS_PY38_PLUS = sys.version_info[:2] >= (3, 8)
-IS_PY310_PLUS = sys.version_info[:2] >= (3,10)
+IS_PY310_PLUS = sys.version_info[:2] >= (3, 10)
 SKIP_IF_NOT_IMPORTLIB_METADATA = pytest.mark.skipif(not IS_PY38_PLUS, reason="importlib.metadata is not supported.")
 SKIP_IF_IMPORTLIB_METADATA = pytest.mark.skipif(
     IS_PY38_PLUS, reason="importlib.metadata is preferred over pkg_resources."


### PR DESCRIPTION
# Overview

* Implement caching for package version lookups to prevent future performance issues.
  * Note: Python 2.7 does not support this decorator and requires a custom implementation of caching. The implementation closely mirrors `@functools.cache` including thread safety and the `cache_clear()` function.

# Related Github Issue
Supersedes and closes #817
