### PR TITLE
Drop python 3.7 tests for Hypercorn

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ envlist =
     python-adapter_daphne-{py37,py38,py39,py310,py311}-daphnelatest,
     python-adapter_gevent-{py27,py37,py38,py310,py311},
     python-adapter_gunicorn-{py37,py38,py39,py310,py311}-aiohttp3-gunicornlatest,
-    python-adapter_hypercorn-{py37,py38,py39,py310,py311}-hypercornlatest,
+    python-adapter_hypercorn-{py38,py39,py310,py311}-hypercornlatest,
     python-adapter_hypercorn-py38-hypercorn{0010,0011,0012,0013},
     python-adapter_uvicorn-{py37,py38,py39,py310,py311}-uvicorn{014,latest},
     python-adapter_waitress-{py37,py38,py39,py310}-waitress02,


### PR DESCRIPTION
Hypercorn released [version 0.15](https://github.com/pgjones/hypercorn/releases/tag/0.15.0) which drops Python 3.7 support.  One non-backwards compatible change is that `Literal` is imported from `typing` which is only supported in Python 3.8+.  This PR removes testing for Python 3.7 in Hypercorn.