### PR TITLE
Remove duplicate kafka import hook

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2448,11 +2448,6 @@ def _process_module_builtin_defaults():
         "newrelic.hooks.messagebroker_kafkapython",
         "instrument_kafka_heartbeat",
     )
-    _process_module_definition(
-        "kafka.consumer.group",
-        "newrelic.hooks.messagebroker_kafkapython",
-        "instrument_kafka_consumer_group",
-    )
 
     _process_module_definition(
         "logging",


### PR DESCRIPTION
This PR removes a duplicate kafka import hook in newrelic/config.py