### PR TITLE
Use named function traces

### DIFF
--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -25,7 +25,6 @@ from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.message_trace import message_trace
 from newrelic.api.time_trace import get_trace_linking_metadata
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 from newrelic.common.package_version_utils import get_package_version
 from newrelic.core.config import global_settings
@@ -312,8 +311,10 @@ def wrap_bedrock_runtime_invoke_model(wrapped, instance, args, kwargs):
 
         extractor = lambda *args: ([], {})  # Empty extractor that returns nothing
 
-    ft_name = callable_name(wrapped)
-    with FunctionTrace(ft_name) as ft:
+    function_name = wrapped.__name__
+    operation = "embedding" if model.startswith("amazon.titan-embed") else "completion"
+
+    with FunctionTrace(name=function_name, group="Llm/%s/Bedrock" % (operation)) as ft:
         try:
             response = wrapped(*args, **kwargs)
         except Exception as exc:

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -48,7 +48,6 @@ def wrap_embedding_create(wrapped, instance, args, kwargs):
 
     settings = transaction.settings if transaction.settings is not None else global_settings()
 
-
     function_name = wrapped.__name__
 
     with FunctionTrace(name=function_name, group="Llm/embedding/OpenAI") as ft:

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -19,7 +19,6 @@ import openai
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.time_trace import get_trace_linking_metadata
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import wrap_function_wrapper
 from newrelic.common.package_version_utils import get_package_version
 from newrelic.core.config import global_settings
@@ -49,8 +48,10 @@ def wrap_embedding_create(wrapped, instance, args, kwargs):
 
     settings = transaction.settings if transaction.settings is not None else global_settings()
 
-    ft_name = callable_name(wrapped)
-    with FunctionTrace(ft_name) as ft:
+
+    function_name = wrapped.__name__
+
+    with FunctionTrace(name=function_name, group="Llm/embedding/OpenAI") as ft:
         try:
             response = wrapped(*args, **kwargs)
         except Exception as exc:
@@ -167,8 +168,9 @@ def wrap_chat_completion_create(wrapped, instance, args, kwargs):
     app_name = settings.app_name
     completion_id = str(uuid.uuid4())
 
-    ft_name = callable_name(wrapped)
-    with FunctionTrace(ft_name) as ft:
+    function_name = wrapped.__name__
+
+    with FunctionTrace(name=function_name, group="Llm/completion/OpenAI") as ft:
         try:
             response = wrapped(*args, **kwargs)
         except Exception as exc:
@@ -432,8 +434,9 @@ async def wrap_embedding_acreate(wrapped, instance, args, kwargs):
 
     settings = transaction.settings if transaction.settings is not None else global_settings()
 
-    ft_name = callable_name(wrapped)
-    with FunctionTrace(ft_name) as ft:
+    function_name = wrapped.__name__
+
+    with FunctionTrace(name=function_name, group="Llm/embedding/OpenAI") as ft:
         try:
             response = await wrapped(*args, **kwargs)
         except Exception as exc:
@@ -550,8 +553,9 @@ async def wrap_chat_completion_acreate(wrapped, instance, args, kwargs):
     app_name = settings.app_name
     completion_id = str(uuid.uuid4())
 
-    ft_name = callable_name(wrapped)
-    with FunctionTrace(ft_name) as ft:
+    function_name = wrapped.__name__
+
+    with FunctionTrace(name=function_name, group="Llm/completion/OpenAI") as ft:
         try:
             response = await wrapped(*args, **kwargs)
         except Exception as exc:

--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -30,10 +30,10 @@ from testing_support.fixtures import (
     reset_core_stats_engine,
     validate_custom_event_count,
 )
+from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_error_trace_attributes import (
     validate_error_trace_attributes,
 )
-from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
 )
@@ -111,6 +111,8 @@ def test_bedrock_chat_completion_in_txn_with_convo_id(set_trace_info, exercise_m
     @validate_custom_event_count(count=3)
     @validate_transaction_metrics(
         name="test_bedrock_chat_completion_in_txn_with_convo_id",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
         custom_metrics=[
             ("Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
         ],
@@ -133,6 +135,8 @@ def test_bedrock_chat_completion_in_txn_no_convo_id(set_trace_info, exercise_mod
     @validate_custom_event_count(count=3)
     @validate_transaction_metrics(
         name="test_bedrock_chat_completion_in_txn_no_convo_id",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
         custom_metrics=[
             ("Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
         ],
@@ -194,6 +198,15 @@ _client_error_name = callable_name(_client_error)
         },
     },
 )
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion:test_bedrock_chat_completion_error_invalid_model",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    custom_metrics=[
+        ("Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
+    ],
+    background_task=True,
+)
 @background_task()
 def test_bedrock_chat_completion_error_invalid_model(bedrock_server, set_trace_info):
     set_trace_info()
@@ -220,7 +233,16 @@ def test_bedrock_chat_completion_error_incorrect_access_key(
             "user": expected_client_error,
         },
     )
-    @background_task()
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            ("Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
     def _test():
         monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
 

--- a/tests/external_botocore/test_bedrock_embeddings.py
+++ b/tests/external_botocore/test_bedrock_embeddings.py
@@ -27,12 +27,12 @@ from testing_support.fixtures import (  # override_application_settings,
     dt_enabled,
     override_application_settings,
     reset_core_stats_engine,
-    validate_custom_event_count
+    validate_custom_event_count,
 )
+from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_error_trace_attributes import (
     validate_error_trace_attributes,
 )
-from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
 )
@@ -96,6 +96,8 @@ def test_bedrock_embedding(set_trace_info, exercise_model, expected_events):
     @validate_custom_event_count(count=1)
     @validate_transaction_metrics(
         name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
         custom_metrics=[
             ("Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
         ],
@@ -148,7 +150,13 @@ def test_bedrock_embedding_error_incorrect_access_key(
             "user": expected_client_error,
         },
     )
-    @background_task()
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
     def _test():
         monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
 

--- a/tests/mlmodel_openai/test_chat_completion.py
+++ b/tests/mlmodel_openai/test_chat_completion.py
@@ -249,6 +249,12 @@ chat_completion_recorded_events_no_convo_id = [
 @validate_custom_events(chat_completion_recorded_events_no_convo_id)
 # One summary event, one system message, one user message, and one response message from the assistant
 @validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion:test_openai_chat_completion_sync_in_txn_no_convo_id",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
 @background_task()
 def test_openai_chat_completion_sync_in_txn_no_convo_id(set_trace_info):
     set_trace_info()
@@ -287,6 +293,12 @@ def test_openai_chat_completion_sync_custom_events_insights_disabled(set_trace_i
 @reset_core_stats_engine()
 @validate_custom_events(chat_completion_recorded_events_no_convo_id)
 @validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion:test_openai_chat_completion_async_conversation_id_unset",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
+)
 @background_task()
 def test_openai_chat_completion_async_conversation_id_unset(loop, set_trace_info):
     set_trace_info()
@@ -301,6 +313,12 @@ def test_openai_chat_completion_async_conversation_id_unset(loop, set_trace_info
 @reset_core_stats_engine()
 @validate_custom_events(chat_completion_recorded_events)
 @validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion:test_openai_chat_completion_async_conversation_id_set",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
+)
 @validate_transaction_metrics(
     name="test_chat_completion:test_openai_chat_completion_async_conversation_id_set",
     custom_metrics=[

--- a/tests/mlmodel_openai/test_chat_completion_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_error.py
@@ -24,6 +24,9 @@ from testing_support.validators.validate_error_trace_attributes import (
     validate_error_trace_attributes,
 )
 from testing_support.validators.validate_span_events import validate_span_events
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
@@ -116,6 +119,12 @@ expected_events_on_no_model_error = [
         "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.chat_completion.ChatCompletion'>",
     }
 )
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_no_model",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
 @validate_custom_events(expected_events_on_no_model_error)
 @validate_custom_event_count(count=3)
 @background_task()
@@ -193,6 +202,12 @@ expected_events_on_invalid_model_error = [
     exact_agents={
         "error.message": "The model `does-not-exist` does not exist",
     }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_invalid_model",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
 )
 @validate_custom_events(expected_events_on_invalid_model_error)
 @validate_custom_event_count(count=2)
@@ -288,6 +303,12 @@ expected_events_on_auth_error = [
         "error.message": "No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.",
     }
 )
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_authentication_error",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
 @validate_custom_events(expected_events_on_auth_error)
 @validate_custom_event_count(count=3)
 @background_task()
@@ -366,6 +387,12 @@ expected_events_on_wrong_api_key_error = [
         "error.message": "Incorrect API key provided: invalid. You can find your API key at https://platform.openai.com/account/api-keys.",
     }
 )
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_wrong_api_key_error",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
 @validate_custom_events(expected_events_on_wrong_api_key_error)
 @validate_custom_event_count(count=2)
 @background_task()
@@ -399,6 +426,12 @@ def test_chat_completion_wrong_api_key_error(monkeypatch, set_trace_info):
     exact_agents={
         "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.chat_completion.ChatCompletion'>",
     }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_no_model_async",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
 )
 @validate_custom_events(expected_events_on_no_model_error)
 @validate_custom_event_count(count=3)
@@ -436,6 +469,12 @@ def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_in
         "error.message": "The model `does-not-exist` does not exist",
     }
 )
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_invalid_model_async",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
+)
 @validate_custom_events(expected_events_on_invalid_model_error)
 @validate_custom_event_count(count=2)
 @background_task()
@@ -469,6 +508,12 @@ def test_chat_completion_invalid_request_error_invalid_model_async(loop, set_tra
         "error.message": "No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.",
     }
 )
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_authentication_error_async",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
+)
 @validate_custom_events(expected_events_on_auth_error)
 @validate_custom_event_count(count=3)
 @background_task()
@@ -501,6 +546,12 @@ def test_chat_completion_authentication_error_async(loop, monkeypatch, set_trace
     exact_agents={
         "error.message": "Incorrect API key provided: invalid. You can find your API key at https://platform.openai.com/account/api-keys.",
     }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_wrong_api_key_error_async",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
 )
 @validate_custom_events(expected_events_on_wrong_api_key_error)
 @validate_custom_event_count(count=2)

--- a/tests/mlmodel_openai/test_embeddings.py
+++ b/tests/mlmodel_openai/test_embeddings.py
@@ -65,6 +65,8 @@ embedding_recorded_events = [
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_embeddings:test_openai_embedding_sync",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -87,6 +89,8 @@ def test_openai_embedding_sync_outside_txn():
 @validate_custom_event_count(count=0)
 @validate_transaction_metrics(
     name="test_embeddings:test_openai_embedding_sync_disabled_settings",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -103,6 +107,8 @@ def test_openai_embedding_sync_disabled_settings(set_trace_info):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_embeddings:test_openai_embedding_async",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -130,6 +136,8 @@ def test_openai_embedding_async_outside_transaction(loop):
 @validate_custom_event_count(count=0)
 @validate_transaction_metrics(
     name="test_embeddings:test_openai_embedding_async_disabled_custom_insights_events",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],

--- a/tests/mlmodel_openai/test_embeddings_error.py
+++ b/tests/mlmodel_openai/test_embeddings_error.py
@@ -24,6 +24,9 @@ from testing_support.validators.validate_error_trace_attributes import (
     validate_error_trace_attributes,
 )
 from testing_support.validators.validate_span_events import validate_span_events
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
 
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
@@ -68,6 +71,15 @@ embedding_recorded_events = [
     exact_agents={
         "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.embedding.Embedding'>",
     }
+)
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_invalid_request_error_no_model",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
 )
 @validate_custom_events(embedding_recorded_events)
 @validate_custom_event_count(count=1)
@@ -122,6 +134,15 @@ invalid_model_events = [
         # "http.statusCode": 404,
     }
 )
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_invalid_request_error_invalid_model",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
 @validate_custom_events(invalid_model_events)
 @validate_custom_event_count(count=1)
 @background_task()
@@ -168,6 +189,15 @@ embedding_auth_error_events = [
     exact_agents={
         "error.message": "No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.",
     }
+)
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_authentication_error",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
 )
 @validate_custom_events(embedding_auth_error_events)
 @validate_custom_event_count(count=1)
@@ -219,6 +249,15 @@ embedding_invalid_key_error_events = [
         "error.message": "Incorrect API key provided: DEADBEEF. You can find your API key at https://platform.openai.com/account/api-keys.",
     }
 )
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_wrong_api_key_error",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
 @validate_custom_events(embedding_invalid_key_error_events)
 @validate_custom_event_count(count=1)
 @background_task()
@@ -249,6 +288,15 @@ def test_embeddings_wrong_api_key_error(monkeypatch, set_trace_info):
     exact_agents={
         "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.embedding.Embedding'>",
     }
+)
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_invalid_request_error_no_model_async",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
 )
 @validate_custom_events(embedding_recorded_events)
 @validate_custom_event_count(count=1)
@@ -282,6 +330,15 @@ def test_embeddings_invalid_request_error_no_model_async(loop, set_trace_info):
         "error.message": "The model `does-not-exist` does not exist",
     }
 )
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_invalid_request_error_invalid_model_async",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
 @validate_custom_events(invalid_model_events)
 @validate_custom_event_count(count=1)
 @background_task()
@@ -306,6 +363,15 @@ def test_embeddings_invalid_request_error_invalid_model_async(loop, set_trace_in
     exact_agents={
         "error.message": "No API key provided. You can set your API key in code using 'openai.api_key = <API-KEY>', or you can set the environment variable OPENAI_API_KEY=<API-KEY>). If your API key is stored in a file, you can point the openai module at it with 'openai.api_key_path = <PATH>'. You can generate API keys in the OpenAI web interface. See https://platform.openai.com/account/api-keys for details.",
     }
+)
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_authentication_error_async",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
 )
 @validate_custom_events(embedding_auth_error_events)
 @validate_custom_event_count(count=1)
@@ -334,6 +400,15 @@ def test_embeddings_authentication_error_async(loop, monkeypatch, set_trace_info
     exact_agents={
         "error.message": "Incorrect API key provided: DEADBEEF. You can find your API key at https://platform.openai.com/account/api-keys.",
     }
+)
+@validate_transaction_metrics(
+    name="test_embeddings_error:test_embeddings_wrong_api_key_error_async",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
 )
 @validate_custom_events(embedding_invalid_key_error_events)
 @validate_custom_event_count(count=1)


### PR DESCRIPTION
# Overview
Use named function traces in OpenAI:
* `Llm/completion/OpenAI/<function name>`
* `Llm/embedding/OpenAI/<function name>`

Use named function traces in Bedrock:
* `Llm/completion/Bedrock/<function name>`
* `Llm/embedding/Bedrock/<function name>`
