### PR TITLE
Update wrapt

### DIFF
--- a/newrelic/common/object_wrapper.py
+++ b/newrelic/common/object_wrapper.py
@@ -64,21 +64,21 @@ class ObjectProxy(_ObjectProxy):
             name = name.replace("_nr_", "_self_", 1)
             setattr(self, name, value)
         else:
-            _ObjectProxy.__setattr__(self, name, value)
+            super(ObjectProxy, self).__setattr__(name, value)
 
     def __getattr__(self, name):
         if name.startswith("_nr_"):
             name = name.replace("_nr_", "_self_", 1)
             return getattr(self, name)
         else:
-            return _ObjectProxy.__getattr__(self, name)
+            return super(ObjectProxy, self).__getattr__(name)
 
     def __delattr__(self, name):
         if name.startswith("_nr_"):
             name = name.replace("_nr_", "_self_", 1)
             delattr(self, name)
         else:
-            _ObjectProxy.__delattr__(self, name)
+            super(ObjectProxy, self).__delattr__(name)
 
     @property
     def _nr_next_object(self):

--- a/newrelic/common/object_wrapper.py
+++ b/newrelic/common/object_wrapper.py
@@ -52,11 +52,12 @@ from newrelic.packages.wrapt.__wrapt__ import _FunctionWrapperBase
 
 class ObjectProxy(_ObjectProxy):
     """
-    This class provides method overrides for all object wrappers used by the agent.
-
-    These methods allow attributes to be defined with the special prefix _nr_ to be interpretted as
-    attributes on the wrapper, rather than the wrapped object. Inheriting from the base class wrapt.ObjectProxy
-    preserves method resolution order (MRO) through multiple inheritance. (See https://www.python.org/download/releases/2.3/mro/).
+    This class provides method overrides for all object wrappers used by the
+    agent. These methods allow attributes to be defined with the special prefix
+    _nr_ to be interpretted as attributes on the wrapper, rather than the
+    wrapped object. Inheriting from the base class wrapt.ObjectProxy preserves
+    method resolution order (MRO) through multiple inheritance.
+    (See https://www.python.org/download/releases/2.3/mro/).
     """
 
     def __setattr__(self, name, value):

--- a/newrelic/common/object_wrapper.py
+++ b/newrelic/common/object_wrapper.py
@@ -145,6 +145,11 @@ class ObjectWrapper(ObjectProxy, _FunctionWrapperBase):
 # Function for creating a decorator for applying to functions, as well as
 # short cut functions for applying wrapper functions via monkey patching.
 
+# WARNING: These functions are reproduced directly from wrapt, but using
+# our FunctionWrapper class which includes the _nr_ attriubte overrides
+# that are inherited from our subclass of wrapt.ObjectProxy.These MUST be 
+# kept in sync with wrapt when upgrading, or drift may introduce bugs.
+
 
 def function_wrapper(wrapper):
     def _wrapper(wrapped, instance, args, kwargs):

--- a/newrelic/packages/wrapt/__init__.py
+++ b/newrelic/packages/wrapt/__init__.py
@@ -1,11 +1,14 @@
-__version_info__ = ('1', '14', '1')
+__version_info__ = ('1', '16', '0')
 __version__ = '.'.join(__version_info__)
 
-from .wrappers import (ObjectProxy, CallableObjectProxy, FunctionWrapper,
-        BoundFunctionWrapper, WeakFunctionProxy, PartialCallableObjectProxy,
-        resolve_path, apply_patch, wrap_object, wrap_object_attribute,
+from .__wrapt__ import (ObjectProxy, CallableObjectProxy, FunctionWrapper,
+        BoundFunctionWrapper, PartialCallableObjectProxy)
+
+from .patches import (resolve_path, apply_patch, wrap_object, wrap_object_attribute,
         function_wrapper, wrap_function_wrapper, patch_function_wrapper,
         transient_function_wrapper)
+
+from .weakrefs import WeakFunctionProxy
 
 from .decorators import (adapter_factory, AdapterFactory, decorator,
         synchronized)

--- a/newrelic/packages/wrapt/__wrapt__.py
+++ b/newrelic/packages/wrapt/__wrapt__.py
@@ -1,0 +1,14 @@
+import os
+
+from .wrappers import (ObjectProxy, CallableObjectProxy,
+        PartialCallableObjectProxy, FunctionWrapper,
+        BoundFunctionWrapper, _FunctionWrapperBase)
+
+try:
+    if not os.environ.get('WRAPT_DISABLE_EXTENSIONS'):
+        from ._wrappers import (ObjectProxy, CallableObjectProxy,
+            PartialCallableObjectProxy, FunctionWrapper,
+            BoundFunctionWrapper, _FunctionWrapperBase)
+
+except ImportError:
+    pass

--- a/newrelic/packages/wrapt/_wrappers.c
+++ b/newrelic/packages/wrapt/_wrappers.c
@@ -1139,6 +1139,30 @@ static int WraptObjectProxy_setitem(WraptObjectProxyObject *self,
 
 /* ------------------------------------------------------------------------- */
 
+static PyObject *WraptObjectProxy_self_setattr(
+        WraptObjectProxyObject *self, PyObject *args)
+{
+    PyObject *name = NULL;
+    PyObject *value = NULL;
+
+#if PY_MAJOR_VERSION >= 3
+    if (!PyArg_ParseTuple(args, "UO:__self_setattr__", &name, &value))
+        return NULL;
+#else
+    if (!PyArg_ParseTuple(args, "SO:__self_setattr__", &name, &value))
+        return NULL;
+#endif
+
+    if (PyObject_GenericSetAttr((PyObject *)self, name, value) != 0) {
+        return NULL;
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+/* ------------------------------------------------------------------------- */
+
 static PyObject *WraptObjectProxy_dir(
         WraptObjectProxyObject *self, PyObject *args)
 {
@@ -1464,6 +1488,19 @@ static PyObject *WraptObjectProxy_get_class(
 
 /* ------------------------------------------------------------------------- */
 
+static int WraptObjectProxy_set_class(WraptObjectProxyObject *self,
+        PyObject *value)
+{
+    if (!self->wrapped) {
+      PyErr_SetString(PyExc_ValueError, "wrapper has not been initialized");
+      return -1;
+    }
+
+    return PyObject_SetAttrString(self->wrapped, "__class__", value);
+}
+
+/* ------------------------------------------------------------------------- */
+
 static PyObject *WraptObjectProxy_get_annotations(
         WraptObjectProxyObject *self)
 {
@@ -1534,6 +1571,9 @@ static PyObject *WraptObjectProxy_getattro(
 
     if (object)
         return object;
+
+    if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        return NULL;
 
     PyErr_Clear();
 
@@ -1738,6 +1778,8 @@ static PyMappingMethods WraptObjectProxy_as_mapping = {
 };
 
 static PyMethodDef WraptObjectProxy_methods[] = {
+    { "__self_setattr__", (PyCFunction)WraptObjectProxy_self_setattr,
+                    METH_VARARGS , 0 },
     { "__dir__",    (PyCFunction)WraptObjectProxy_dir, METH_NOARGS, 0 },
     { "__enter__",  (PyCFunction)WraptObjectProxy_enter,
                     METH_VARARGS | METH_KEYWORDS, 0 },
@@ -1776,7 +1818,7 @@ static PyGetSetDef WraptObjectProxy_getset[] = {
     { "__doc__",            (getter)WraptObjectProxy_get_doc,
                             (setter)WraptObjectProxy_set_doc, 0 },
     { "__class__",          (getter)WraptObjectProxy_get_class,
-                            NULL, 0 },
+                            (setter)WraptObjectProxy_set_class, 0 },
     { "__annotations__",    (getter)WraptObjectProxy_get_annotations,
                             (setter)WraptObjectProxy_set_annotations, 0 },
     { "__wrapped__",        (getter)WraptObjectProxy_get_wrapped,
@@ -2547,7 +2589,6 @@ static PyObject *WraptFunctionWrapperBase_set_name(
 static PyObject *WraptFunctionWrapperBase_instancecheck(
         WraptFunctionWrapperObject *self, PyObject *instance)
 {
-    PyObject *object = NULL;
     PyObject *result = NULL;
 
     int check = 0;

--- a/newrelic/packages/wrapt/decorators.py
+++ b/newrelic/packages/wrapt/decorators.py
@@ -41,7 +41,7 @@ try:
 except ImportError:
     pass
 
-from .wrappers import (FunctionWrapper, BoundFunctionWrapper, ObjectProxy,
+from .__wrapt__ import (FunctionWrapper, BoundFunctionWrapper, ObjectProxy,
     CallableObjectProxy)
 
 # Adapter wrapper for the wrapped function which will overlay certain

--- a/newrelic/packages/wrapt/patches.py
+++ b/newrelic/packages/wrapt/patches.py
@@ -1,0 +1,141 @@
+import inspect
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    string_types = basestring,
+else:
+    string_types = str,
+
+from .__wrapt__ import FunctionWrapper
+
+# Helper functions for applying wrappers to existing functions.
+
+def resolve_path(module, name):
+    if isinstance(module, string_types):
+        __import__(module)
+        module = sys.modules[module]
+
+    parent = module
+
+    path = name.split('.')
+    attribute = path[0]
+
+    # We can't just always use getattr() because in doing
+    # that on a class it will cause binding to occur which
+    # will complicate things later and cause some things not
+    # to work. For the case of a class we therefore access
+    # the __dict__ directly. To cope though with the wrong
+    # class being given to us, or a method being moved into
+    # a base class, we need to walk the class hierarchy to
+    # work out exactly which __dict__ the method was defined
+    # in, as accessing it from __dict__ will fail if it was
+    # not actually on the class given. Fallback to using
+    # getattr() if we can't find it. If it truly doesn't
+    # exist, then that will fail.
+
+    def lookup_attribute(parent, attribute):
+        if inspect.isclass(parent):
+            for cls in inspect.getmro(parent):
+                if attribute in vars(cls):
+                    return vars(cls)[attribute]
+            else:
+                return getattr(parent, attribute)
+        else:
+            return getattr(parent, attribute)
+
+    original = lookup_attribute(parent, attribute)
+
+    for attribute in path[1:]:
+        parent = original
+        original = lookup_attribute(parent, attribute)
+
+    return (parent, attribute, original)
+
+def apply_patch(parent, attribute, replacement):
+    setattr(parent, attribute, replacement)
+
+def wrap_object(module, name, factory, args=(), kwargs={}):
+    (parent, attribute, original) = resolve_path(module, name)
+    wrapper = factory(original, *args, **kwargs)
+    apply_patch(parent, attribute, wrapper)
+    return wrapper
+
+# Function for applying a proxy object to an attribute of a class
+# instance. The wrapper works by defining an attribute of the same name
+# on the class which is a descriptor and which intercepts access to the
+# instance attribute. Note that this cannot be used on attributes which
+# are themselves defined by a property object.
+
+class AttributeWrapper(object):
+
+    def __init__(self, attribute, factory, args, kwargs):
+        self.attribute = attribute
+        self.factory = factory
+        self.args = args
+        self.kwargs = kwargs
+
+    def __get__(self, instance, owner):
+        value = instance.__dict__[self.attribute]
+        return self.factory(value, *self.args, **self.kwargs)
+
+    def __set__(self, instance, value):
+        instance.__dict__[self.attribute] = value
+
+    def __delete__(self, instance):
+        del instance.__dict__[self.attribute]
+
+def wrap_object_attribute(module, name, factory, args=(), kwargs={}):
+    path, attribute = name.rsplit('.', 1)
+    parent = resolve_path(module, path)[2]
+    wrapper = AttributeWrapper(attribute, factory, args, kwargs)
+    apply_patch(parent, attribute, wrapper)
+    return wrapper
+
+# Functions for creating a simple decorator using a FunctionWrapper,
+# plus short cut functions for applying wrappers to functions. These are
+# for use when doing monkey patching. For a more featured way of
+# creating decorators see the decorator decorator instead.
+
+def function_wrapper(wrapper):
+    def _wrapper(wrapped, instance, args, kwargs):
+        target_wrapped = args[0]
+        if instance is None:
+            target_wrapper = wrapper
+        elif inspect.isclass(instance):
+            target_wrapper = wrapper.__get__(None, instance)
+        else:
+            target_wrapper = wrapper.__get__(instance, type(instance))
+        return FunctionWrapper(target_wrapped, target_wrapper)
+    return FunctionWrapper(wrapper, _wrapper)
+
+def wrap_function_wrapper(module, name, wrapper):
+    return wrap_object(module, name, FunctionWrapper, (wrapper,))
+
+def patch_function_wrapper(module, name, enabled=None):
+    def _wrapper(wrapper):
+        return wrap_object(module, name, FunctionWrapper, (wrapper, enabled))
+    return _wrapper
+
+def transient_function_wrapper(module, name):
+    def _decorator(wrapper):
+        def _wrapper(wrapped, instance, args, kwargs):
+            target_wrapped = args[0]
+            if instance is None:
+                target_wrapper = wrapper
+            elif inspect.isclass(instance):
+                target_wrapper = wrapper.__get__(None, instance)
+            else:
+                target_wrapper = wrapper.__get__(instance, type(instance))
+            def _execute(wrapped, instance, args, kwargs):
+                (parent, attribute, original) = resolve_path(module, name)
+                replacement = FunctionWrapper(original, target_wrapper)
+                setattr(parent, attribute, replacement)
+                try:
+                    return wrapped(*args, **kwargs)
+                finally:
+                    setattr(parent, attribute, original)
+            return FunctionWrapper(target_wrapped, _execute)
+        return FunctionWrapper(wrapper, _wrapper)
+    return _decorator

--- a/newrelic/packages/wrapt/weakrefs.py
+++ b/newrelic/packages/wrapt/weakrefs.py
@@ -1,0 +1,98 @@
+import functools
+import weakref
+
+from .__wrapt__ import ObjectProxy, _FunctionWrapperBase
+
+# A weak function proxy. This will work on instance methods, class
+# methods, static methods and regular functions. Special treatment is
+# needed for the method types because the bound method is effectively a
+# transient object and applying a weak reference to one will immediately
+# result in it being destroyed and the weakref callback called. The weak
+# reference is therefore applied to the instance the method is bound to
+# and the original function. The function is then rebound at the point
+# of a call via the weak function proxy.
+
+def _weak_function_proxy_callback(ref, proxy, callback):
+    if proxy._self_expired:
+        return
+
+    proxy._self_expired = True
+
+    # This could raise an exception. We let it propagate back and let
+    # the weakref.proxy() deal with it, at which point it generally
+    # prints out a short error message direct to stderr and keeps going.
+
+    if callback is not None:
+        callback(proxy)
+
+class WeakFunctionProxy(ObjectProxy):
+
+    __slots__ = ('_self_expired', '_self_instance')
+
+    def __init__(self, wrapped, callback=None):
+        # We need to determine if the wrapped function is actually a
+        # bound method. In the case of a bound method, we need to keep a
+        # reference to the original unbound function and the instance.
+        # This is necessary because if we hold a reference to the bound
+        # function, it will be the only reference and given it is a
+        # temporary object, it will almost immediately expire and
+        # the weakref callback triggered. So what is done is that we
+        # hold a reference to the instance and unbound function and
+        # when called bind the function to the instance once again and
+        # then call it. Note that we avoid using a nested function for
+        # the callback here so as not to cause any odd reference cycles.
+
+        _callback = callback and functools.partial(
+                _weak_function_proxy_callback, proxy=self,
+                callback=callback)
+
+        self._self_expired = False
+
+        if isinstance(wrapped, _FunctionWrapperBase):
+            self._self_instance = weakref.ref(wrapped._self_instance,
+                    _callback)
+
+            if wrapped._self_parent is not None:
+                super(WeakFunctionProxy, self).__init__(
+                        weakref.proxy(wrapped._self_parent, _callback))
+
+            else:
+                super(WeakFunctionProxy, self).__init__(
+                        weakref.proxy(wrapped, _callback))
+
+            return
+
+        try:
+            self._self_instance = weakref.ref(wrapped.__self__, _callback)
+
+            super(WeakFunctionProxy, self).__init__(
+                    weakref.proxy(wrapped.__func__, _callback))
+
+        except AttributeError:
+            self._self_instance = None
+
+            super(WeakFunctionProxy, self).__init__(
+                    weakref.proxy(wrapped, _callback))
+
+    def __call__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+
+        # We perform a boolean check here on the instance and wrapped
+        # function as that will trigger the reference error prior to
+        # calling if the reference had expired.
+
+        instance = self._self_instance and self._self_instance()
+        function = self.__wrapped__ and self.__wrapped__
+
+        # If the wrapped function was originally a bound function, for
+        # which we retained a reference to the instance and the unbound
+        # function we need to rebind the function and then call it. If
+        # not just called the wrapped function.
+
+        if instance is None:
+            return self.__wrapped__(*args, **kwargs)
+
+        return function.__get__(instance, type(instance))(*args, **kwargs)

--- a/newrelic/packages/wrapt/wrappers.py
+++ b/newrelic/packages/wrapt/wrappers.py
@@ -1,8 +1,5 @@
-import os
 import sys
-import functools
 import operator
-import weakref
 import inspect
 
 PY2 = sys.version_info[0] == 2
@@ -93,6 +90,9 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
             object.__setattr__(self, '__annotations__', wrapped.__annotations__)
         except AttributeError:
             pass
+
+    def __self_setattr__(self, name, value):
+        object.__setattr__(self, name, value)
 
     @property
     def __name__(self):
@@ -445,12 +445,22 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
 
 class CallableObjectProxy(ObjectProxy):
 
-    def __call__(self, *args, **kwargs):
+    def __call__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+
         return self.__wrapped__(*args, **kwargs)
 
 class PartialCallableObjectProxy(ObjectProxy):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+
         if len(args) < 1:
             raise TypeError('partial type takes at least one argument')
 
@@ -464,7 +474,12 @@ class PartialCallableObjectProxy(ObjectProxy):
         self._self_args = args
         self._self_kwargs = kwargs
 
-    def __call__(self, *args, **kwargs):
+    def __call__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+    
         _args = self._self_args + args
 
         _kwargs = dict(self._self_kwargs)
@@ -544,7 +559,12 @@ class _FunctionWrapperBase(ObjectProxy):
 
         return self
 
-    def __call__(self, *args, **kwargs):
+    def __call__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+
         # If enabled has been specified, then evaluate it at this point
         # and if the wrapper is not to be executed, then simply return
         # the bound function rather than a bound wrapper for the bound
@@ -607,7 +627,12 @@ class _FunctionWrapperBase(ObjectProxy):
 
 class BoundFunctionWrapper(_FunctionWrapperBase):
 
-    def __call__(self, *args, **kwargs):
+    def __call__(*args, **kwargs):
+        def _unpack_self(self, *args):
+            return self, args
+
+        self, args = _unpack_self(*args)
+
         # If enabled has been specified, then evaluate it at this point
         # and if the wrapper is not to be executed, then simply return
         # the bound function rather than a bound wrapper for the bound
@@ -757,230 +782,3 @@ class FunctionWrapper(_FunctionWrapperBase):
 
         super(FunctionWrapper, self).__init__(wrapped, None, wrapper,
                 enabled, binding)
-
-try:
-    if not os.environ.get('WRAPT_DISABLE_EXTENSIONS'):
-        from ._wrappers import (ObjectProxy, CallableObjectProxy,
-            PartialCallableObjectProxy, FunctionWrapper,
-            BoundFunctionWrapper, _FunctionWrapperBase)
-except ImportError:
-    pass
-
-# Helper functions for applying wrappers to existing functions.
-
-def resolve_path(module, name):
-    if isinstance(module, string_types):
-        __import__(module)
-        module = sys.modules[module]
-
-    parent = module
-
-    path = name.split('.')
-    attribute = path[0]
-
-    # We can't just always use getattr() because in doing
-    # that on a class it will cause binding to occur which
-    # will complicate things later and cause some things not
-    # to work. For the case of a class we therefore access
-    # the __dict__ directly. To cope though with the wrong
-    # class being given to us, or a method being moved into
-    # a base class, we need to walk the class hierarchy to
-    # work out exactly which __dict__ the method was defined
-    # in, as accessing it from __dict__ will fail if it was
-    # not actually on the class given. Fallback to using
-    # getattr() if we can't find it. If it truly doesn't
-    # exist, then that will fail.
-
-    def lookup_attribute(parent, attribute):
-        if inspect.isclass(parent):
-            for cls in inspect.getmro(parent):
-                if attribute in vars(cls):
-                    return vars(cls)[attribute]
-            else:
-                return getattr(parent, attribute)
-        else:
-            return getattr(parent, attribute)
-
-    original = lookup_attribute(parent, attribute)
-
-    for attribute in path[1:]:
-        parent = original
-        original = lookup_attribute(parent, attribute)
-
-    return (parent, attribute, original)
-
-def apply_patch(parent, attribute, replacement):
-    setattr(parent, attribute, replacement)
-
-def wrap_object(module, name, factory, args=(), kwargs={}):
-    (parent, attribute, original) = resolve_path(module, name)
-    wrapper = factory(original, *args, **kwargs)
-    apply_patch(parent, attribute, wrapper)
-    return wrapper
-
-# Function for applying a proxy object to an attribute of a class
-# instance. The wrapper works by defining an attribute of the same name
-# on the class which is a descriptor and which intercepts access to the
-# instance attribute. Note that this cannot be used on attributes which
-# are themselves defined by a property object.
-
-class AttributeWrapper(object):
-
-    def __init__(self, attribute, factory, args, kwargs):
-        self.attribute = attribute
-        self.factory = factory
-        self.args = args
-        self.kwargs = kwargs
-
-    def __get__(self, instance, owner):
-        value = instance.__dict__[self.attribute]
-        return self.factory(value, *self.args, **self.kwargs)
-
-    def __set__(self, instance, value):
-        instance.__dict__[self.attribute] = value
-
-    def __delete__(self, instance):
-        del instance.__dict__[self.attribute]
-
-def wrap_object_attribute(module, name, factory, args=(), kwargs={}):
-    path, attribute = name.rsplit('.', 1)
-    parent = resolve_path(module, path)[2]
-    wrapper = AttributeWrapper(attribute, factory, args, kwargs)
-    apply_patch(parent, attribute, wrapper)
-    return wrapper
-
-# Functions for creating a simple decorator using a FunctionWrapper,
-# plus short cut functions for applying wrappers to functions. These are
-# for use when doing monkey patching. For a more featured way of
-# creating decorators see the decorator decorator instead.
-
-def function_wrapper(wrapper):
-    def _wrapper(wrapped, instance, args, kwargs):
-        target_wrapped = args[0]
-        if instance is None:
-            target_wrapper = wrapper
-        elif inspect.isclass(instance):
-            target_wrapper = wrapper.__get__(None, instance)
-        else:
-            target_wrapper = wrapper.__get__(instance, type(instance))
-        return FunctionWrapper(target_wrapped, target_wrapper)
-    return FunctionWrapper(wrapper, _wrapper)
-
-def wrap_function_wrapper(module, name, wrapper):
-    return wrap_object(module, name, FunctionWrapper, (wrapper,))
-
-def patch_function_wrapper(module, name):
-    def _wrapper(wrapper):
-        return wrap_object(module, name, FunctionWrapper, (wrapper,))
-    return _wrapper
-
-def transient_function_wrapper(module, name):
-    def _decorator(wrapper):
-        def _wrapper(wrapped, instance, args, kwargs):
-            target_wrapped = args[0]
-            if instance is None:
-                target_wrapper = wrapper
-            elif inspect.isclass(instance):
-                target_wrapper = wrapper.__get__(None, instance)
-            else:
-                target_wrapper = wrapper.__get__(instance, type(instance))
-            def _execute(wrapped, instance, args, kwargs):
-                (parent, attribute, original) = resolve_path(module, name)
-                replacement = FunctionWrapper(original, target_wrapper)
-                setattr(parent, attribute, replacement)
-                try:
-                    return wrapped(*args, **kwargs)
-                finally:
-                    setattr(parent, attribute, original)
-            return FunctionWrapper(target_wrapped, _execute)
-        return FunctionWrapper(wrapper, _wrapper)
-    return _decorator
-
-# A weak function proxy. This will work on instance methods, class
-# methods, static methods and regular functions. Special treatment is
-# needed for the method types because the bound method is effectively a
-# transient object and applying a weak reference to one will immediately
-# result in it being destroyed and the weakref callback called. The weak
-# reference is therefore applied to the instance the method is bound to
-# and the original function. The function is then rebound at the point
-# of a call via the weak function proxy.
-
-def _weak_function_proxy_callback(ref, proxy, callback):
-    if proxy._self_expired:
-        return
-
-    proxy._self_expired = True
-
-    # This could raise an exception. We let it propagate back and let
-    # the weakref.proxy() deal with it, at which point it generally
-    # prints out a short error message direct to stderr and keeps going.
-
-    if callback is not None:
-        callback(proxy)
-
-class WeakFunctionProxy(ObjectProxy):
-
-    __slots__ = ('_self_expired', '_self_instance')
-
-    def __init__(self, wrapped, callback=None):
-        # We need to determine if the wrapped function is actually a
-        # bound method. In the case of a bound method, we need to keep a
-        # reference to the original unbound function and the instance.
-        # This is necessary because if we hold a reference to the bound
-        # function, it will be the only reference and given it is a
-        # temporary object, it will almost immediately expire and
-        # the weakref callback triggered. So what is done is that we
-        # hold a reference to the instance and unbound function and
-        # when called bind the function to the instance once again and
-        # then call it. Note that we avoid using a nested function for
-        # the callback here so as not to cause any odd reference cycles.
-
-        _callback = callback and functools.partial(
-                _weak_function_proxy_callback, proxy=self,
-                callback=callback)
-
-        self._self_expired = False
-
-        if isinstance(wrapped, _FunctionWrapperBase):
-            self._self_instance = weakref.ref(wrapped._self_instance,
-                    _callback)
-
-            if wrapped._self_parent is not None:
-                super(WeakFunctionProxy, self).__init__(
-                        weakref.proxy(wrapped._self_parent, _callback))
-
-            else:
-                super(WeakFunctionProxy, self).__init__(
-                        weakref.proxy(wrapped, _callback))
-
-            return
-
-        try:
-            self._self_instance = weakref.ref(wrapped.__self__, _callback)
-
-            super(WeakFunctionProxy, self).__init__(
-                    weakref.proxy(wrapped.__func__, _callback))
-
-        except AttributeError:
-            self._self_instance = None
-
-            super(WeakFunctionProxy, self).__init__(
-                    weakref.proxy(wrapped, _callback))
-
-    def __call__(self, *args, **kwargs):
-        # We perform a boolean check here on the instance and wrapped
-        # function as that will trigger the reference error prior to
-        # calling if the reference had expired.
-
-        instance = self._self_instance and self._self_instance()
-        function = self.__wrapped__ and self.__wrapped__
-
-        # If the wrapped function was originally a bound function, for
-        # which we retained a reference to the instance and the unbound
-        # function we need to rebind the function and then call it. If
-        # not just called the wrapped function.
-
-        if instance is None:
-            return self.__wrapped__(*args, **kwargs)
-
-        return function.__get__(instance, type(instance))(*args, **kwargs)

--- a/tests/agent_streaming/test_infinite_tracing.py
+++ b/tests/agent_streaming/test_infinite_tracing.py
@@ -389,12 +389,12 @@ def test_no_data_loss_on_reconnect(mock_grpc_server, app, buffer_empty_event, ba
         # Wait for OK status code to close the channel
         start_time = time.time()
         while not (request_iterator._stream and request_iterator._stream.done()):
-            assert time.time() - start_time < 5, "Timed out waiting for OK status code."
+            assert time.time() - start_time < 15, "Timed out waiting for OK status code."
             time.sleep(0.5)
 
         # Put new span and wait until buffer has been emptied and either sent or lost
         stream_buffer.put(span)
-        assert spans_processed_event.wait(timeout=5), "Data lost in stream buffer iterator."
+        assert spans_processed_event.wait(timeout=15), "Data lost in stream buffer iterator."
 
     _test()
 

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -22,6 +22,7 @@ def wrapper():
     @function_wrapper
     def _wrapper(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
+
     return _wrapper
 
 
@@ -54,7 +55,9 @@ def test_prefixed_attributes_share_namespace(wrapped_function):
     wrapped_function._nr_attr = 1
     wrapped_function._self_attr = 2
 
-    assert wrapped_function._nr_attr == 2, "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
+    assert (
+        wrapped_function._nr_attr == 2
+    ), "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
 
 
 def test_wrapped_function_attributes(wrapped_function):

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -26,17 +26,20 @@ def test_function_wrapper_attributes():
         return True
 
     exercise._nr_attr = 1
-    assert exercise._nr_attr == 1
+    assert exercise._nr_attr == 1, "_nr_ attributes should be stored on wrapper object and retrievable."
+
     exercise._self_attr = 2
-    assert exercise._self_attr == 2
-    assert exercise._nr_attr == 2
+    assert exercise._self_attr == 2, "_self_ attributes should be stored on wrapper object and retrievable."
+
+    assert exercise._nr_attr == 2, "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
+
     exercise._other_attr = 3
-    assert exercise._other_attr == 3
+    assert exercise._other_attr == 3, "All other attributes should be stored on wrapped object and retrievable."
 
     vars_ = vars(exercise)
-    assert "_nr_attr" not in vars_
-    assert "_self_attr" not in vars_
-    assert "_other_attr" in vars_
+    assert "_nr_attr" not in vars_, "_nr_ attributes should NOT appear in __dict__."
+    assert "_self_attr" not in vars_, "_self_ attributes should NOT appear in __dict__."
+    assert "_other_attr" in vars_, "Other types of attributes SHOULD appear in __dict__."
 
     assert exercise()
 

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -17,7 +17,7 @@ import pytest
 from newrelic.common.object_wrapper import function_wrapper
 
 
-@pytest.fixutre(scope="function")
+@pytest.fixture(scope="function")
 def wrapper():
     @function_wrapper
     def _wrapper(wrapped, instance, args, kwargs):
@@ -26,7 +26,7 @@ def wrapper():
     return _wrapper
 
 
-@pytest.fixutre(scope="function")
+@pytest.fixture(scope="function")
 def wrapped_function(wrapper):
     @wrapper
     def wrapped():

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -20,34 +20,61 @@ def wrapper(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 
 
-def test_function_wrapper_attributes():
+def test_nr_prefix_attributes():
     @wrapper
     def exercise():
         return True
 
     exercise._nr_attr = 1
-    assert exercise._nr_attr == 1, "_nr_ attributes should be stored on wrapper object and retrievable."
+    vars_ = vars(exercise)
 
+    assert exercise._nr_attr == 1, "_nr_ attributes should be stored on wrapper object and retrievable."
+    assert "_nr_attr" not in vars_, "_nr_ attributes should NOT appear in __dict__."
+
+
+def test_self_prefix_attributes():
+    @wrapper
+    def exercise():
+        return True
+
+    exercise._self_attr = 1
+    vars_ = vars(exercise)
+
+    assert exercise._self_attr == 1, "_self_ attributes should be stored on wrapper object and retrievable."
+    assert "_nr_attr" not in vars_, "_self_ attributes should NOT appear in __dict__."
+
+
+def test_prefixed_attributes_share_namespace():
+    @wrapper
+    def exercise():
+        return True
+
+    exercise._nr_attr = 1
     exercise._self_attr = 2
-    assert exercise._self_attr == 2, "_self_ attributes should be stored on wrapper object and retrievable."
 
     assert exercise._nr_attr == 2, "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
 
-    exercise._other_attr = 3
-    assert exercise._other_attr == 3, "All other attributes should be stored on wrapped object and retrievable."
 
+def test_wrapped_function_attributes():
+    @wrapper
+    def exercise():
+        return True
+
+    exercise._other_attr = 1
     vars_ = vars(exercise)
-    assert "_nr_attr" not in vars_, "_nr_ attributes should NOT appear in __dict__."
-    assert "_self_attr" not in vars_, "_self_ attributes should NOT appear in __dict__."
+
+    assert exercise._other_attr == 1, "All other attributes should be stored on wrapped object and retrievable."
     assert "_other_attr" in vars_, "Other types of attributes SHOULD appear in __dict__."
 
     assert exercise()
 
 
 def test_multiple_wrapper_last_object():
-    def exercise():
+    def wrapped():
         pass
 
-    wrapped = wrapper(wrapper(exercise))
+    wrapper_1 = wrapper(wrapped)
+    wrapper_2 = wrapper(wrapper_1)
 
-    assert wrapped._nr_last_object is exercise
+    assert wrapper_2._nr_last_object is wrapped, "Last object in chain should be the wrapped function."
+    assert wrapper_2._nr_next_object is wrapper_1, "Next object in chain should be the middle function."

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -12,64 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from newrelic.common.object_wrapper import function_wrapper
 
 
-@function_wrapper
-def wrapper(wrapped, instance, args, kwargs):
-    return wrapped(*args, **kwargs)
+@pytest.fixutre(scope="function")
+def wrapper():
+    @function_wrapper
+    def _wrapper(wrapped, instance, args, kwargs):
+        return wrapped(*args, **kwargs)
+    return _wrapper
 
 
-def test_nr_prefix_attributes():
+@pytest.fixutre(scope="function")
+def wrapped_function(wrapper):
     @wrapper
-    def exercise():
+    def wrapped():
         return True
 
-    exercise._nr_attr = 1
-    vars_ = vars(exercise)
+    return wrapped
 
-    assert exercise._nr_attr == 1, "_nr_ attributes should be stored on wrapper object and retrievable."
+
+def test_nr_prefix_attributes(wrapped_function):
+    wrapped_function._nr_attr = 1
+    vars_ = vars(wrapped_function)
+
+    assert wrapped_function._nr_attr == 1, "_nr_ attributes should be stored on wrapper object and retrievable."
     assert "_nr_attr" not in vars_, "_nr_ attributes should NOT appear in __dict__."
 
 
-def test_self_prefix_attributes():
-    @wrapper
-    def exercise():
-        return True
+def test_self_prefix_attributes(wrapped_function):
+    wrapped_function._self_attr = 1
+    vars_ = vars(wrapped_function)
 
-    exercise._self_attr = 1
-    vars_ = vars(exercise)
-
-    assert exercise._self_attr == 1, "_self_ attributes should be stored on wrapper object and retrievable."
+    assert wrapped_function._self_attr == 1, "_self_ attributes should be stored on wrapper object and retrievable."
     assert "_nr_attr" not in vars_, "_self_ attributes should NOT appear in __dict__."
 
 
-def test_prefixed_attributes_share_namespace():
-    @wrapper
-    def exercise():
-        return True
+def test_prefixed_attributes_share_namespace(wrapped_function):
+    wrapped_function._nr_attr = 1
+    wrapped_function._self_attr = 2
 
-    exercise._nr_attr = 1
-    exercise._self_attr = 2
-
-    assert exercise._nr_attr == 2, "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
+    assert wrapped_function._nr_attr == 2, "_nr_ attributes share a namespace with _self_ attributes and should be overwritten."
 
 
-def test_wrapped_function_attributes():
-    @wrapper
-    def exercise():
-        return True
+def test_wrapped_function_attributes(wrapped_function):
+    wrapped_function._other_attr = 1
+    vars_ = vars(wrapped_function)
 
-    exercise._other_attr = 1
-    vars_ = vars(exercise)
-
-    assert exercise._other_attr == 1, "All other attributes should be stored on wrapped object and retrievable."
+    assert wrapped_function._other_attr == 1, "All other attributes should be stored on wrapped object and retrievable."
     assert "_other_attr" in vars_, "Other types of attributes SHOULD appear in __dict__."
 
-    assert exercise()
+    assert wrapped_function()
 
 
-def test_multiple_wrapper_last_object():
+def test_multiple_wrapper_last_object(wrapper):
     def wrapped():
         pass
 

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -19,6 +19,7 @@ from newrelic.common.object_wrapper import function_wrapper
 def wrapper(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 
+
 def test_function_wrapper_attributes():
     @wrapper
     def exercise():

--- a/tests/agent_unittests/test_wrappers.py
+++ b/tests/agent_unittests/test_wrappers.py
@@ -1,0 +1,49 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from newrelic.common.object_wrapper import function_wrapper
+
+
+@function_wrapper
+def wrapper(wrapped, instance, args, kwargs):
+    return wrapped(*args, **kwargs)
+
+def test_function_wrapper_attributes():
+    @wrapper
+    def exercise():
+        return True
+
+    exercise._nr_attr = 1
+    assert exercise._nr_attr == 1
+    exercise._self_attr = 2
+    assert exercise._self_attr == 2
+    assert exercise._nr_attr == 2
+    exercise._other_attr = 3
+    assert exercise._other_attr == 3
+
+    vars_ = vars(exercise)
+    assert "_nr_attr" not in vars_
+    assert "_self_attr" not in vars_
+    assert "_other_attr" in vars_
+
+    assert exercise()
+
+
+def test_multiple_wrapper_last_object():
+    def exercise():
+        pass
+
+    wrapped = wrapper(wrapper(exercise))
+
+    assert wrapped._nr_last_object is exercise


### PR DESCRIPTION
# Overview

* Update `wrapt` to v1.16.0
* Add tests for wrapt function wrapper attributes
* Update older duplicate object wrapper functions to use functions imported from wrapt.
* Update inheritance tree of `newrelic.common.object_wrapper.ObjectWrapper` to fix issues with newer versions of wrapt.