### PR TITLE
Fix Kafka/Confluent Kafka header bug

### DIFF
--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -65,10 +65,12 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         destination_type="Topic",
         destination_name=topic or "Default",
         source=wrapped,
-    ) as trace:
-        dt_headers = {k: v.encode("utf-8") for k, v in trace.generate_request_headers(transaction)}
+    ):
+        dt_headers = {k: v.encode("utf-8") for k, v in MessageTrace.generate_request_headers(transaction)}
         # headers can be a list of tuples or a dict so convert to dict for consistency.
-        dt_headers.update(dict(headers) if headers else {})
+        if headers:
+            dt_headers.update(dict(headers))
+
         try:
             return wrapped(topic, headers=dt_headers, *args, **kwargs)
         except Exception as error:

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -25,6 +25,7 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
+from newrelic.api.function_trace import FunctionTrace
 from newrelic.common.object_names import callable_name
 from newrelic.packages import six
 
@@ -66,6 +67,25 @@ def test_distributed_tracing_headers(topic, send_producer_message):
     @validate_messagebroker_headers
     def test():
         send_producer_message()
+
+    test()
+
+
+def test_distributed_tracing_headers_under_terminal(topic, send_producer_message):
+    @validate_transaction_metrics(
+        "test_distributed_tracing_headers_under_terminal",
+        rollup_metrics=[
+            ("Supportability/TraceContext/Create/Success", 1),
+            ("Supportability/DistributedTrace/CreatePayload/Success", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_distributed_tracing_headers_under_terminal")
+    @cache_kafka_producer_headers
+    @validate_messagebroker_headers
+    def test():
+        with FunctionTrace(name="terminal_trace", terminal=True):
+            send_producer_message()
 
     test()
 


### PR DESCRIPTION
Only add headers if headers exist in MessageTrace

A fix for https://github.com/newrelic/newrelic-python-agent/issues/743