### PR TITLE
Update flaskrestx testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,10 +45,91 @@ setupdir = {toxinidir}
 ; Fail tests when interpreters are missing.
 skip_missing_interpreters = false
 envlist =
-    elasticsearchserver07-datastore_elasticsearch-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy38}-elasticsearch07,
-    elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,pypy38}-elasticsearch08,
-    firestore-datastore_firestore-{py37,py38,py39,py310,py311,py312},
-    grpc-framework_grpc-{py37,py38,py39,py310,py311,py312}-grpclatest,
+    python-adapter_cheroot-{py27,py37,py38,py39,py310,py311},
+    python-adapter_daphne-{py37,py38,py39,py310,py311}-daphnelatest,
+    python-adapter_gevent-{py27,py37,py38,py310,py311},
+    python-adapter_gunicorn-{py37,py38,py39,py310,py311}-aiohttp3-gunicornlatest,
+    python-adapter_hypercorn-{py38,py39,py310,py311}-hypercornlatest,
+    python-adapter_hypercorn-py38-hypercorn{0010,0011,0012,0013},
+    python-adapter_uvicorn-{py37,py38,py39,py310,py311}-uvicorn{014,latest},
+    python-adapter_waitress-{py37,py38,py39,py310}-waitress02,
+    python-adapter_waitress-{py37,py38,py39,py310,py311}-waitresslatest,
+    python-agent_features-{py27,py37,py38,py39,py310,py311}-{with,without}_extensions,
+    python-agent_features-{pypy27,pypy38}-without_extensions,
+    python-agent_streaming-py27-grpc0125-{with,without}_extensions,
+    python-agent_streaming-{py37,py38,py39,py310,py311}-protobuf04-{with,without}_extensions,
+    python-agent_streaming-py39-protobuf{03,0319}-{with,without}_extensions,
+    python-agent_unittests-{py27,py37,py38,py39,py310,py311}-{with,without}_extensions,
+    python-agent_unittests-{pypy27,pypy38}-without_extensions,
+    python-application_celery-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    gearman-application_gearman-{py27,pypy27},
+    python-mlmodel_sklearn-{py38,py39,py310,py311}-scikitlearnlatest,
+    python-mlmodel_sklearn-{py37}-scikitlearn0101,
+    python-component_djangorestframework-py27-djangorestframework0300,
+    python-component_djangorestframework-{py37,py38,py39,py310,py311}-djangorestframeworklatest,
+    python-component_flask_rest-py37-flaskrestx110,
+    python-component_flask_rest-{py38,py39,pypy38}-flaskrestxlatest,
+    python-component_flask_rest-{py27,pypy27}-flaskrestx051,
+    python-component_graphqlserver-{py37,py38,py39,py310,py311},
+    python-component_tastypie-{py27,pypy27}-tastypie0143,
+    python-component_tastypie-{py37,py38,py39,pypy38}-tastypie{0143,latest},
+    python-coroutines_asyncio-{py37,py38,py39,py310,py311,pypy38},
+    python-cross_agent-{py27,py37,py38,py39,py310,py311}-{with,without}_extensions,
+    python-cross_agent-pypy27-without_extensions,
+    postgres-datastore_asyncpg-{py37,py38,py39,py310,py311},
+    memcached-datastore_bmemcached-{pypy27,py27,py37,py38,py39,py310,py311}-memcached030,
+    elasticsearchserver07-datastore_elasticsearch-{py27,py37,py38,py39,py310,py311,pypy27,pypy38}-elasticsearch07,
+    elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,pypy38}-elasticsearch08,
+    memcached-datastore_memcache-{py27,py37,py38,py39,py310,py311,pypy27,pypy38}-memcached01,
+    mysql-datastore_mysql-mysql080023-py27,
+    mysql-datastore_mysql-mysqllatest-{py37,py38,py39,py310,py311},
+    firestore-datastore_firestore-{py37,py38,py39,py310,py311},
+    postgres-datastore_postgresql-{py37,py38,py39},
+    postgres-datastore_psycopg2-{py27,py37,py38,py39,py310,py311}-psycopg2latest
+    postgres-datastore_psycopg2cffi-{py27,pypy27,py37,py38,py39,py310,py311}-psycopg2cffilatest,
+    postgres-datastore_pyodbc-{py27,py37,py311}-pyodbclatest
+    memcached-datastore_pylibmc-{py27,py37},
+    memcached-datastore_pymemcache-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    mongodb-datastore_pymongo-{py27,py37,py38,py39,py310,py311,pypy27}-pymongo{03},
+    mongodb-datastore_pymongo-{py37,py38,py39,py310,py311,pypy27,pypy38}-pymongo04,
+    mssql-datastore_pymssql-{py37,py38,py39,py310,py311},
+    mysql-datastore_pymysql-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    solr-datastore_pysolr-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    redis-datastore_redis-{py37,py38,py39,py310,py311,pypy38}-redis{0400,latest},
+    rediscluster-datastore_rediscluster-{py37,py311,pypy38}-redis{latest},
+    python-datastore_sqlite-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    python-external_botocore-{py37,py38,py39,py310,py311}-botocorelatest,
+    python-external_botocore-{py311}-botocore128,
+    python-external_botocore-py310-botocore0125,
+    python-external_feedparser-py27-feedparser{05,06},
+    python-external_http-{py27,py37,py38,py39,py310,py311,pypy27},
+    python-external_httplib-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    python-external_httplib2-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    python-external_httpx-{py37,py38,py39,py310,py311},
+    python-external_requests-{py27,py37,py38,py39,py310,py311,pypy27,pypy38},
+    python-external_urllib3-{py27,py37,pypy27}-urllib3{0109},
+    python-external_urllib3-{py27,py37,py38,py39,py310,py311,pypy27,pypy38}-urllib3latest,
+    python-framework_aiohttp-{py37,py38,py39,py310,py311,pypy38}-aiohttp03,
+    python-framework_ariadne-{py37,py38,py39,py310,py311}-ariadnelatest,
+    python-framework_ariadne-py37-ariadne{0011,0012,0013},
+    python-framework_bottle-{py27,py37,py38,py39,py310,py311,pypy27,pypy38}-bottle0012,
+    ; CherryPy still uses inspect.getargspec, deprecated in favor of inspect.getfullargspec.  Not supported in 3.11
+    python-framework_cherrypy-{py37,py38,py39,py310,py311,pypy38}-CherryPylatest,
+    python-framework_django-{pypy27,py27}-Django0103,
+    python-framework_django-{pypy27,py27,py37}-Django0108,
+    python-framework_django-{py39}-Django{0200,0201,0202,0300,0301,latest},
+    python-framework_django-{py37,py38,py39,py310,py311}-Django0302,
+    python-framework_falcon-{py27,py37,py38,py39,pypy27,pypy38}-falcon0103,
+    python-framework_falcon-{py37,py38,py39,py310,pypy38}-falcon{0200,master},
+    # Falcon master branch failing on 3.11 currently.
+    python-framework_falcon-py311-falcon0200,
+    python-framework_fastapi-{py37,py38,py39,py310,py311},
+    ; temporarily disabling flaskmaster tests
+    python-framework_flask-{py37,py38,py39,py310,py311,pypy38}-flasklatest,
+    python-framework_graphene-{py37,py38,py39,py310,py311}-graphenelatest,
+    python-framework_graphql-{py37,py38,py39,py310,py311,pypy38}-graphqllatest,
+    ; temporarily disabling graphqlmaster tests
+    python-framework_graphql-py37-graphql{0300,0301,0302},
     grpc-framework_grpc-py27-grpc0125,
     kafka-messagebroker_confluentkafka-{py27,py39}-confluentkafka{0107,0106},
     kafka-messagebroker_confluentkafka-{py37,py38,py39,py310,py311,py312}-confluentkafkalatest,
@@ -91,8 +172,9 @@ envlist =
     python-agent_unittests-{pypy27,pypy38}-without_extensions,
     python-application_celery-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy38},
     python-component_djangorestframework-{py37,py38,py39,py310,py311,py312}-djangorestframeworklatest,
+    python-component_flask_rest-py37-flaskrestx110,
+    python-component_flask_rest-{py38,py39,py310,py311,py312,pypy38}-flaskrestxlatest,
     python-component_flask_rest-{py27,pypy27}-flaskrestx051,
-    python-component_flask_rest-{py37,py38,py39,pypy38}-flaskrestxlatest,
     python-component_graphqlserver-{py37,py38,py39,py310,py311,py312},
     python-component_tastypie-{py37,py38,py39,py310,py311,py312,pypy38}-tastypielatest,
     python-coroutines_asyncio-{py37,py38,py39,py310,py311,py312,pypy38},
@@ -203,8 +285,11 @@ deps =
     component_flask_rest: jinja2
     component_flask_rest: itsdangerous
     component_flask_rest-flaskrestxlatest: flask-restx
-    ; Pin Flask version until flask-restx is updated to support v3
-    component_flask_rest-flaskrestxlatest: flask<3.0
+    component_flask_rest-flaskrestxlatest: Flask
+    ; flask-restx only supports Flask v3 after flask-restx v1.3.0
+    component_flask_rest-flaskrestx110: Flask<3.0
+    component_flask_rest-flaskrestx110: flask-restx<1.2
+    component_flask_rest-flaskrestx051: Flask<3.0
     component_flask_rest-flaskrestx051: flask-restx<1.0
     component_graphqlserver: graphql-server[sanic,flask]==3.0.0b5
     component_graphqlserver: sanic>20


### PR DESCRIPTION
Update flask-restx test suite to 

- include Python 3.10, 3.11, and 3.12
- pin flaskrestx version 1.1.0 for Python 3.7 (New Relic supports this until 6/27/2024)
- no longer pin Flask 2.0 for tests running with latest version of flask-restx