### PR TITLE
Remove memcached testing for Python 2.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ envlist =
     kafka-messagebroker_kafkapython-{py27,py38}-kafkapython{020001,020000},
     kafka-messagebroker_kafkapython-{pypy27,py27,py37,py38,pypy38}-kafkapythonlatest,
     memcached-datastore_bmemcached-{pypy27,py27,py37,py38,py39,py310,py311,py312}-memcached030,
-    memcached-datastore_memcache-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy38}-memcached01,
+    memcached-datastore_memcache-{py37,py38,py39,py310,py311,py312,pypy38}-memcached01,
     memcached-datastore_pylibmc-{py27,py37},
     memcached-datastore_pymemcache-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy38},
     mongodb-datastore_pymongo-{py27,py37,py38,py39,py310,py311,py312,pypy27}-pymongo03,


### PR DESCRIPTION
# Overview
This PR removes Python 2.7 from the memcached testing suite.  Memcached [v1.59](https://github.com/linsomniac/python-memcached/releases/tag/1.59) is the last version to support 2.7 and it is outside of New Relic's support window.
