### PR TITLE
Temporarily pin hypercorn version in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -174,6 +174,7 @@ deps =
     adapter_gunicorn-aiohttp03-py312: aiohttp==3.9.0rc0
     adapter_gunicorn-gunicorn19: gunicorn<20
     adapter_gunicorn-gunicornlatest: gunicorn
+    ; Temporarily pinned.  Needs to be addressed
     adapter_hypercorn-hypercornlatest: hypercorn<0.16
     adapter_hypercorn-hypercorn0013: hypercorn<0.14
     adapter_hypercorn-hypercorn0012: hypercorn<0.13

--- a/tox.ini
+++ b/tox.ini
@@ -174,7 +174,7 @@ deps =
     adapter_gunicorn-aiohttp03-py312: aiohttp==3.9.0rc0
     adapter_gunicorn-gunicorn19: gunicorn<20
     adapter_gunicorn-gunicornlatest: gunicorn
-    adapter_hypercorn-hypercornlatest: hypercorn<0.15
+    adapter_hypercorn-hypercornlatest: hypercorn<0.16
     adapter_hypercorn-hypercorn0013: hypercorn<0.14
     adapter_hypercorn-hypercorn0012: hypercorn<0.13
     adapter_hypercorn-hypercorn0011: hypercorn<0.12

--- a/tox.ini
+++ b/tox.ini
@@ -174,7 +174,7 @@ deps =
     adapter_gunicorn-aiohttp03-py312: aiohttp==3.9.0rc0
     adapter_gunicorn-gunicorn19: gunicorn<20
     adapter_gunicorn-gunicornlatest: gunicorn
-    adapter_hypercorn-hypercornlatest: hypercorn
+    adapter_hypercorn-hypercornlatest: hypercorn<0.15
     adapter_hypercorn-hypercorn0013: hypercorn<0.14
     adapter_hypercorn-hypercorn0012: hypercorn<0.13
     adapter_hypercorn-hypercorn0011: hypercorn<0.12


### PR DESCRIPTION
# Overview
Temporarily pin hypercorn testing suite from latest to <0.16