### PR TITLE
Add 3.12 wheels to build

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -57,7 +57,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.1
         env:
           CIBW_PLATFORM: linux
-          CIBW_BUILD: cp37-manylinux* cp38-manylinux* cp39-manylinux* cp310-manylinux* cp311-manylinux*
+          CIBW_BUILD: cp37-manylinux* cp38-manylinux* cp39-manylinux* cp310-manylinux* cp311-manylinux* cp312-manylinux*
           CIBW_ARCHS: x86_64 aarch64
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib"
 


### PR DESCRIPTION
# Overview
This PR fixes up some issues with supporting 3.12.
* Add 3.12 into the list of wheel build envs.
