### PR TITLE
Remove Slack section in CONTRIBUTING.rst.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -228,14 +228,3 @@ entering the directory of the tests you want to run. Then, run the
 following command:
 
 ``tox -c tox.ini -e [test environment]``
-
-*******
- Slack
-*******
-
-We host a public Slack with a dedicated channel for contributors and
-maintainers of open source projects hosted by New Relic. If you are
-contributing to this project, you're welcome to request access to the
-#oss-contributors channel in the newrelicusers.slack.com workspace. To
-request access, please use this `link
-<https://join.slack.com/t/newrelicusers/shared_invite/zt-1ayj69rzm-~go~Eo1whIQGYnu3qi15ng/>`__.


### PR DESCRIPTION
This PR removes the Slack workspace details present in the `CONTRIBUTING.rst` as the workspace is no longer active.  

Fixes #968 
