### PR TITLE
Update botocore tests.

### DIFF
--- a/tests/external_botocore/test_boto3_iam.py
+++ b/tests/external_botocore/test_boto3_iam.py
@@ -16,7 +16,7 @@ import sys
 import uuid
 
 import boto3
-import moto
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -68,7 +68,7 @@ _iam_rollup_metrics = [
     background_task=True,
 )
 @background_task()
-@moto.mock_iam
+@mock_aws
 def test_iam():
     iam = boto3.client(
         "iam",

--- a/tests/external_botocore/test_boto3_s3.py
+++ b/tests/external_botocore/test_boto3_s3.py
@@ -17,7 +17,7 @@ import uuid
 
 import boto3
 import botocore
-import moto
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -87,7 +87,7 @@ _s3_rollup_metrics = [
     "test_boto3_s3:test_s3", scoped_metrics=_s3_scoped_metrics, rollup_metrics=_s3_rollup_metrics, background_task=True
 )
 @background_task()
-@moto.mock_s3
+@mock_aws
 def test_s3():
     client = boto3.client(
         "s3",

--- a/tests/external_botocore/test_boto3_sns.py
+++ b/tests/external_botocore/test_boto3_sns.py
@@ -15,8 +15,8 @@
 import sys
 
 import boto3
-import moto
 import pytest
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -59,7 +59,7 @@ sns_metrics_phone = [("MessageBroker/SNS/Topic" "/Produce/Named/PhoneNumber", 1)
     background_task=True,
 )
 @background_task()
-@moto.mock_sns
+@mock_aws
 def test_publish_to_sns_topic(topic_argument):
     conn = boto3.client(
         "sns",
@@ -88,7 +88,7 @@ def test_publish_to_sns_topic(topic_argument):
     background_task=True,
 )
 @background_task()
-@moto.mock_sns
+@mock_aws
 def test_publish_to_sns_phone():
     conn = boto3.client(
         "sns",

--- a/tests/external_botocore/test_botocore_dynamodb.py
+++ b/tests/external_botocore/test_botocore_dynamodb.py
@@ -16,7 +16,7 @@ import sys
 import uuid
 
 import botocore.session
-import moto
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -81,7 +81,7 @@ _dynamodb_rollup_metrics = [
     background_task=True,
 )
 @background_task()
-@moto.mock_dynamodb
+@mock_aws
 def test_dynamodb():
     session = botocore.session.get_session()
     client = session.create_client(

--- a/tests/external_botocore/test_botocore_ec2.py
+++ b/tests/external_botocore/test_botocore_ec2.py
@@ -16,7 +16,7 @@ import sys
 import uuid
 
 import botocore.session
-import moto
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -69,7 +69,7 @@ _ec2_rollup_metrics = [
     background_task=True,
 )
 @background_task()
-@moto.mock_ec2
+@mock_aws
 def test_ec2():
     session = botocore.session.get_session()
     client = session.create_client(

--- a/tests/external_botocore/test_botocore_s3.py
+++ b/tests/external_botocore/test_botocore_s3.py
@@ -17,7 +17,7 @@ import uuid
 
 import botocore
 import botocore.session
-import moto
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -84,7 +84,7 @@ _s3_rollup_metrics = [
     background_task=True,
 )
 @background_task()
-@moto.mock_s3
+@mock_aws
 def test_s3():
     session = botocore.session.get_session()
     client = session.create_client(

--- a/tests/external_botocore/test_botocore_sqs.py
+++ b/tests/external_botocore/test_botocore_sqs.py
@@ -16,8 +16,8 @@ import sys
 import uuid
 
 import botocore.session
-import moto
 import pytest
+from moto import mock_aws
 from testing_support.fixtures import dt_enabled
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import (
@@ -85,7 +85,7 @@ _sqs_rollup_metrics_malformed = [
     background_task=True,
 )
 @background_task()
-@moto.mock_sqs
+@mock_aws
 def test_sqs():
     session = botocore.session.get_session()
     client = session.create_client(
@@ -133,7 +133,7 @@ def test_sqs():
     background_task=True,
 )
 @background_task()
-@moto.mock_sqs
+@mock_aws
 def test_sqs_malformed():
     session = botocore.session.get_session()
     client = session.create_client(

--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ envlist =
     python-cross_agent-pypy27-without_extensions,
     python-datastore_sqlite-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy38},
     python-external_botocore-py311-botocore128,
-    python-external_botocore-{py37,py38,py39,py310,py311,py312}-botocorelatest,
+    python-external_botocore-{py38,py39,py310,py311,py312}-botocorelatest,
     python-external_botocore-py310-botocore0125,
     python-external_feedparser-py27-feedparser{05,06},
     python-external_http-{py27,py37,py38,py39,py310,py311,py312,pypy27},
@@ -250,7 +250,7 @@ deps =
     external_botocore-botocorelatest: boto3
     external_botocore-botocore128: botocore<1.29
     external_botocore-botocore0125: botocore<1.26
-    external_botocore-{py37,py38,py39,py310,py311,py312}: moto
+    external_botocore-{py38,py39,py310,py311,py312}: moto
     external_feedparser-feedparser05: feedparser<6
     external_feedparser-feedparser06: feedparser<7
     external_httplib2: httplib2<1.0

--- a/tox.ini
+++ b/tox.ini
@@ -250,9 +250,7 @@ deps =
     external_botocore-botocorelatest: boto3
     external_botocore-botocore128: botocore<1.29
     external_botocore-botocore0125: botocore<1.26
-    external_botocore-{py37,py38,py39,py310,py311,py312}: moto[awslambda,ec2,iam,sqs]
-    external_botocore-py27: rsa<4.7.1
-    external_botocore-py27: moto[awslambda,ec2,iam,sqs]<2.0
+    external_botocore-{py37,py38,py39,py310,py311,py312}: moto
     external_feedparser-feedparser05: feedparser<6
     external_feedparser-feedparser06: feedparser<7
     external_httplib2: httplib2<1.0


### PR DESCRIPTION
This PR updates the `moto` decorators used in `botocore` tests and removes py27 dependencies listed in `tox.ini`. It also drops testing for Python 3.7 since `botocore` no longer supports this version.