### PR TITLE
Remove imports for moto on py37.

### DIFF
--- a/tests/external_botocore/test_boto3_iam.py
+++ b/tests/external_botocore/test_boto3_iam.py
@@ -31,12 +31,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 MOTO_VERSION = get_package_version_tuple("moto")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec (This is fine for testing purposes)
 

--- a/tests/external_botocore/test_boto3_s3.py
+++ b/tests/external_botocore/test_boto3_s3.py
@@ -29,12 +29,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 MOTO_VERSION = get_package_version_tuple("moto")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec
 AWS_REGION_NAME = "us-west-2"

--- a/tests/external_botocore/test_boto3_sns.py
+++ b/tests/external_botocore/test_boto3_sns.py
@@ -31,12 +31,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 MOTO_VERSION = get_package_version_tuple("moto")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec (This is fine for testing purposes)
 AWS_REGION_NAME = "us-east-1"

--- a/tests/external_botocore/test_botocore_dynamodb.py
+++ b/tests/external_botocore/test_botocore_dynamodb.py
@@ -31,13 +31,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 MOTO_VERSION = get_package_version_tuple("moto")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec (This is fine for testing purposes)
 AWS_REGION = "us-east-1"

--- a/tests/external_botocore/test_botocore_ec2.py
+++ b/tests/external_botocore/test_botocore_ec2.py
@@ -31,12 +31,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 MOTO_VERSION = get_package_version_tuple("moto")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec (This is fine for testing purposes)
 AWS_REGION = "us-east-1"

--- a/tests/external_botocore/test_botocore_s3.py
+++ b/tests/external_botocore/test_botocore_s3.py
@@ -30,13 +30,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 MOTO_VERSION = MOTO_VERSION = get_package_version_tuple("moto")
 BOTOCORE_VERSION = get_package_version_tuple("botocore")
 
-
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
 AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec
 AWS_REGION = "us-east-1"

--- a/tests/external_botocore/test_botocore_sqs.py
+++ b/tests/external_botocore/test_botocore_sqs.py
@@ -30,12 +30,6 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 MOTO_VERSION = get_package_version_tuple("moto")
 BOTOCORE_VERSION = get_package_version_tuple("botocore")
 
-# patch earlier versions of moto to support py37
-if sys.version_info >= (3, 7) and MOTO_VERSION <= (1, 3, 1):
-    import re
-
-    moto.packages.responses.responses.re._pattern_type = re.Pattern
-
 url = "sqs.us-east-1.amazonaws.com"
 
 if BOTOCORE_VERSION < (1, 29, 0):


### PR DESCRIPTION
This PR removes moto imports for Python 3.7 since support for this version has been dropped. 
