### PR TITLE
Fix Priority Sampling Error Events Test

### DIFF
--- a/tests/agent_features/test_priority_sampling.py
+++ b/tests/agent_features/test_priority_sampling.py
@@ -83,8 +83,9 @@ def test_priority_used_in_transaction_error_events(first_transaction_saved):
         error_events = list(stats_engine.error_events)
         assert len(error_events) == 1
 
-        # highest priority should win
-        assert stats_engine.error_events.pq[0][0] == 1
+        # Highest priority should win.
+        # Priority can be 1 or 2 depending on randomness in sampling computation.
+        assert stats_engine.error_events.pq[0][0] >= 1
 
         if first_transaction_saved:
             assert error_events[0][0]["transactionName"].endswith("/T1")

--- a/tests/agent_features/test_priority_sampling.py
+++ b/tests/agent_features/test_priority_sampling.py
@@ -63,22 +63,22 @@ def test_priority_used_in_transaction_error_events(first_transaction_saved):
 
     @reset_core_stats_engine()
     def _test():
-        with BackgroundTask(application(), name="T1") as txn:
-            txn._priority = first_priority
-            try:
-                raise ValueError("OOPS")
-            except ValueError:
-                txn.notice_error()
-
-        with BackgroundTask(application(), name="T2") as txn:
-            txn._priority = second_priority
-            try:
-                raise ValueError("OOPS")
-            except ValueError:
-                txn.notice_error()
-
         # Stats engine
         stats_engine = core_application_stats_engine()
+
+        with BackgroundTask(application(), name="T1") as txn1:
+            txn1._priority = first_priority
+            try:
+                raise ValueError("OOPS")
+            except ValueError:
+                txn1.notice_error()
+
+        with BackgroundTask(application(), name="T2") as txn2:
+            txn2._priority = second_priority
+            try:
+                raise ValueError("OOPS")
+            except ValueError:
+                txn2.notice_error()
 
         error_events = list(stats_engine.error_events)
         assert len(error_events) == 1


### PR DESCRIPTION
# Overview
This PR makes the `test_priority_used_in_transaction_error_events` found in `tests/agent_features/test_priority_sampling.py` run more consistently.  Here, the priority measured can be 1 or 2 depending on the randomness in sampling computation.
