### PR TITLE
Fix CherryPy PyPy 3.8 Tests by Pinning Pydantic

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -272,6 +272,7 @@ deps =
     framework_bottle: markupsafe<2.1
     framework_cherrypy: routes
     framework_cherrypy: CherryPy
+    framework_cherrypy-pypy38: pydantic-core<2.15
     framework_django-Django0202: Django<2.3
     framework_django-Django0300: Django<3.1
     framework_django-Django0301: Django<3.2


### PR DESCRIPTION
# Overview

* Pin `pydantic-core` for PyPy 3.8 to last version with wheel support.
