### PR TITLE
Drop attributes with a value of None

### DIFF
--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -52,12 +52,12 @@ from newrelic.core.attribute import (
     MAX_NUM_USER_ATTRIBUTES,
     create_agent_attributes,
     create_attributes,
-    create_user_attributes,
     process_user_attribute,
     resolve_logging_context_attributes,
     truncate,
 )
 from newrelic.core.attribute_filter import (
+    DST_ALL,
     DST_ERROR_COLLECTOR,
     DST_NONE,
     DST_TRANSACTION_TRACER,
@@ -1004,7 +1004,7 @@ class Transaction(object):
 
     @property
     def user_attributes(self):
-        return create_user_attributes(self._custom_params, self.attribute_filter)
+        return create_attributes(self._custom_params, DST_ALL, self.attribute_filter)
 
     def _compute_sampled_and_priority(self):
         if self._priority is None:

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -147,6 +147,12 @@ def create_agent_attributes(attr_dict, attribute_filter):
 
 
 def resolve_user_attributes(attr_dict, attribute_filter, target_destination, attr_class=dict):
+    """
+    Returns an attr_class of key value attributes filtered to the target_destination.
+
+    process_user_attribute MUST be called before this function to filter out invalid
+    attributes.
+    """
     u_attrs = attr_class()
 
     for attr_name, attr_value in attr_dict.items():
@@ -200,11 +206,6 @@ def resolve_logging_context_attributes(attr_dict, attribute_filter, attr_prefix,
                 )
 
     return c_attrs
-
-
-def create_user_attributes(attr_dict, attribute_filter):
-    destinations = DST_ALL
-    return create_attributes(attr_dict, destinations, attribute_filter)
 
 
 def truncate(text, maxsize=MAX_ATTRIBUTE_LENGTH, encoding="utf-8", ending=None):

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -130,6 +130,13 @@ def create_attributes(attr_dict, destinations, attribute_filter):
 
 
 def create_agent_attributes(attr_dict, attribute_filter):
+    """
+    Returns a dictionary of Attribute objects with appropriate destinations.
+
+    If the attribute's key is in the known list of event attributes, it is assigned
+    to _DESTINATIONS_WITH_EVENTS, otherwise it is assigned to _DESTINATIONS.
+    Note attributes with a value of None are filtered out.
+    """
     attributes = []
 
     for k, v in attr_dict.items():

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -333,20 +333,9 @@ def sanitize(value):
     """
 
     valid_value_types = (six.text_type, six.binary_type, bool, float, six.integer_types)
-    # The agent spec says:
-    #   Agents **SHOULD NOT** report `null` attribute values. The behavior of `IS NULL`
-    #   queries in insights makes it so that omitted keys behave the same as `null`
-    #   keys. Since there is no difference between omitting the key and sending a
-    #   `null, we **SHOULD** reduce the payload size by omitting `null` values from the
-    #   payload entirely.
-    #
-    #   Since there should not be a difference in behavior for customers recording
-    #   `null` attributes versus customers omitting an attribute, agents **SHOULD** add
-    #   debug logging when a null value is recorded. This will give agents observability
-    #   on recording of `null` attributes outside of audit logs.
-    #
-    #   "empty" values such as `""` and `0` **MUST** be sent as an attribute in the
-    #   payload.
+    # According to the agent spec, agents should not report None attribute values.
+    # There is no difference between omitting the key and sending a None, so we can
+    # reduce the payload size by not sending None values.
     if value is None:
         raise NullValueException(
             "Attribute value is of type: None. Omitting value since there is "

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -150,9 +150,6 @@ def resolve_user_attributes(attr_dict, attribute_filter, target_destination, att
     u_attrs = attr_class()
 
     for attr_name, attr_value in attr_dict.items():
-        if attr_value is None:
-            continue
-
         dest = attribute_filter.apply(attr_name, DST_ALL)
 
         if dest & target_destination:

--- a/newrelic/core/node_mixin.py
+++ b/newrelic/core/node_mixin.py
@@ -13,141 +13,118 @@
 # limitations under the License.
 
 import newrelic.core.attribute as attribute
-
-from newrelic.core.attribute_filter import (DST_SPAN_EVENTS,
-        DST_TRANSACTION_SEGMENTS)
+from newrelic.core.attribute_filter import DST_SPAN_EVENTS, DST_TRANSACTION_SEGMENTS
 
 
 class GenericNodeMixin(object):
     @property
     def processed_user_attributes(self):
-        if hasattr(self, '_processed_user_attributes'):
+        if hasattr(self, "_processed_user_attributes"):
             return self._processed_user_attributes
 
         self._processed_user_attributes = u_attrs = {}
-        user_attributes = getattr(self, 'user_attributes', u_attrs)
+        user_attributes = getattr(self, "user_attributes", u_attrs)
         for k, v in user_attributes.items():
             k, v = attribute.process_user_attribute(k, v)
-            u_attrs[k] = v
+            # Only record the attribute if it passes processing.
+            # Failures return (None, None).
+            if k:
+                u_attrs[k] = v
         return u_attrs
 
     def get_trace_segment_params(self, settings, params=None):
         _params = attribute.resolve_agent_attributes(
-                self.agent_attributes,
-                settings.attribute_filter,
-                DST_TRANSACTION_SEGMENTS)
+            self.agent_attributes, settings.attribute_filter, DST_TRANSACTION_SEGMENTS
+        )
 
         if params:
             _params.update(params)
 
-        _params.update(attribute.resolve_user_attributes(
-                self.processed_user_attributes,
-                settings.attribute_filter,
-                DST_TRANSACTION_SEGMENTS))
+        _params.update(
+            attribute.resolve_user_attributes(
+                self.processed_user_attributes, settings.attribute_filter, DST_TRANSACTION_SEGMENTS
+            )
+        )
 
-        _params['exclusive_duration_millis'] = 1000.0 * self.exclusive
+        _params["exclusive_duration_millis"] = 1000.0 * self.exclusive
         return _params
 
-    def span_event(
-                self,
-                settings,
-                base_attrs=None,
-                parent_guid=None,
-                attr_class=dict):
+    def span_event(self, settings, base_attrs=None, parent_guid=None, attr_class=dict):
         i_attrs = base_attrs and base_attrs.copy() or attr_class()
-        i_attrs['type'] = 'Span'
-        i_attrs['name'] = self.name
-        i_attrs['guid'] = self.guid
-        i_attrs['timestamp'] = int(self.start_time * 1000)
-        i_attrs['duration'] = self.duration
-        i_attrs['category'] = 'generic'
+        i_attrs["type"] = "Span"
+        i_attrs["name"] = self.name
+        i_attrs["guid"] = self.guid
+        i_attrs["timestamp"] = int(self.start_time * 1000)
+        i_attrs["duration"] = self.duration
+        i_attrs["category"] = "generic"
 
         if parent_guid:
-            i_attrs['parentId'] = parent_guid
+            i_attrs["parentId"] = parent_guid
 
         a_attrs = attribute.resolve_agent_attributes(
-                self.agent_attributes,
-                settings.attribute_filter,
-                DST_SPAN_EVENTS,
-                attr_class=attr_class)
+            self.agent_attributes, settings.attribute_filter, DST_SPAN_EVENTS, attr_class=attr_class
+        )
 
         u_attrs = attribute.resolve_user_attributes(
-                self.processed_user_attributes,
-                settings.attribute_filter,
-                DST_SPAN_EVENTS,
-                attr_class=attr_class)
+            self.processed_user_attributes, settings.attribute_filter, DST_SPAN_EVENTS, attr_class=attr_class
+        )
 
         # intrinsics, user attrs, agent attrs
         return [i_attrs, u_attrs, a_attrs]
 
-    def span_events(self,
-            settings, base_attrs=None, parent_guid=None, attr_class=dict):
-
-        yield self.span_event(
-                settings,
-                base_attrs=base_attrs,
-                parent_guid=parent_guid,
-                attr_class=attr_class)
+    def span_events(self, settings, base_attrs=None, parent_guid=None, attr_class=dict):
+        yield self.span_event(settings, base_attrs=base_attrs, parent_guid=parent_guid, attr_class=attr_class)
 
         for child in self.children:
             for event in child.span_events(
-                    settings,
-                    base_attrs=base_attrs,
-                    parent_guid=self.guid,
-                    attr_class=attr_class):
+                settings, base_attrs=base_attrs, parent_guid=self.guid, attr_class=attr_class
+            ):
                 yield event
 
 
 class DatastoreNodeMixin(GenericNodeMixin):
-
     @property
     def name(self):
         product = self.product
         target = self.target
-        operation = self.operation or 'other'
+        operation = self.operation or "other"
 
         if target:
-            name = 'Datastore/statement/%s/%s/%s' % (product, target,
-                    operation)
+            name = "Datastore/statement/%s/%s/%s" % (product, target, operation)
         else:
-            name = 'Datastore/operation/%s/%s' % (product, operation)
+            name = "Datastore/operation/%s/%s" % (product, operation)
 
         return name
 
     @property
     def db_instance(self):
-        if hasattr(self, '_db_instance'):
+        if hasattr(self, "_db_instance"):
             return self._db_instance
 
         db_instance_attr = None
         if self.database_name:
-            _, db_instance_attr = attribute.process_user_attribute(
-                    'db.instance', self.database_name)
+            _, db_instance_attr = attribute.process_user_attribute("db.instance", self.database_name)
 
         self._db_instance = db_instance_attr
         return db_instance_attr
 
     def span_event(self, *args, **kwargs):
-        self.agent_attributes['db.instance'] = self.db_instance
+        self.agent_attributes["db.instance"] = self.db_instance
         attrs = super(DatastoreNodeMixin, self).span_event(*args, **kwargs)
         i_attrs = attrs[0]
         a_attrs = attrs[2]
 
-        i_attrs['category'] = 'datastore'
-        i_attrs['component'] = self.product
-        i_attrs['span.kind'] = 'client'
+        i_attrs["category"] = "datastore"
+        i_attrs["component"] = self.product
+        i_attrs["span.kind"] = "client"
 
         if self.instance_hostname:
-            _, a_attrs['peer.hostname'] = attribute.process_user_attribute(
-                    'peer.hostname', self.instance_hostname)
+            _, a_attrs["peer.hostname"] = attribute.process_user_attribute("peer.hostname", self.instance_hostname)
         else:
-            a_attrs['peer.hostname'] = 'Unknown'
+            a_attrs["peer.hostname"] = "Unknown"
 
-        peer_address = '%s:%s' % (
-                self.instance_hostname or 'Unknown',
-                self.port_path_or_id or 'Unknown')
+        peer_address = "%s:%s" % (self.instance_hostname or "Unknown", self.port_path_or_id or "Unknown")
 
-        _, a_attrs['peer.address'] = attribute.process_user_attribute(
-                'peer.address', peer_address)
+        _, a_attrs["peer.address"] = attribute.process_user_attribute("peer.address", peer_address)
 
         return attrs

--- a/newrelic/core/root_node.py
+++ b/newrelic/core/root_node.py
@@ -16,30 +16,39 @@ from collections import namedtuple
 
 import newrelic.core.trace_node
 from newrelic.core.node_mixin import GenericNodeMixin
-from newrelic.core.attribute import resolve_user_attributes
 
-from newrelic.packages import six
-
-_RootNode = namedtuple('_RootNode',
-        ['name', 'children', 'start_time', 'end_time', 'exclusive',
-        'duration', 'guid', 'agent_attributes', 'user_attributes',
-        'path', 'trusted_parent_span', 'tracing_vendors',])
+_RootNode = namedtuple(
+    "_RootNode",
+    [
+        "name",
+        "children",
+        "start_time",
+        "end_time",
+        "exclusive",
+        "duration",
+        "guid",
+        "agent_attributes",
+        "user_attributes",
+        "path",
+        "trusted_parent_span",
+        "tracing_vendors",
+    ],
+)
 
 
 class RootNode(_RootNode, GenericNodeMixin):
     def span_event(self, *args, **kwargs):
         span = super(RootNode, self).span_event(*args, **kwargs)
         i_attrs = span[0]
-        i_attrs['transaction.name'] = self.path
-        i_attrs['nr.entryPoint'] = True
+        i_attrs["transaction.name"] = self.path
+        i_attrs["nr.entryPoint"] = True
         if self.trusted_parent_span:
-            i_attrs['trustedParentId'] = self.trusted_parent_span
+            i_attrs["trustedParentId"] = self.trusted_parent_span
         if self.tracing_vendors:
-            i_attrs['tracingVendors'] = self.tracing_vendors
+            i_attrs["tracingVendors"] = self.tracing_vendors
         return span
 
     def trace_node(self, stats, root, connections):
-
         name = self.path
 
         start_time = newrelic.core.trace_node.node_start_time(root, self)
@@ -57,9 +66,5 @@ class RootNode(_RootNode, GenericNodeMixin):
         params = self.get_trace_segment_params(root.settings)
 
         return newrelic.core.trace_node.TraceNode(
-                start_time=start_time,
-                end_time=end_time,
-                name=name,
-                params=params,
-                children=children,
-                label=None)
+            start_time=start_time, end_time=end_time, name=name, params=params, children=children, label=None
+        )

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -41,12 +41,12 @@ from newrelic.common.streaming_utils import StreamBuffer
 from newrelic.core.attribute import (
     MAX_LOG_MESSAGE_LENGTH,
     create_agent_attributes,
-    create_user_attributes,
+    create_attributes,
     process_user_attribute,
     resolve_logging_context_attributes,
     truncate,
 )
-from newrelic.core.attribute_filter import DST_ERROR_COLLECTOR
+from newrelic.core.attribute_filter import DST_ALL, DST_ERROR_COLLECTOR
 from newrelic.core.code_level_metrics import extract_code_from_traceback
 from newrelic.core.config import is_expected_error, should_ignore_error
 from newrelic.core.database_utils import explain_plan
@@ -824,7 +824,7 @@ class StatsEngine(object):
                 )
                 custom_attributes = {}
 
-            user_attributes = create_user_attributes(custom_attributes, settings.attribute_filter)
+            user_attributes = create_attributes(custom_attributes, DST_ALL, settings.attribute_filter)
 
         # Extract additional details about the exception as agent attributes
         agent_attributes = {}

--- a/tests/agent_features/test_custom_events.py
+++ b/tests/agent_features/test_custom_events.py
@@ -62,6 +62,25 @@ _event = [_intrinsics, _user_params]
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event)
 @background_task()
+def test_add_custom_event_to_transaction_stats_engine_drops_none_attr():
+    attrs = {"drop-me": None}
+    attrs.update(_user_params)
+    record_custom_event("FooEvent", attrs)
+
+
+@reset_core_stats_engine()
+@validate_custom_event_in_application_stats_engine(_event)
+def test_add_custom_event_to_application_stats_engine_drops_none_attr():
+    attrs = {"drop-me": None}
+    attrs.update(_user_params)
+
+    app = application()
+    record_custom_event("FooEvent", attrs, application=app)
+
+
+@reset_core_stats_engine()
+@validate_custom_event_in_application_stats_engine(_event)
+@background_task()
 def test_add_custom_event_to_transaction_stats_engine():
     record_custom_event('FooEvent', _user_params)
 

--- a/tests/agent_features/test_custom_events.py
+++ b/tests/agent_features/test_custom_events.py
@@ -14,50 +14,59 @@
 
 import time
 
+from testing_support.fixtures import (
+    function_not_called,
+    override_application_settings,
+    reset_core_stats_engine,
+    validate_custom_event_count,
+    validate_custom_event_in_application_stats_engine,
+)
+
 from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import record_custom_event
 from newrelic.core.custom_event import process_event_type
 
-from testing_support.fixtures import (reset_core_stats_engine,
-        validate_custom_event_count,
-        validate_custom_event_in_application_stats_engine,
-        override_application_settings, function_not_called)
-
-# Test process_event_type()
 
 def test_process_event_type_name_is_string():
-    name = 'string'
+    name = "string"
     assert process_event_type(name) == name
+
 
 def test_process_event_type_name_is_not_string():
     name = 42
     assert process_event_type(name) is None
 
+
 def test_process_event_type_name_ok_length():
-    ok_name = 'CustomEventType'
+    ok_name = "CustomEventType"
     assert process_event_type(ok_name) == ok_name
 
+
 def test_process_event_type_name_too_long():
-    too_long = 'a' * 256
+    too_long = "a" * 256
     assert process_event_type(too_long) is None
 
+
 def test_process_event_type_name_valid_chars():
-    valid_name = 'az09: '
+    valid_name = "az09: "
     assert process_event_type(valid_name) == valid_name
 
+
 def test_process_event_type_name_invalid_chars():
-    invalid_name = '&'
+    invalid_name = "&"
     assert process_event_type(invalid_name) is None
+
 
 _now = time.time()
 
 _intrinsics = {
-    'type': 'FooEvent',
-    'timestamp': _now,
+    "type": "FooEvent",
+    "timestamp": _now,
 }
-_user_params = {'foo': 'bar'}
+_user_params = {"foo": "bar"}
 _event = [_intrinsics, _user_params]
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event)
@@ -82,79 +91,93 @@ def test_add_custom_event_to_application_stats_engine_drops_none_attr():
 @validate_custom_event_in_application_stats_engine(_event)
 @background_task()
 def test_add_custom_event_to_transaction_stats_engine():
-    record_custom_event('FooEvent', _user_params)
+    record_custom_event("FooEvent", _user_params)
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event)
 def test_add_custom_event_to_application_stats_engine():
     app = application()
-    record_custom_event('FooEvent', _user_params, application=app)
+    record_custom_event("FooEvent", _user_params, application=app)
+
 
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 @background_task()
 def test_custom_event_inside_transaction_bad_event_type():
-    record_custom_event('!@#$%^&*()', {'foo': 'bar'})
+    record_custom_event("!@#$%^&*()", {"foo": "bar"})
+
 
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 @background_task()
 def test_custom_event_outside_transaction_bad_event_type():
     app = application()
-    record_custom_event('!@#$%^&*()', {'foo': 'bar'}, application=app)
+    record_custom_event("!@#$%^&*()", {"foo": "bar"}, application=app)
 
-_mixed_params = {'foo': 'bar', 123: 'bad key'}
+
+_mixed_params = {"foo": "bar", 123: "bad key"}
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event)
 @background_task()
 def test_custom_event_inside_transaction_mixed_params():
-    record_custom_event('FooEvent', _mixed_params)
+    record_custom_event("FooEvent", _mixed_params)
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event)
 @background_task()
 def test_custom_event_outside_transaction_mixed_params():
     app = application()
-    record_custom_event('FooEvent', _mixed_params, application=app)
+    record_custom_event("FooEvent", _mixed_params, application=app)
 
-_bad_params = {'*' * 256: 'too long', 123: 'bad key'}
-_event_with_no_params = [{'type': 'FooEvent', 'timestamp': _now}, {}]
+
+_bad_params = {"*" * 256: "too long", 123: "bad key"}
+_event_with_no_params = [{"type": "FooEvent", "timestamp": _now}, {}]
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event_with_no_params)
 @background_task()
 def test_custom_event_inside_transaction_bad_params():
-    record_custom_event('FooEvent', _bad_params)
+    record_custom_event("FooEvent", _bad_params)
+
 
 @reset_core_stats_engine()
 @validate_custom_event_in_application_stats_engine(_event_with_no_params)
 @background_task()
 def test_custom_event_outside_transaction_bad_params():
     app = application()
-    record_custom_event('FooEvent', _bad_params, application=app)
+    record_custom_event("FooEvent", _bad_params, application=app)
+
 
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 @background_task()
 def test_custom_event_params_not_a_dict():
-    record_custom_event('ParamsListEvent', ['not', 'a', 'dict'])
+    record_custom_event("ParamsListEvent", ["not", "a", "dict"])
+
 
 # Tests for Custom Events configuration settings
 
-@override_application_settings({'collect_custom_events': False})
+
+@override_application_settings({"collect_custom_events": False})
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 @background_task()
 def test_custom_event_settings_check_collector_flag():
-    record_custom_event('FooEvent', _user_params)
+    record_custom_event("FooEvent", _user_params)
 
-@override_application_settings({'custom_insights_events.enabled': False})
+
+@override_application_settings({"custom_insights_events.enabled": False})
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 @background_task()
 def test_custom_event_settings_check_custom_insights_enabled():
-    record_custom_event('FooEvent', _user_params)
+    record_custom_event("FooEvent", _user_params)
+
 
 # Test that record_custom_event() methods will short-circuit.
 #
@@ -162,15 +185,17 @@ def test_custom_event_settings_check_custom_insights_enabled():
 # `create_custom_event()` function is not called, in order to avoid the
 # event_type and attribute processing.
 
-@override_application_settings({'custom_insights_events.enabled': False})
-@function_not_called('newrelic.api.transaction', 'create_custom_event')
+
+@override_application_settings({"custom_insights_events.enabled": False})
+@function_not_called("newrelic.api.transaction", "create_custom_event")
 @background_task()
 def test_transaction_create_custom_event_not_called():
-    record_custom_event('FooEvent', _user_params)
+    record_custom_event("FooEvent", _user_params)
 
-@override_application_settings({'custom_insights_events.enabled': False})
-@function_not_called('newrelic.core.application', 'create_custom_event')
+
+@override_application_settings({"custom_insights_events.enabled": False})
+@function_not_called("newrelic.core.application", "create_custom_event")
 @background_task()
 def test_application_create_custom_event_not_called():
     app = application()
-    record_custom_event('FooEvent', _user_params, application=app)
+    record_custom_event("FooEvent", _user_params, application=app)

--- a/tests/agent_features/test_dimensional_metrics.py
+++ b/tests/agent_features/test_dimensional_metrics.py
@@ -62,6 +62,7 @@ def otlp_content_encoding(request):
 _test_tags_examples = [
     (None, None),
     ({}, None),
+    ({"drop-me": None}, None),
     ([], None),
     ({"str": "a"}, frozenset({("str", "a")})),
     ({"int": 1}, frozenset({("int", 1)})),

--- a/tests/agent_features/test_error_events.py
+++ b/tests/agent_features/test_error_events.py
@@ -247,11 +247,14 @@ _err_params = {"key": "value"}
 @reset_core_stats_engine()
 @validate_non_transaction_error_event(_intrinsic_attributes, required_user=_err_params)
 def test_error_event_with_params_outside_transaction():
+    attrs = {"drop-me": None}
+    attrs.update(_err_params)
+
     try:
         raise outside_error
     except ErrorEventOutsideTransactionError:
         app = application()
-        notice_error(sys.exc_info(), attributes=_err_params, application=app)
+        notice_error(sys.exc_info(), attributes=attrs, application=app)
 
 
 @reset_core_stats_engine()

--- a/tests/agent_features/test_log_events.py
+++ b/tests/agent_features/test_log_events.py
@@ -69,7 +69,8 @@ def exercise_record_log_event():
     set_trace_ids()
 
     record_log_event("no_other_arguments")
-    record_log_event("keyword_arguments", timestamp=1234, level="ERROR", attributes={"key": "value"})
+    # Attributes with value None should be dropped.
+    record_log_event("keyword_arguments", timestamp=1234, level="ERROR", attributes={"key": "value", "drop-me": None})
     record_log_event("positional_arguments", "WARNING", 2345, {"key": "value"})
     record_log_event("serialized_attributes", attributes=_serialized_attributes)
     record_log_event(None, attributes={"attributes_only": "value"})

--- a/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
+++ b/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
@@ -29,6 +29,7 @@ from testing_support.validators.validate_transaction_event_attributes import (
 
 from newrelic.api.application import application_settings
 from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 from newrelic.common.encoding_utils import deobfuscate
 from newrelic.common.object_wrapper import transient_function_wrapper
 
@@ -491,7 +492,7 @@ _expected_attributes = {
 }
 
 _expected_absent_attributes = {
-    "user": ("foo"),
+    "user": ("foo", "drop-me"),
     "agent": ("response.status", "request.method"),
     "intrinsic": ("port"),
 }
@@ -500,4 +501,6 @@ _expected_absent_attributes = {
 @validate_transaction_event_attributes(_expected_attributes, _expected_absent_attributes)
 @background_task()
 def test_background_task_intrinsics_has_no_port():
+    transaction = current_transaction()
+    transaction.add_custom_attribute("drop-me", None)
     pass

--- a/tests/logger_logging/test_attributes.py
+++ b/tests/logger_logging/test_attributes.py
@@ -58,7 +58,7 @@ def test_logging_extra_attributes(logger):
     logger.error("extras", extra={"extra_attr": 1})
 
 
-@validate_log_events([{"message": "exc_info"}], required_attrs=["context.exc_info", "context.exc_text"])
+@validate_log_events([{"message": "exc_info"}], required_attrs=["context.exc_info"])
 @validate_log_event_count(1)
 @background_task()
 def test_logging_exc_info_context_attributes(logger):

--- a/tests/logger_loguru/test_attributes.py
+++ b/tests/logger_loguru/test_attributes.py
@@ -53,7 +53,7 @@ def test_loguru_default_context_attributes(logger):
         bound_logger.error("context_attrs: {}", "arg1", kwarg_attr=4)
 
 
-@validate_log_events([{"message": "exc_info"}], required_attrs=["context.exception"])
+@validate_log_events([{"message": "exc_info"}], required_attrs=["context.file"])
 @validate_log_event_count(1)
 @background_task()
 def test_loguru_exception_context_attributes(logger):

--- a/tests/logger_loguru/test_attributes.py
+++ b/tests/logger_loguru/test_attributes.py
@@ -53,14 +53,14 @@ def test_loguru_default_context_attributes(logger):
         bound_logger.error("context_attrs: {}", "arg1", kwarg_attr=4)
 
 
-@validate_log_events([{"message": "exc_info"}], required_attrs=["context.file"])
+@validate_log_events([{"message": "exc_info"}], required_attrs=["context.exception"])
 @validate_log_event_count(1)
 @background_task()
 def test_loguru_exception_context_attributes(logger):
     try:
         raise RuntimeError("Oops")
     except Exception:
-        logger.error("exc_info")
+        logger.opt(exception=True).error("exc_info")
 
 
 @validate_log_events([{"context.extra.attr": 1}])


### PR DESCRIPTION
# Overview
This PR attempts to align the Python agent with the agent spec by dropping attributes with a value of None.

According to the spec:
> Agents **SHOULD NOT** report `null` attribute values. The behavior of `IS NULL` queries in insights makes it so that omitted keys behave the same as `null` keys. Since there is no difference between omitting the key and sending a `null`, we **SHOULD** reduce the payload size by omitting `null` values from the payload entirely.

> Since there should not be a difference in behavior for customers recording `null` attributes versus customers omitting an attribute, agents **SHOULD** add debug logging when a null value is recorded. This will give agents observability on recording of `null` attributes outside of audit logs.

> "empty" values such as `""` and `0` **MUST** be sent as an attribute in the payload.

It also performs some minor cleanup and adds descriptions to some function inside our attribute filtering system.
It also contains a fix for previously failing sklearn tests due to a non integer version: `0.0.post12`.

Recommended review strategy: review each commit one at a time.