### PR TITLE
Fix sklearn version tuple parsing in tests

### DIFF
--- a/tests/mlmodel_sklearn/test_cluster_models.py
+++ b/tests/mlmodel_sklearn/test_cluster_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_dummy_models.py
+++ b/tests/mlmodel_sklearn/test_dummy_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_ensemble_models.py
+++ b/tests/mlmodel_sklearn/test_ensemble_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(
@@ -195,7 +195,6 @@ def test_between_v1_0_and_v1_1_model_methods_wrapped_in_function_trace(ensemble_
         run_ensemble_model(ensemble_model_name)
 
     _test()
-
 
 
 @pytest.mark.skipif(SKLEARN_VERSION < (1, 1, 0), reason="Requires sklearn >= 1.1")

--- a/tests/mlmodel_sklearn/test_feature_selection_models.py
+++ b/tests/mlmodel_sklearn/test_feature_selection_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_linear_models.py
+++ b/tests/mlmodel_sklearn/test_linear_models.py
@@ -18,11 +18,11 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
-SCIPY_VERSION = tuple(map(int, get_package_version("scipy").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
+SCIPY_VERSION = get_package_version_tuple("scipy")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_multioutput_models.py
+++ b/tests/mlmodel_sklearn/test_multioutput_models.py
@@ -20,10 +20,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 # Python 2 will not allow instantiation of abstract class

--- a/tests/mlmodel_sklearn/test_naive_bayes_models.py
+++ b/tests/mlmodel_sklearn/test_naive_bayes_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.skipif(SKLEARN_VERSION < (1, 0, 0), reason="Requires sklearn >= 1.0")

--- a/tests/mlmodel_sklearn/test_neighbors_models.py
+++ b/tests/mlmodel_sklearn/test_neighbors_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_neural_network_models.py
+++ b/tests/mlmodel_sklearn/test_neural_network_models.py
@@ -18,10 +18,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_pipeline_models.py
+++ b/tests/mlmodel_sklearn/test_pipeline_models.py
@@ -21,10 +21,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_semi_supervised_models.py
+++ b/tests/mlmodel_sklearn/test_semi_supervised_models.py
@@ -19,10 +19,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(

--- a/tests/mlmodel_sklearn/test_svm_models.py
+++ b/tests/mlmodel_sklearn/test_svm_models.py
@@ -18,10 +18,10 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.packages import six
 
-SKLEARN_VERSION = tuple(map(int, get_package_version("sklearn").split(".")))
+SKLEARN_VERSION = get_package_version_tuple("sklearn")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Utilize the common parsing method that already handels non integer versions rather than building our own.
