### PR TITLE
Run langchain agent tests

### DIFF
--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -526,7 +526,6 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
     if not settings.ai_monitoring.enabled:
         return await wrapped(*args, **kwargs)
 
-
     # Framework metric also used for entity tagging in the UI
     transaction.add_ml_model_info("OpenAI", OPENAI_VERSION)
     transaction._add_agent_attribute("llm", True)

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -1018,7 +1018,9 @@ def record_stream_chunk(self, return_val):
         if choices:
             delta = choices[0].get("delta", {})
             if delta:
-                self._nr_openai_attrs["content"] = self._nr_openai_attrs.get("content", "") + delta.get("content", "")
+                self._nr_openai_attrs["content"] = self._nr_openai_attrs.get("content", "") + (
+                    delta.get("content") or ""
+                )
                 self._nr_openai_attrs["role"] = self._nr_openai_attrs.get("role", None) or delta.get("role")
             self._nr_openai_attrs["finish_reason"] = choices[0].get("finish_reason", "")
 

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -191,6 +191,8 @@ def wrap_chat_completion_sync(wrapped, instance, args, kwargs):
     # Framework metric also used for entity tagging in the UI
     transaction.add_ml_model_info("OpenAI", OPENAI_VERSION)
     transaction._add_agent_attribute("llm", True)
+    if not settings.ai_monitoring.streaming.enabled:
+        transaction.record_custom_metric("Supportability/Python/ML/Streaming/Disabled", 1)
 
     request_message_list = kwargs.get("messages", [])
 
@@ -677,6 +679,8 @@ async def wrap_chat_completion_async(wrapped, instance, args, kwargs):
     # Framework metric also used for entity tagging in the UI
     transaction.add_ml_model_info("OpenAI", OPENAI_VERSION)
     transaction._add_agent_attribute("llm", True)
+    if not settings.ai_monitoring.streaming.enabled:
+        transaction.record_custom_metric("Supportability/Python/ML/Streaming/Disabled", 1)
 
     request_message_list = kwargs.get("messages", [])
 

--- a/tests/mlmodel_langchain/_mock_external_openai_server.py
+++ b/tests/mlmodel_langchain/_mock_external_openai_server.py
@@ -29,7 +29,175 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 #    transactions to separate the ones created in the test app and the ones
 #    created by an external call.
 # 3) This app runs on a separate thread meaning it won't block the test app.
-STREAMED_RESPONSES_V1 = {}
+STREAMED_RESPONSES_V1 = {
+    "You are a world class algorithm for extracting information in structured formats.": [
+        {
+            "content-type": "text/event-stream",
+            "openai-model": "gpt-3.5-turbo-0125",
+            "openai-organization": "foobar-jtbczk",
+            "openai-processing-ms": "511",
+            "openai-version": "2020-10-01",
+            "x-ratelimit-limit-requests": "200",
+            "x-ratelimit-limit-tokens": "40000",
+            "x-ratelimit-remaining-requests": "196",
+            "x-ratelimit-remaining-tokens": "39924",
+            "x-ratelimit-reset-requests": "23m16.298s",
+            "x-ratelimit-reset-tokens": "114ms",
+            "x-request-id": "req_69c9ac5f95907fdb4af31572fd99537f",
+        },
+        200,
+        [
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant", "content": ""}, "logprobs": None, "finish_reason": None}
+                ],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": "The"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " extracted"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [
+                    {"index": 0, "delta": {"content": " information"}, "logprobs": None, "finish_reason": None}
+                ],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " from"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " the"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " input"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": ' "'}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": "Hello"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": ","}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " world"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": '"'}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": " is"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": ' "'}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": "H"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": "elloworld"}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {"content": '"'}, "logprobs": None, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl-8uUiO2kRX1yl9fyniZCjJ6q3GN8wf",
+                "object": "chat.completion.chunk",
+                "created": 1708475128,
+                "model": "gpt-3.5-turbo-0125",
+                "system_fingerprint": "fp_69829325d0",
+                "choices": [{"index": 0, "delta": {}, "logprobs": None, "finish_reason": "stop"}],
+            },
+        ],
+    ],
+}
 RESPONSES_V1 = {
     "You are a world class algorithm for extracting information in structured formats.": [
         {

--- a/tests/mlmodel_langchain/test_agent.py
+++ b/tests/mlmodel_langchain/test_agent.py
@@ -59,7 +59,6 @@ def prompt():
     )
 
 
-@pytest.mark.skip(reason="Streaming not enabled yet for NR")
 @reset_core_stats_engine()
 @validate_transaction_metrics(
     name="test_agent:test_sync_agent",
@@ -79,7 +78,6 @@ def test_sync_agent(chat_openai_client, tools, prompt):
     assert response
 
 
-@pytest.mark.skip(reason="Streaming not enabled yet for NR")
 @reset_core_stats_engine()
 @validate_transaction_metrics(
     name="test_agent:test_async_agent",

--- a/tests/mlmodel_openai/test_chat_completion_stream.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream.py
@@ -277,7 +277,10 @@ def test_openai_chat_completion_sync_in_txn_no_convo_id(set_trace_info):
 @validate_custom_event_count(count=0)
 @validate_transaction_metrics(
     "test_chat_completion_stream:test_openai_chat_completion_sync_ai_monitoring_streaming_disabled",
-    custom_metrics=[("Python/ML/OpenAI/%s" % openai.__version__, 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+        ("Supportability/Python/ML/Streaming/Disabled", 1),
+    ],
     scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
     background_task=True,
@@ -390,7 +393,10 @@ def test_openai_chat_completion_async_conversation_id_set(loop, set_trace_info):
 @validate_custom_event_count(count=0)
 @validate_transaction_metrics(
     name="test_chat_completion_stream:test_openai_chat_completion_async_ai_monitoring_streaming_disabled",
-    custom_metrics=[("Python/ML/OpenAI/%s" % openai.__version__, 1)],
+    custom_metrics=[
+        ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+        ("Supportability/Python/ML/Streaming/Disabled", 1),
+    ],
     scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
     background_task=True,

--- a/tests/mlmodel_openai/test_chat_completion_stream_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_v1.py
@@ -282,6 +282,7 @@ def test_openai_chat_completion_sync_in_txn_no_convo_id(set_trace_info, sync_ope
     "test_chat_completion_stream_v1:test_openai_chat_completion_sync_ai_monitoring_streaming_disabled",
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+        ("Supportability/Python/ML/Streaming/Disabled", 1),
     ],
     scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
@@ -427,6 +428,7 @@ def test_openai_chat_completion_async_conversation_id_set(loop, set_trace_info, 
     "test_chat_completion_stream_v1:test_openai_chat_completion_async_ai_monitoring_streaming_disabled",
     custom_metrics=[
         ("Python/ML/OpenAI/%s" % openai.__version__, 1),
+        ("Supportability/Python/ML/Streaming/Disabled", 1),
     ],
     scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/create", 1)],


### PR DESCRIPTION
Previously, langchain agent tests were skipped because they were dependent on streaming instrumentation support which hadn't been implemented yet. Now we support streaming in openai so remove the skip condition and actually run these tests.

Note: this is dependent on #1068 which should be merged first.