### PR TITLE
Add ai_monitoring.record_content.enabled flag

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -561,6 +561,7 @@ def _process_configuration(section):
     _process_setting(section, "machine_learning.enabled", "getboolean", None)
     _process_setting(section, "machine_learning.inference_events_value.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.enabled", "getboolean", None)
+    _process_setting(section, "ai_monitoring.record_content.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.streaming.enabled", "getboolean", None)
     _process_setting(section, "package_reporting.enabled", "getboolean", None)
 

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -152,6 +152,10 @@ class AIMonitoringStreamingSettings(Settings):
     pass
 
 
+class AIMonitoringRecordContentSettings(Settings):
+    pass
+
+
 class PackageReportingSettings(Settings):
     pass
 
@@ -419,6 +423,7 @@ _settings.machine_learning = MachineLearningSettings()
 _settings.machine_learning.inference_events_value = MachineLearningInferenceEventsValueSettings()
 _settings.ai_monitoring = AIMonitoringSettings()
 _settings.ai_monitoring.streaming = AIMonitoringStreamingSettings()
+_settings.ai_monitoring.record_content = AIMonitoringRecordContentSettings()
 _settings.package_reporting = PackageReportingSettings()
 _settings.attributes = AttributesSettings()
 _settings.browser_monitoring = BrowserMonitorSettings()
@@ -935,6 +940,9 @@ _settings.machine_learning.inference_events_value.enabled = _environ_as_bool(
 )
 _settings.ai_monitoring.enabled = _environ_as_bool("NEW_RELIC_AI_MONITORING_ENABLED", default=False)
 _settings.ai_monitoring.streaming.enabled = _environ_as_bool("NEW_RELIC_AI_MONITORING_STREAMING_ENABLED", default=True)
+_settings.ai_monitoring.record_content.enabled = _environ_as_bool(
+    "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED", default=True
+)
 _settings.package_reporting.enabled = _environ_as_bool("NEW_RELIC_PACKAGE_REPORTING_ENABLED", default=True)
 _settings.ml_insights_events.enabled = _environ_as_bool("NEW_RELIC_ML_INSIGHTS_EVENTS_ENABLED", default=False)
 

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -213,7 +213,6 @@ def extract_bedrock_titan_embedding_model(request_body, response_body=None):
     input_tokens = response_body.get("inputTextTokenCount", None)
 
     embedding_dict = {
-        "input": request_body.get("inputText", ""),
         "response.usage.prompt_tokens": input_tokens,
         "response.usage.total_tokens": input_tokens,
     }
@@ -542,7 +541,6 @@ def handle_embedding_event(
             "span_id": span_id,
             "trace_id": trace_id,
             "request_id": request_id,
-            "input": request_body.get("inputText", ""),
             "transaction_id": transaction.guid,
             "api_key_last_four_digits": client._request_signer._credentials.access_key[-4:],
             "duration": duration,
@@ -551,8 +549,8 @@ def handle_embedding_event(
         }
     )
 
-    if not settings.ai_monitoring.record_content.enabled:
-        del embedding_dict["input"]
+    if settings.ai_monitoring.record_content.enabled:
+        embedding_dict.update({"input": request_body.get("inputText", "")})
 
     if is_error:
         embedding_dict.update({"error": True})

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -122,7 +122,7 @@ def create_chat_completion_message_event(
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            chat_completion_message_dict.update({"content": message.get("content", "")})
+            chat_completion_message_dict["content"] = message.get("content", "")
 
         chat_completion_message_dict.update(llm_metadata_dict)
 
@@ -154,7 +154,7 @@ def create_chat_completion_message_event(
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            chat_completion_message_dict.update({"content": message.get("content", "")})
+            chat_completion_message_dict["content"] = message.get("content", "")
 
         chat_completion_message_dict.update(llm_metadata_dict)
 
@@ -550,7 +550,7 @@ def handle_embedding_event(
     )
 
     if settings.ai_monitoring.record_content.enabled:
-        embedding_dict.update({"input": request_body.get("inputText", "")})
+        embedding_dict["input"] = request_body.get("inputText", "")
 
     if is_error:
         embedding_dict.update({"error": True})

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -97,6 +97,8 @@ def create_chat_completion_message_event(
     if not transaction:
         return
 
+    settings = transaction.settings if transaction.settings is not None else global_settings()
+
     message_ids = []
     for index, message in enumerate(input_message_list):
         if response_id:
@@ -111,7 +113,6 @@ def create_chat_completion_message_event(
             "span_id": span_id,
             "trace_id": trace_id,
             "transaction_id": transaction.guid,
-            "content": message.get("content", ""),
             "role": message.get("role"),
             "completion_id": chat_completion_id,
             "sequence": index,
@@ -119,6 +120,9 @@ def create_chat_completion_message_event(
             "vendor": "bedrock",
             "ingest_source": "Python",
         }
+
+        if settings.ai_monitoring.record_content.enabled:
+            chat_completion_message_dict.update({"content": message.get("content", "")})
 
         chat_completion_message_dict.update(llm_metadata_dict)
 
@@ -140,7 +144,6 @@ def create_chat_completion_message_event(
             "span_id": span_id,
             "trace_id": trace_id,
             "transaction_id": transaction.guid,
-            "content": message.get("content", ""),
             "role": message.get("role"),
             "completion_id": chat_completion_id,
             "sequence": index,
@@ -149,6 +152,9 @@ def create_chat_completion_message_event(
             "ingest_source": "Python",
             "is_response": True,
         }
+
+        if settings.ai_monitoring.record_content.enabled:
+            chat_completion_message_dict.update({"content": message.get("content", "")})
 
         chat_completion_message_dict.update(llm_metadata_dict)
 
@@ -544,6 +550,10 @@ def handle_embedding_event(
             "response.model": model,
         }
     )
+
+    if not settings.ai_monitoring.record_content.enabled:
+        del embedding_dict["input"]
+
     if is_error:
         embedding_dict.update({"error": True})
 

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -171,7 +171,7 @@ async def wrap_asimilarity_search(wrapped, instance, args, kwargs):
     }
 
     if settings.ai_monitoring.record_content.enabled:
-        LLMVectorSearch_dict.update({"request.query": request_query})
+        LLMVectorSearch_dict["request.query"] = request_query
 
     # In both LlmVectorSearch and LlmVectorSearchResult dicts
     LLMVectorSearch_union_dict = {
@@ -205,7 +205,7 @@ async def wrap_asimilarity_search(wrapped, instance, args, kwargs):
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            LLMVectorSearchResult_dict.update({"page_content": page_content})
+            LLMVectorSearchResult_dict["page_content"] = page_content
 
         LLMVectorSearchResult_dict.update(LLMVectorSearch_union_dict)
         LLMVectorSearchResult_dict.update(metadata_dict)
@@ -272,7 +272,7 @@ def wrap_similarity_search(wrapped, instance, args, kwargs):
     }
 
     if settings.ai_monitoring.record_content.enabled:
-        LLMVectorSearch_dict.update({"request.query": request_query})
+        LLMVectorSearch_dict["request.query"] = request_query
 
     # In both LlmVectorSearch and LlmVectorSearchResult dicts
     LLMVectorSearch_union_dict = {
@@ -306,7 +306,7 @@ def wrap_similarity_search(wrapped, instance, args, kwargs):
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            LLMVectorSearchResult_dict.update({"page_content": page_content})
+            LLMVectorSearchResult_dict["page_content"] = page_content
 
         LLMVectorSearchResult_dict.update(LLMVectorSearch_union_dict)
         LLMVectorSearchResult_dict.update(metadata_dict)
@@ -397,7 +397,7 @@ def wrap_tool_sync_run(wrapped, instance, args, kwargs):
             )
 
             if settings.ai_monitoring.record_content.enabled:
-                error_tool_event_dict.update({"input": tool_input})
+                error_tool_event_dict["input"] = tool_input
 
             error_tool_event_dict.update(llm_metadata_dict)
 
@@ -531,7 +531,7 @@ async def wrap_tool_async_run(wrapped, instance, args, kwargs):
             )
 
             if settings.ai_monitoring.record_content.enabled:
-                error_tool_event_dict.update({"input": tool_input})
+                error_tool_event_dict["input"] = tool_input
 
             error_tool_event_dict.update(llm_metadata_dict)
 
@@ -913,7 +913,7 @@ def create_chat_completion_message_event(
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            chat_completion_input_message_dict.update({"content": message})
+            chat_completion_input_message_dict["content"] = message
 
         chat_completion_input_message_dict.update(llm_metadata_dict)
 
@@ -941,7 +941,7 @@ def create_chat_completion_message_event(
             }
 
             if settings.ai_monitoring.record_content.enabled:
-                chat_completion_output_message_dict.update({"content": message})
+                chat_completion_output_message_dict["content"] = message
 
             chat_completion_output_message_dict.update(llm_metadata_dict)
 

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -115,6 +115,9 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
                 "error": True,
             }
 
+            if not settings.ai_monitoring.record_content.enabled:
+                del error_embedding_dict["input"]
+
             error_embedding_dict.update(llm_metadata_dict)
 
             transaction.record_custom_event("LlmEmbedding", error_embedding_dict)
@@ -178,6 +181,9 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
         "vendor": "openAI",
         "ingest_source": "Python",
     }
+
+    if not settings.ai_monitoring.record_content.enabled:
+        del full_embedding_response_dict["input"]
 
     full_embedding_response_dict.update(llm_metadata_dict)
 
@@ -454,6 +460,8 @@ def create_chat_completion_message_event(
     llm_metadata_dict,
     output_message_list,
 ):
+    settings = transaction.settings if transaction.settings is not None else global_settings()
+
     message_ids = []
 
     # Loop through all input messages received from the create request and emit a custom event for each one
@@ -484,6 +492,9 @@ def create_chat_completion_message_event(
             "vendor": "openAI",
             "ingest_source": "Python",
         }
+
+        if not settings.ai_monitoring.record_content.enabled:
+            del chat_completion_input_message_dict["content"]
 
         chat_completion_input_message_dict.update(llm_metadata_dict)
 
@@ -522,6 +533,9 @@ def create_chat_completion_message_event(
                 "ingest_source": "Python",
                 "is_response": True,
             }
+
+            if not settings.ai_monitoring.record_content.enabled:
+                del chat_completion_output_message_dict["content"]
 
             chat_completion_output_message_dict.update(llm_metadata_dict)
 
@@ -616,6 +630,9 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
                 "error": True,
             }
 
+            if not settings.ai_monitoring.record_content.enabled:
+                del error_embedding_dict["input"]
+
             error_embedding_dict.update(llm_metadata_dict)
 
             transaction.record_custom_event("LlmEmbedding", error_embedding_dict)
@@ -679,6 +696,9 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
         "vendor": "openAI",
         "ingest_source": "Python",
     }
+
+    if not settings.ai_monitoring.record_content.enabled:
+        del full_embedding_response_dict["input"]
 
     full_embedding_response_dict.update(llm_metadata_dict)
 

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -115,7 +115,7 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
             }
 
             if settings.ai_monitoring.record_content.enabled:
-                error_embedding_dict.update({"input": kwargs.get("input", "")})
+                error_embedding_dict["input"] = kwargs.get("input", "")
 
             error_embedding_dict.update(llm_metadata_dict)
 
@@ -181,7 +181,7 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
     }
 
     if settings.ai_monitoring.record_content.enabled:
-        full_embedding_response_dict.update({"input": kwargs.get("input", "")})
+        full_embedding_response_dict["input"] = kwargs.get("input", "")
 
     full_embedding_response_dict.update(llm_metadata_dict)
 
@@ -491,7 +491,7 @@ def create_chat_completion_message_event(
         }
 
         if settings.ai_monitoring.record_content.enabled:
-            chat_completion_input_message_dict.update({"content": message_content})
+            chat_completion_input_message_dict["content"] = message_content
 
         chat_completion_input_message_dict.update(llm_metadata_dict)
 
@@ -531,7 +531,7 @@ def create_chat_completion_message_event(
             }
 
             if settings.ai_monitoring.record_content.enabled:
-                chat_completion_output_message_dict.update({"content": message_content})
+                chat_completion_output_message_dict["content"] = message_content
 
             chat_completion_output_message_dict.update(llm_metadata_dict)
 
@@ -626,7 +626,7 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
             }
 
             if settings.ai_monitoring.record_content.enabled:
-                error_embedding_dict.update({"input": kwargs.get("input", "")})
+                error_embedding_dict["input"] = kwargs.get("input", "")
 
             error_embedding_dict.update(llm_metadata_dict)
 
@@ -692,7 +692,7 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
     }
 
     if settings.ai_monitoring.record_content.enabled:
-        full_embedding_response_dict.update({"input": kwargs.get("input", "")})
+        full_embedding_response_dict["input"] = kwargs.get("input", "")
 
     full_embedding_response_dict.update(llm_metadata_dict)
 

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -106,7 +106,6 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
                 "span_id": span_id,
                 "trace_id": trace_id,
                 "transaction_id": transaction.guid,
-                "input": kwargs.get("input", ""),
                 "request.model": kwargs.get("model") or kwargs.get("engine") or "",
                 "vendor": "openAI",
                 "ingest_source": "Python",
@@ -115,8 +114,8 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
                 "error": True,
             }
 
-            if not settings.ai_monitoring.record_content.enabled:
-                del error_embedding_dict["input"]
+            if settings.ai_monitoring.record_content.enabled:
+                error_embedding_dict.update({"input": kwargs.get("input", "")})
 
             error_embedding_dict.update(llm_metadata_dict)
 
@@ -149,7 +148,6 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
         "span_id": span_id,
         "trace_id": trace_id,
         "transaction_id": transaction.guid,
-        "input": kwargs.get("input", ""),
         "api_key_last_four_digits": f"sk-{api_key[-4:]}" if api_key else "",
         "request.model": kwargs.get("model") or kwargs.get("engine") or "",
         "request_id": request_id,
@@ -182,8 +180,8 @@ def wrap_embedding_sync(wrapped, instance, args, kwargs):
         "ingest_source": "Python",
     }
 
-    if not settings.ai_monitoring.record_content.enabled:
-        del full_embedding_response_dict["input"]
+    if settings.ai_monitoring.record_content.enabled:
+        full_embedding_response_dict.update({"input": kwargs.get("input", "")})
 
     full_embedding_response_dict.update(llm_metadata_dict)
 
@@ -484,7 +482,6 @@ def create_chat_completion_message_event(
             "span_id": span_id,
             "trace_id": trace_id,
             "transaction_id": transaction.guid,
-            "content": message_content,
             "role": message.get("role", ""),
             "completion_id": chat_completion_id,
             "sequence": index,
@@ -493,8 +490,8 @@ def create_chat_completion_message_event(
             "ingest_source": "Python",
         }
 
-        if not settings.ai_monitoring.record_content.enabled:
-            del chat_completion_input_message_dict["content"]
+        if settings.ai_monitoring.record_content.enabled:
+            chat_completion_input_message_dict.update({"content": message_content})
 
         chat_completion_input_message_dict.update(llm_metadata_dict)
 
@@ -524,7 +521,6 @@ def create_chat_completion_message_event(
                 "span_id": span_id,
                 "trace_id": trace_id,
                 "transaction_id": transaction.guid,
-                "content": message_content,
                 "role": message.get("role", ""),
                 "completion_id": chat_completion_id,
                 "sequence": index,
@@ -534,8 +530,8 @@ def create_chat_completion_message_event(
                 "is_response": True,
             }
 
-            if not settings.ai_monitoring.record_content.enabled:
-                del chat_completion_output_message_dict["content"]
+            if settings.ai_monitoring.record_content.enabled:
+                chat_completion_output_message_dict.update({"content": message_content})
 
             chat_completion_output_message_dict.update(llm_metadata_dict)
 
@@ -621,7 +617,6 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
                 "span_id": span_id,
                 "trace_id": trace_id,
                 "transaction_id": transaction.guid,
-                "input": kwargs.get("input", ""),
                 "request.model": kwargs.get("model") or kwargs.get("engine") or "",
                 "vendor": "openAI",
                 "ingest_source": "Python",
@@ -630,8 +625,8 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
                 "error": True,
             }
 
-            if not settings.ai_monitoring.record_content.enabled:
-                del error_embedding_dict["input"]
+            if settings.ai_monitoring.record_content.enabled:
+                error_embedding_dict.update({"input": kwargs.get("input", "")})
 
             error_embedding_dict.update(llm_metadata_dict)
 
@@ -664,7 +659,6 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
         "span_id": span_id,
         "trace_id": trace_id,
         "transaction_id": transaction.guid,
-        "input": kwargs.get("input", ""),
         "api_key_last_four_digits": f"sk-{api_key[-4:]}" if api_key else "",
         "request.model": kwargs.get("model") or kwargs.get("engine") or "",
         "request_id": request_id,
@@ -697,8 +691,8 @@ async def wrap_embedding_async(wrapped, instance, args, kwargs):
         "ingest_source": "Python",
     }
 
-    if not settings.ai_monitoring.record_content.enabled:
-        del full_embedding_response_dict["input"]
+    if settings.ai_monitoring.record_content.enabled:
+        full_embedding_response_dict.update({"input": kwargs.get("input", "")})
 
     full_embedding_response_dict.update(llm_metadata_dict)
 

--- a/tests/external_botocore/conftest.py
+++ b/tests/external_botocore/conftest.py
@@ -58,6 +58,9 @@ BEDROCK_AUDIT_LOG_FILE = os.path.join(os.path.realpath(os.path.dirname(__file__)
 BEDROCK_AUDIT_LOG_CONTENTS = {}
 
 disabled_ai_monitoring_settings = override_application_settings({"ai_monitoring.enabled": False})
+disabled_ai_monitoring_record_content_settings = override_application_settings(
+    {"ai_monitoring.record_content.enabled": False}
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -28,7 +28,6 @@ from _test_bedrock_chat_completion import (
 from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from conftest import BOTOCORE_VERSION
 from testing_support.fixtures import (
-    dt_enabled,
     override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
@@ -93,8 +92,26 @@ def expected_events(model_id):
 
 
 @pytest.fixture(scope="module")
+def expected_events_no_content(model_id):
+    events = copy.deepcopy(chat_completion_expected_events[model_id])
+    for event in events:
+        if "content" in event[1]:
+            del event[1]["content"]
+    return events
+
+
+@pytest.fixture(scope="module")
 def expected_invalid_access_key_error_events(model_id):
     return chat_completion_invalid_access_key_error_events[model_id]
+
+
+@pytest.fixture(scope="module")
+def expected_invalid_access_key_error_events_no_content(model_id):
+    events = copy.deepcopy(chat_completion_invalid_access_key_error_events[model_id])
+    for event in events:
+        if "content" in event[1]:
+            del event[1]["content"]
+    return events
 
 
 @pytest.fixture(scope="module")
@@ -130,6 +147,36 @@ def test_bedrock_chat_completion_in_txn_with_llm_metadata(set_trace_info, exerci
     )
     @validate_attributes("agent", ["llm"])
     @background_task(name="test_bedrock_chat_completion_in_txn_with_llm_metadata")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+# not working with claude
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+def test_bedrock_chat_completion_in_txn_with_llm_metadata_no_content(
+    set_trace_info, exercise_model, expected_events_no_content
+):
+    @validate_custom_events(expected_events_no_content)
+    # One summary event, one user message, and one response message from the assistant
+    @validate_custom_event_count(count=3)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_in_txn_with_llm_metadata_no_content",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            ("Supportability/Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_chat_completion_in_txn_with_llm_metadata_no_content")
     def _test():
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
@@ -246,7 +293,6 @@ def test_bedrock_chat_completion_error_invalid_model(bedrock_server, set_trace_i
     _test()
 
 
-@dt_enabled
 @reset_core_stats_engine()
 def test_bedrock_chat_completion_error_incorrect_access_key(
     monkeypatch,
@@ -257,6 +303,49 @@ def test_bedrock_chat_completion_error_incorrect_access_key(
     expected_invalid_access_key_error_events,
 ):
     @validate_custom_events(expected_invalid_access_key_error_events)
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": expected_client_error,
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            ("Supportability/Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):  # not sure where this exception actually comes from
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token", temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+def test_bedrock_chat_completion_error_incorrect_access_key_no_content(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_client_error,
+    expected_invalid_access_key_error_events_no_content,
+):
+    @validate_custom_events(expected_invalid_access_key_error_events_no_content)
     @validate_error_trace_attributes(
         _client_error_name,
         exact_attrs={

--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -25,8 +25,11 @@ from _test_bedrock_chat_completion import (
     chat_completion_invalid_model_error_events,
     chat_completion_payload_templates,
 )
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
-from conftest import BOTOCORE_VERSION
+from conftest import (  # pylint: disable=E0611
+    BOTOCORE_VERSION,
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
 from testing_support.fixtures import (
     override_application_settings,
     reset_core_stats_engine,
@@ -159,7 +162,7 @@ def test_bedrock_chat_completion_in_txn_with_llm_metadata(set_trace_info, exerci
 
 # not working with claude
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 def test_bedrock_chat_completion_in_txn_with_llm_metadata_no_content(
     set_trace_info, exercise_model, expected_events_no_content
 ):
@@ -336,7 +339,7 @@ def test_bedrock_chat_completion_error_incorrect_access_key(
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 def test_bedrock_chat_completion_error_incorrect_access_key_no_content(
     monkeypatch,
     bedrock_server,

--- a/tests/external_botocore/test_bedrock_embeddings.py
+++ b/tests/external_botocore/test_bedrock_embeddings.py
@@ -24,8 +24,11 @@ from _test_bedrock_embeddings import (
     embedding_expected_events,
     embedding_payload_templates,
 )
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
-from conftest import BOTOCORE_VERSION
+from conftest import (  # pylint: disable=E0611
+    BOTOCORE_VERSION,
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
 from testing_support.fixtures import (  # override_application_settings,
     dt_enabled,
     override_application_settings,
@@ -141,7 +144,7 @@ def test_bedrock_embedding(set_trace_info, exercise_model, expected_events):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 def test_bedrock_embedding_no_content(set_trace_info, exercise_model, expected_events_no_content):
     @validate_custom_events(expected_events_no_content)
     @validate_custom_event_count(count=1)
@@ -237,7 +240,7 @@ def test_bedrock_embedding_error_incorrect_access_key(
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 def test_bedrock_embedding_error_incorrect_access_key_no_content(
     monkeypatch, bedrock_server, exercise_model, set_trace_info, expected_error_events_no_content, expected_client_error
 ):

--- a/tests/external_botocore/test_bedrock_embeddings.py
+++ b/tests/external_botocore/test_bedrock_embeddings.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 from io import BytesIO
 
@@ -88,8 +89,24 @@ def expected_events(model_id):
 
 
 @pytest.fixture(scope="module")
+def expected_events_no_content(model_id):
+    events = copy.deepcopy(embedding_expected_events[model_id])
+    for event in events:
+        del event[1]["input"]
+    return events
+
+
+@pytest.fixture(scope="module")
 def expected_error_events(model_id):
     return embedding_expected_error_events[model_id]
+
+
+@pytest.fixture(scope="module")
+def expected_error_events_no_content(model_id):
+    events = copy.deepcopy(embedding_expected_error_events[model_id])
+    for event in events:
+        del event[1]["input"]
+    return events
 
 
 @pytest.fixture(scope="module")
@@ -100,6 +117,33 @@ def expected_client_error(model_id):
 @reset_core_stats_engine()
 def test_bedrock_embedding(set_trace_info, exercise_model, expected_events):
     @validate_custom_events(expected_events)
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            ("Supportability/Python/ML/Bedrock/%s" % BOTOCORE_VERSION, 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        exercise_model(prompt="This is an embedding test.")
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+def test_bedrock_embedding_no_content(set_trace_info, exercise_model, expected_events_no_content):
+    @validate_custom_events(expected_events_no_content)
     @validate_custom_event_count(count=1)
     @validate_transaction_metrics(
         name="test_bedrock_embedding",
@@ -167,6 +211,37 @@ def test_bedrock_embedding_error_incorrect_access_key(
     monkeypatch, bedrock_server, exercise_model, set_trace_info, expected_error_events, expected_client_error
 ):
     @validate_custom_events(expected_error_events)
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": expected_client_error,
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):  # not sure where this exception actually comes from
+            set_trace_info()
+            exercise_model(prompt="Invalid Token", temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+def test_bedrock_embedding_error_incorrect_access_key_no_content(
+    monkeypatch, bedrock_server, exercise_model, set_trace_info, expected_error_events_no_content, expected_client_error
+):
+    @validate_custom_events(expected_error_events_no_content)
     @validate_error_trace_attributes(
         _client_error_name,
         exact_attrs={

--- a/tests/mlmodel_langchain/conftest.py
+++ b/tests/mlmodel_langchain/conftest.py
@@ -30,7 +30,7 @@ from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=
 from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
     collector_agent_registration_fixture,
     collector_available_fixture,
-    override_application_settings
+    override_application_settings,
 )
 
 from newrelic.api.transaction import current_transaction
@@ -59,6 +59,9 @@ OPENAI_AUDIT_LOG_CONTENTS = {}
 RECORDED_HEADERS = set(["x-request-id", "content-type"])
 
 disabled_ai_monitoring_settings = override_application_settings({"ai_monitoring.enabled": False})
+disabled_ai_monitoring_record_content_settings = override_application_settings(
+    {"ai_monitoring.record_content.enabled": False}
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/mlmodel_langchain/test_chain.py
+++ b/tests/mlmodel_langchain/test_chain.py
@@ -19,7 +19,10 @@ import uuid
 import langchain
 import openai
 import pytest
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
 from langchain.chains.openai_functions import (
     create_structured_output_chain,
     create_structured_output_runnable,
@@ -1242,7 +1245,7 @@ def test_langchain_chain_no_content(
     expected_events,
 ):
     @reset_core_stats_engine()
-    @override_application_settings({"ai_monitoring.record_content.enabled": False})
+    @disabled_ai_monitoring_record_content_settings
     @validate_custom_events(expected_events)
     # 3 langchain events and 5 openai events.
     @validate_custom_event_count(count=8)
@@ -1551,7 +1554,7 @@ def test_langchain_chain_error_in_langchain_no_content(
     expected_error,
 ):
     @reset_core_stats_engine()
-    @override_application_settings({"ai_monitoring.record_content.enabled": False})
+    @disabled_ai_monitoring_record_content_settings
     @validate_transaction_error_event_count(1)
     @validate_error_trace_attributes(
         callable_name(expected_error),
@@ -1665,6 +1668,49 @@ def test_langchain_chain_ai_monitoring_disabled(
 )
 @background_task()
 def test_async_langchain_chain_list_response(
+    set_trace_info, comma_separated_list_output_parser, chat_openai_client, loop
+):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    template = """You are a helpful assistant who generates comma separated lists.
+    A user will pass in a category, and you should generate 5 objects in that category in a comma separated list.
+    ONLY return a comma separated list, and nothing more."""
+    human_template = "{text}"
+
+    chat_prompt = ChatPromptTemplate.from_messages(
+        [
+            ("system", template),
+            ("human", human_template),
+        ]
+    )
+    chain = chat_prompt | chat_openai_client | comma_separated_list_output_parser
+
+    loop.run_until_complete(
+        chain.ainvoke(
+            {"text": "colors"},
+            config={
+                "metadata": {"id": "123", "message_ids": ["message-id-0", "message-id-1"]},
+            },
+        )
+    )
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+@validate_custom_events(events_sans_content(chat_completion_recorded_events_list_response))
+@validate_custom_event_count(count=7)
+@validate_transaction_metrics(
+    name="test_chain:test_async_langchain_chain_list_response_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@background_task()
+def test_async_langchain_chain_list_response_no_content(
     set_trace_info, comma_separated_list_output_parser, chat_openai_client, loop
 ):
     set_trace_info()
@@ -2072,6 +2118,81 @@ def test_async_langchain_chain_error_in_lanchain(
     @validate_custom_event_count(count=2)
     @validate_transaction_metrics(
         name="test_chain:test_async_langchain_chain_error_in_lanchain.<locals>._test",
+        custom_metrics=[
+            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ],
+        background_task=True,
+    )
+    @background_task()
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        runnable = create_function(json_schema, chat_openai_client, prompt)
+
+        with pytest.raises(expected_error):
+            loop.run_until_complete(getattr(runnable, call_function)(*call_function_args, **call_function_kwargs))
+
+    _test()
+
+
+@pytest.mark.parametrize(
+    "create_function,call_function,call_function_args,call_function_kwargs,expected_events,expected_error",
+    (
+        pytest.param(
+            create_structured_output_runnable,
+            "ainvoke",
+            ({"no-exist": "Sally is 13"},),
+            {
+                "config": {
+                    "metadata": {"id": "123", "message_ids": ["message-id-0", "message-id-1"]},
+                }
+            },
+            events_sans_content(chat_completion_recorded_events_invoke_langchain_error),
+            KeyError,
+            id="runnable_chain.ainvoke",
+        ),
+        pytest.param(
+            create_structured_output_chain,
+            "ainvoke",
+            ({"no-exist": "Sally is 13"},),
+            {
+                "config": {
+                    "metadata": {"id": "123", "message_ids": ["message-id-0", "message-id-1"]},
+                },
+                "return_only_outputs": True,
+            },
+            events_sans_content(chat_completion_recorded_events_invoke_langchain_error),
+            ValueError,
+            id="chain.ainvoke",
+        ),
+    ),
+)
+def test_async_langchain_chain_error_in_lanchain_no_content(
+    set_trace_info,
+    chat_openai_client,
+    json_schema,
+    prompt,
+    create_function,
+    call_function,
+    call_function_args,
+    call_function_kwargs,
+    expected_events,
+    expected_error,
+    loop,
+):
+    @reset_core_stats_engine()
+    @disabled_ai_monitoring_record_content_settings
+    @validate_transaction_error_event_count(1)
+    @validate_error_trace_attributes(
+        callable_name(expected_error),
+    )
+    @validate_custom_events(expected_events)
+    @validate_custom_event_count(count=2)
+    @validate_transaction_metrics(
+        name="test_chain:test_async_langchain_chain_error_in_lanchain_no_content.<locals>._test",
         custom_metrics=[
             ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
         ],

--- a/tests/mlmodel_langchain/test_tool.py
+++ b/tests/mlmodel_langchain/test_tool.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import uuid
 
 import langchain
 import pydantic
 import pytest
+from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from langchain.tools import tool
 from mock import patch
 from testing_support.fixtures import (
@@ -37,7 +39,6 @@ from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
 )
 
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
 
@@ -60,6 +61,15 @@ def multi_arg_tool():
         return first_num + second_num
 
     return _multi_arg_tool
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        del _event[1]["input"]
+        if "output" in _event[1]:
+            del _event[1]["output"]
+    return new_event
 
 
 single_arg_tool_recorded_events = [
@@ -105,6 +115,26 @@ def test_langchain_single_arg_tool(set_trace_info, single_arg_tool):
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(single_arg_tool_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_tool:test_langchain_single_arg_tool_no_content",
+    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
+    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_langchain_single_arg_tool_no_content(set_trace_info, single_arg_tool):
+    set_trace_info()
+    single_arg_tool.run({"query": "Python Agent"})
+
+
+@reset_core_stats_engine()
 @validate_custom_events(single_arg_tool_recorded_events)
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
@@ -119,6 +149,26 @@ def test_langchain_single_arg_tool(set_trace_info, single_arg_tool):
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_langchain_single_arg_tool_async(set_trace_info, single_arg_tool, loop):
+    set_trace_info()
+    loop.run_until_complete(single_arg_tool.arun({"query": "Python Agent"}))
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(single_arg_tool_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_tool:test_langchain_single_arg_tool_async_no_content",
+    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
+    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_langchain_single_arg_tool_async_no_content(set_trace_info, single_arg_tool, loop):
     set_trace_info()
     loop.run_until_complete(single_arg_tool.arun({"query": "Python Agent"}))
 
@@ -255,6 +305,38 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_transaction_error_event_count(1)
+@validate_error_trace_attributes(
+    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {},
+    },
+)
+@validate_custom_events(events_sans_content(multi_arg_error_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_tool:test_langchain_error_in_run_no_content",
+    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
+    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@background_task()
+def test_langchain_error_in_run_no_content(set_trace_info, multi_arg_tool):
+    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+        set_trace_info()
+        # Only one argument is provided while the tool expects two to create an error
+        multi_arg_tool.run(
+            {"first_num": 53}, tags=["test_tags", "python"], metadata={"test_run": True, "test": "langchain"}
+        )
+
+
+@reset_core_stats_engine()
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
     callable_name(pydantic.v1.error_wrappers.ValidationError),
@@ -277,6 +359,40 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 )
 @background_task()
 def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
+    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+        set_trace_info()
+        # Only one argument is provided while the tool expects two to create an error
+        loop.run_until_complete(
+            multi_arg_tool.arun(
+                {"first_num": 53}, tags=["test_tags", "python"], metadata={"test_run": True, "test": "langchain"}
+            )
+        )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_transaction_error_event_count(1)
+@validate_error_trace_attributes(
+    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {},
+    },
+)
+@validate_custom_events(events_sans_content(multi_arg_error_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_tool:test_langchain_error_in_run_async_no_content",
+    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
+    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@background_task()
+def test_langchain_error_in_run_async_no_content(set_trace_info, multi_arg_tool, loop):
     with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
         set_trace_info()
         # Only one argument is provided while the tool expects two to create an error

--- a/tests/mlmodel_langchain/test_tool.py
+++ b/tests/mlmodel_langchain/test_tool.py
@@ -19,7 +19,10 @@ import uuid
 import langchain
 import pydantic
 import pytest
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
 from langchain.tools import tool
 from mock import patch
 from testing_support.fixtures import (
@@ -115,7 +118,7 @@ def test_langchain_single_arg_tool(set_trace_info, single_arg_tool):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(single_arg_tool_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
@@ -154,7 +157,7 @@ def test_langchain_single_arg_tool_async(set_trace_info, single_arg_tool, loop):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(single_arg_tool_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
@@ -305,7 +308,7 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
     callable_name(pydantic.v1.error_wrappers.ValidationError),
@@ -370,7 +373,7 @@ def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
     callable_name(pydantic.v1.error_wrappers.ValidationError),

--- a/tests/mlmodel_langchain/test_vectorstore.py
+++ b/tests/mlmodel_langchain/test_vectorstore.py
@@ -17,11 +17,13 @@ import os
 
 import langchain
 import pytest
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_community.vectorstores.faiss import FAISS
 from testing_support.fixtures import (
-    override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
     validate_custom_event_count,
@@ -157,7 +159,7 @@ def test_pdf_pagesplitter_vectorstore_in_txn(set_trace_info, embedding_openai_cl
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(vectorstore_recorded_events))
 # Two OpenAI LlmEmbedded, two LangChain LlmVectorSearch
 @validate_custom_event_count(count=4)
@@ -248,7 +250,7 @@ def test_async_pdf_pagesplitter_vectorstore_in_txn(loop, set_trace_info, embeddi
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(vectorstore_recorded_events))
 # Two OpenAI LlmEmbedded, two LangChain LlmVectorSearch
 @validate_custom_event_count(count=4)
@@ -360,7 +362,7 @@ def test_vectorstore_error_no_query(set_trace_info, embedding_openai_client):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(TypeError),
     required_params={"user": ["vector_store_id"], "intrinsic": [], "agent": []},
@@ -416,7 +418,7 @@ def test_async_vectorstore_error_no_query(loop, set_trace_info, embedding_openai
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(TypeError),
     required_params={"user": ["vector_store_id"], "intrinsic": [], "agent": []},

--- a/tests/mlmodel_langchain/test_vectorstore.py
+++ b/tests/mlmodel_langchain/test_vectorstore.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 
-import pytest
 import langchain
+import pytest
+from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_community.vectorstores.faiss import FAISS
 from testing_support.fixtures import (
+    override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
     validate_custom_event_count,
@@ -30,10 +33,20 @@ from testing_support.validators.validate_error_trace_attributes import (
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
 )
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "request.query" in _event[1]:
+            del _event[1]["request.query"]
+        if "page_content" in _event[1]:
+            del _event[1]["page_content"]
+    return new_event
 
 
 vectorstore_recorded_events = [
@@ -144,6 +157,35 @@ def test_pdf_pagesplitter_vectorstore_in_txn(set_trace_info, embedding_openai_cl
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(vectorstore_recorded_events))
+# Two OpenAI LlmEmbedded, two LangChain LlmVectorSearch
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_vectorstore:test_pdf_pagesplitter_vectorstore_in_txn_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_pdf_pagesplitter_vectorstore_in_txn_no_content(set_trace_info, embedding_openai_client):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    script_dir = os.path.dirname(__file__)
+    loader = PyPDFLoader(os.path.join(script_dir, "hello.pdf"))
+    docs = loader.load()
+
+    faiss_index = FAISS.from_documents(docs, embedding_openai_client)
+    docs = faiss_index.similarity_search("Complete this sentence: Hello", k=1)
+    assert "Hello world" in docs[0].page_content
+
+
+@reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 def test_pdf_pagesplitter_vectorstore_outside_txn(set_trace_info, embedding_openai_client):
     set_trace_info()
@@ -187,6 +229,39 @@ def test_pdf_pagesplitter_vectorstore_ai_monitoring_disabled(set_trace_info, emb
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_async_pdf_pagesplitter_vectorstore_in_txn(loop, set_trace_info, embedding_openai_client):
+    async def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        script_dir = os.path.dirname(__file__)
+        loader = PyPDFLoader(os.path.join(script_dir, "hello.pdf"))
+        docs = loader.load()
+
+        faiss_index = await FAISS.afrom_documents(docs, embedding_openai_client)
+        docs = await faiss_index.asimilarity_search("Complete this sentence: Hello", k=1)
+        return docs
+
+    docs = loop.run_until_complete(_test())
+    assert "Hello world" in docs[0].page_content
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(vectorstore_recorded_events))
+# Two OpenAI LlmEmbedded, two LangChain LlmVectorSearch
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_vectorstore:test_async_pdf_pagesplitter_vectorstore_in_txn_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_async_pdf_pagesplitter_vectorstore_in_txn_no_content(loop, set_trace_info, embedding_openai_client):
     async def _test():
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
@@ -285,6 +360,32 @@ def test_vectorstore_error_no_query(set_trace_info, embedding_openai_client):
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_error_trace_attributes(
+    callable_name(TypeError),
+    required_params={"user": ["vector_store_id"], "intrinsic": [], "agent": []},
+)
+@validate_custom_events(events_sans_content(vectorstore_error_events))
+@validate_transaction_metrics(
+    name="test_vectorstore:test_vectorstore_error_no_query_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@background_task()
+def test_vectorstore_error_no_query_no_content(set_trace_info, embedding_openai_client):
+    with pytest.raises(TypeError):
+        set_trace_info()
+        script_dir = os.path.dirname(__file__)
+        loader = PyPDFLoader(os.path.join(script_dir, "hello.pdf"))
+        docs = loader.load()
+
+        faiss_index = FAISS.from_documents(docs, embedding_openai_client)
+        faiss_index.similarity_search(k=1)
+
+
+@reset_core_stats_engine()
 @validate_error_trace_attributes(
     callable_name(TypeError),
     required_params={"user": ["vector_store_id"], "intrinsic": [], "agent": []},
@@ -299,6 +400,37 @@ def test_vectorstore_error_no_query(set_trace_info, embedding_openai_client):
 )
 @background_task()
 def test_async_vectorstore_error_no_query(loop, set_trace_info, embedding_openai_client):
+    async def _test():
+        set_trace_info()
+
+        script_dir = os.path.dirname(__file__)
+        loader = PyPDFLoader(os.path.join(script_dir, "hello.pdf"))
+        docs = loader.load()
+
+        faiss_index = await FAISS.afrom_documents(docs, embedding_openai_client)
+        docs = await faiss_index.asimilarity_search(k=1)
+        return docs
+
+    with pytest.raises(TypeError):
+        loop.run_until_complete(_test())
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_error_trace_attributes(
+    callable_name(TypeError),
+    required_params={"user": ["vector_store_id"], "intrinsic": [], "agent": []},
+)
+@validate_custom_events(events_sans_content(vectorstore_error_events))
+@validate_transaction_metrics(
+    name="test_vectorstore:test_async_vectorstore_error_no_query_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+    ],
+    background_task=True,
+)
+@background_task()
+def test_async_vectorstore_error_no_query_no_content(loop, set_trace_info, embedding_openai_client):
     async def _test():
         set_trace_info()
 

--- a/tests/mlmodel_openai/conftest.py
+++ b/tests/mlmodel_openai/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import json
 import os
 
@@ -84,6 +85,19 @@ RECORDED_HEADERS = set(["x-request-id", "content-type"])
 
 disabled_ai_monitoring_settings = override_application_settings({"ai_monitoring.enabled": False})
 disabled_ai_monitoring_streaming_settings = override_application_settings({"ai_monitoring.streaming.enabled": False})
+disabled_ai_monitoring_record_content_settings = override_application_settings(
+    {"ai_monitoring.record_content.enabled": False}
+)
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "input" in _event[1]:
+            del _event[1]["input"]
+        elif "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
 
 
 @pytest.fixture(scope="session")

--- a/tests/mlmodel_openai/test_chat_completion.py
+++ b/tests/mlmodel_openai/test_chat_completion.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from testing_support.fixtures import (
@@ -27,6 +29,15 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -152,6 +163,31 @@ chat_completion_recorded_events = [
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    openai.ChatCompletion.create(
+        model="gpt-3.5-turbo", messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+# One summary event, one system message, one user message, and one response message from the assistant
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_chat_completion:test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content(set_trace_info):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     add_custom_attribute("llm.foo", "bar")
@@ -347,6 +383,34 @@ def test_openai_chat_completion_async_no_llm_metadata(loop, set_trace_info):
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    loop.run_until_complete(
+        openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo", messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100
+        )
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion:test_openai_chat_completion_async_with_llm_metadata_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_async_with_llm_metadata_no_content(loop, set_trace_info):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     add_custom_attribute("llm.foo", "bar")

--- a/tests/mlmodel_openai/test_chat_completion.py
+++ b/tests/mlmodel_openai/test_chat_completion.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    events_sans_content,
+)
 from testing_support.fixtures import (
     override_application_settings,
     reset_core_stats_engine,
@@ -29,15 +31,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -174,7 +167,7 @@ def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 # One summary event, one system message, one user message, and one response message from the assistant
 @validate_custom_event_count(count=4)
@@ -396,7 +389,7 @@ def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_chat_completion_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_error.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 import pytest
 from testing_support.fixtures import (
     dt_enabled,
+    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -31,6 +34,15 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -129,6 +141,45 @@ expected_events_on_no_model_error = [
 @validate_custom_event_count(count=3)
 @background_task()
 def test_chat_completion_invalid_request_error_no_model(set_trace_info):
+    with pytest.raises(openai.InvalidRequestError):
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        openai.ChatCompletion.create(
+            # no model provided,
+            messages=_test_openai_chat_completion_messages,
+            temperature=0.7,
+            max_tokens=100,
+        )
+
+
+@dt_enabled
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@reset_core_stats_engine()
+@validate_error_trace_attributes(
+    callable_name(openai.InvalidRequestError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "error.param": "engine",
+        },
+    },
+)
+@validate_span_events(
+    exact_agents={
+        "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.chat_completion.ChatCompletion'>",
+    }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_no_model_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
+@validate_custom_events(events_sans_content(expected_events_on_no_model_error))
+@validate_custom_event_count(count=3)
+@background_task()
+def test_chat_completion_invalid_request_error_no_model_no_content(set_trace_info):
     with pytest.raises(openai.InvalidRequestError):
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
@@ -435,6 +486,47 @@ def test_chat_completion_wrong_api_key_error(monkeypatch, set_trace_info):
 @validate_custom_event_count(count=3)
 @background_task()
 def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_info):
+    with pytest.raises(openai.InvalidRequestError):
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        loop.run_until_complete(
+            openai.ChatCompletion.acreate(
+                # no model provided,
+                messages=_test_openai_chat_completion_messages,
+                temperature=0.7,
+                max_tokens=100,
+            )
+        )
+
+
+@dt_enabled
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_error_trace_attributes(
+    callable_name(openai.InvalidRequestError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "error.param": "engine",
+        },
+    },
+)
+@validate_span_events(
+    exact_agents={
+        "error.message": "Must provide an 'engine' or 'model' parameter to create a <class 'openai.api_resources.chat_completion.ChatCompletion'>",
+    }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_error:test_chat_completion_invalid_request_error_no_model_async_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    background_task=True,
+)
+@validate_custom_events(events_sans_content(expected_events_on_no_model_error))
+@validate_custom_event_count(count=3)
+@background_task()
+def test_chat_completion_invalid_request_error_no_model_async_no_content(loop, set_trace_info):
     with pytest.raises(openai.InvalidRequestError):
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")

--- a/tests/mlmodel_openai/test_chat_completion_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_error.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -34,15 +33,6 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -153,7 +143,7 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info):
 
 
 @dt_enabled
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @reset_core_stats_engine()
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
@@ -501,7 +491,7 @@ def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_in
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_chat_completion_error_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_error_v1.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -34,15 +32,6 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -146,7 +135,7 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info, sync_ope
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(TypeError),
     exact_attrs={
@@ -214,7 +203,7 @@ def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_in
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(TypeError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_chat_completion_stream.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 from conftest import (  # pylint: disable=E0611
     disabled_ai_monitoring_settings,
     disabled_ai_monitoring_streaming_settings,
 )
 from testing_support.fixtures import (
+    override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
     validate_custom_event_count,
@@ -29,6 +32,15 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -147,6 +159,37 @@ chat_completion_recorded_events = [
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    generator = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=_test_openai_chat_completion_messages,
+        temperature=0.7,
+        max_tokens=100,
+        stream=True,
+    )
+    for resp in generator:
+        assert resp
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+# One summary event, one system message, one user message, and one response message from the assistant
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_chat_completion_stream:test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content(set_trace_info):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     add_custom_attribute("llm.foo", "bar")
@@ -362,10 +405,6 @@ def test_openai_chat_completion_async_no_llm_metadata(loop, set_trace_info):
     "test_chat_completion_stream:test_openai_chat_completion_async_with_llm_metadata",
     scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
-    background_task=True,
-)
-@validate_transaction_metrics(
-    name="test_chat_completion_stream:test_openai_chat_completion_async_with_llm_metadata",
     custom_metrics=[
         ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -374,6 +413,41 @@ def test_openai_chat_completion_async_no_llm_metadata(loop, set_trace_info):
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    async def consumer():
+        generator = await openai.ChatCompletion.acreate(
+            model="gpt-3.5-turbo",
+            messages=_test_openai_chat_completion_messages,
+            temperature=0.7,
+            max_tokens=100,
+            stream=True,
+        )
+        async for resp in generator:
+            assert resp
+
+    loop.run_until_complete(consumer())
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion_stream:test_openai_chat_completion_async_with_llm_metadata_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_async_with_llm_metadata_no_content(loop, set_trace_info):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     add_custom_attribute("llm.foo", "bar")

--- a/tests/mlmodel_openai/test_chat_completion_stream.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 
 import openai
 from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     disabled_ai_monitoring_streaming_settings,
+    events_sans_content,
 )
 from testing_support.fixtures import (
-    override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
     validate_custom_event_count,
@@ -32,15 +32,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -176,7 +167,7 @@ def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 # One summary event, one system message, one user message, and one response message from the assistant
 @validate_custom_event_count(count=4)
@@ -433,7 +424,7 @@ def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_chat_completion_stream_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_error.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -34,15 +33,6 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -155,7 +145,7 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info):
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
     exact_attrs={
@@ -510,7 +500,7 @@ def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_in
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -34,15 +33,6 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -148,7 +138,7 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info, sync_ope
 
 
 @dt_enabled
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @reset_core_stats_engine()
 @validate_error_trace_attributes(
     callable_name(TypeError),
@@ -224,7 +214,7 @@ def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_in
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(TypeError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 import pytest
 from testing_support.fixtures import (
     dt_enabled,
+    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -31,6 +34,15 @@ from testing_support.validators.validate_transaction_metrics import (
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
 from newrelic.common.object_names import callable_name
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 _test_openai_chat_completion_messages = (
     {"role": "system", "content": "You are a scientist."},
@@ -136,6 +148,42 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info, sync_ope
 
 
 @dt_enabled
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@reset_core_stats_engine()
+@validate_error_trace_attributes(
+    callable_name(TypeError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {},
+    },
+)
+@validate_span_events(
+    exact_agents={
+        "error.message": "Missing required arguments; Expected either ('messages' and 'model') or ('messages', 'model' and 'stream') arguments to be given",
+    }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_stream_error_v1:test_chat_completion_invalid_request_error_no_model_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
+@validate_custom_events(events_sans_content(expected_events_on_no_model_error))
+@validate_custom_event_count(count=3)
+@background_task()
+def test_chat_completion_invalid_request_error_no_model_no_content(set_trace_info, sync_openai_client):
+    with pytest.raises(TypeError):
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        generator = sync_openai_client.chat.completions.create(
+            messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100, stream=True
+        )
+        for resp in generator:
+            assert resp
+
+
+@dt_enabled
 @reset_core_stats_engine()
 @validate_error_trace_attributes(
     callable_name(TypeError),
@@ -160,6 +208,46 @@ def test_chat_completion_invalid_request_error_no_model(set_trace_info, sync_ope
 @validate_custom_event_count(count=3)
 @background_task()
 def test_chat_completion_invalid_request_error_no_model_async(loop, set_trace_info, async_openai_client):
+    with pytest.raises(TypeError):
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+
+        async def consumer():
+            generator = await async_openai_client.chat.completions.create(
+                messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100, stream=True
+            )
+            async for resp in generator:
+                assert resp
+
+        loop.run_until_complete(consumer())
+
+
+@dt_enabled
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_error_trace_attributes(
+    callable_name(TypeError),
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {},
+    },
+)
+@validate_span_events(
+    exact_agents={
+        "error.message": "Missing required arguments; Expected either ('messages' and 'model') or ('messages', 'model' and 'stream') arguments to be given",
+    }
+)
+@validate_transaction_metrics(
+    "test_chat_completion_stream_error_v1:test_chat_completion_invalid_request_error_no_model_async_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    background_task=True,
+)
+@validate_custom_events(events_sans_content(expected_events_on_no_model_error))
+@validate_custom_event_count(count=3)
+@background_task()
+def test_chat_completion_invalid_request_error_no_model_async_no_content(loop, set_trace_info, async_openai_client):
     with pytest.raises(TypeError):
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")

--- a/tests/mlmodel_openai/test_chat_completion_stream_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_v1.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 from conftest import (  # pylint: disable=E0611
     disabled_ai_monitoring_settings,
@@ -30,6 +32,15 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -145,6 +156,34 @@ chat_completion_recorded_events = [
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info, sync_openai_client):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    generator = sync_openai_client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=_test_openai_chat_completion_messages,
+        temperature=0.7,
+        max_tokens=100,
+        stream=True,
+    )
+    for resp in generator:
+        assert resp
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+# One summary event, one system message, one user message, and one response message from the assistant
+# @validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_chat_completion_stream_v1:test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content(set_trace_info, sync_openai_client):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     generator = sync_openai_client.chat.completions.create(
@@ -388,10 +427,6 @@ def test_openai_chat_completion_async_conversation_id_unset(loop, set_trace_info
     "test_chat_completion_stream_v1:test_openai_chat_completion_async_conversation_id_set",
     scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
-    background_task=True,
-)
-@validate_transaction_metrics(
-    name="test_chat_completion_stream_v1:test_openai_chat_completion_async_conversation_id_set",
     custom_metrics=[
         ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -400,6 +435,39 @@ def test_openai_chat_completion_async_conversation_id_unset(loop, set_trace_info
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_async_conversation_id_set(loop, set_trace_info, async_openai_client):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+
+    async def consumer():
+        generator = await async_openai_client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=_test_openai_chat_completion_messages,
+            temperature=0.7,
+            max_tokens=100,
+            stream=True,
+        )
+        async for resp in generator:
+            assert resp
+
+    loop.run_until_complete(consumer())
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion_stream_v1:test_openai_chat_completion_async_conversation_id_set_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_async_conversation_id_set_no_content(loop, set_trace_info, async_openai_client):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
 

--- a/tests/mlmodel_openai/test_chat_completion_stream_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_v1.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 
 import openai
 from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     disabled_ai_monitoring_streaming_settings,
+    events_sans_content,
 )
 from testing_support.fixtures import (
     override_application_settings,
@@ -32,15 +33,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -170,7 +162,7 @@ def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info, sy
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 # One summary event, one system message, one user message, and one response message from the assistant
 # @validate_custom_event_count(count=4)
@@ -453,7 +445,7 @@ def test_openai_chat_completion_async_conversation_id_set(loop, set_trace_info, 
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_chat_completion_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_v1.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    events_sans_content,
+)
 from testing_support.fixtures import (
     override_application_settings,
     reset_core_stats_engine,
@@ -29,15 +31,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        if "content" in _event[1]:
-            del _event[1]["content"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -167,7 +160,7 @@ def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info, sy
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 # One summary event, one system message, one user message, and one response message from the assistant
 @validate_custom_event_count(count=4)
@@ -385,7 +378,7 @@ def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info, as
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(chat_completion_recorded_events))
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_chat_completion_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_v1.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from testing_support.fixtures import (
@@ -27,6 +29,15 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        if "content" in _event[1]:
+            del _event[1]["content"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -148,6 +159,28 @@ chat_completion_recorded_events = [
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_sync_in_txn_with_llm_metadata(set_trace_info, sync_openai_client):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    sync_openai_client.chat.completions.create(
+        model="gpt-3.5-turbo", messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+# One summary event, one system message, one user message, and one response message from the assistant
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    name="test_chat_completion_v1:test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content",
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_sync_in_txn_with_llm_metadata_no_content(set_trace_info, sync_openai_client):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     sync_openai_client.chat.completions.create(
@@ -333,10 +366,6 @@ def test_openai_chat_completion_async_no_llm_metadata(loop, set_trace_info, asyn
     "test_chat_completion_v1:test_openai_chat_completion_async_with_llm_metadata",
     scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
     rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
-    background_task=True,
-)
-@validate_transaction_metrics(
-    name="test_chat_completion_v1:test_openai_chat_completion_async_with_llm_metadata",
     custom_metrics=[
         ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
     ],
@@ -345,6 +374,32 @@ def test_openai_chat_completion_async_no_llm_metadata(loop, set_trace_info, asyn
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_chat_completion_async_with_llm_metadata(loop, set_trace_info, async_openai_client):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+
+    loop.run_until_complete(
+        async_openai_client.chat.completions.create(
+            model="gpt-3.5-turbo", messages=_test_openai_chat_completion_messages, temperature=0.7, max_tokens=100
+        )
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(chat_completion_recorded_events))
+@validate_custom_event_count(count=4)
+@validate_transaction_metrics(
+    "test_chat_completion_v1:test_openai_chat_completion_async_with_llm_metadata_no_content",
+    scoped_metrics=[("Llm/completion/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/completion/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_chat_completion_async_with_llm_metadata_no_content(loop, set_trace_info, async_openai_client):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
 

--- a/tests/mlmodel_openai/test_embeddings.py
+++ b/tests/mlmodel_openai/test_embeddings.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    events_sans_content,
+)
 from testing_support.fixtures import (  # override_application_settings,
     override_application_settings,
     reset_core_stats_engine,
@@ -29,14 +31,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        del _event[1]["input"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -99,7 +93,7 @@ def test_openai_embedding_sync(set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
@@ -181,7 +175,7 @@ def test_openai_embedding_async(loop, set_trace_info):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_embeddings.py
+++ b/tests/mlmodel_openai/test_embeddings.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
 from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from testing_support.fixtures import (  # override_application_settings,
@@ -27,6 +29,14 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import add_custom_attribute
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        del _event[1]["input"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -89,6 +99,30 @@ def test_openai_embedding_sync(set_trace_info):
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(embedding_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_embeddings:test_openai_embedding_sync_no_content",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_embedding_sync_no_content(set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    openai.Embedding.create(input="This is an embedding test.", model="text-embedding-ada-002")
+
+
+@reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 def test_openai_embedding_sync_outside_txn():
     openai.Embedding.create(input="This is an embedding test.", model="text-embedding-ada-002")
@@ -136,6 +170,32 @@ def test_openai_embedding_sync_disabled_ai_monitoring_events(set_trace_info):
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_embedding_async(loop, set_trace_info):
+    set_trace_info()
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    add_custom_attribute("llm.foo", "bar")
+    add_custom_attribute("non_llm_attr", "python-agent")
+
+    loop.run_until_complete(
+        openai.Embedding.acreate(input="This is an embedding test.", model="text-embedding-ada-002")
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(embedding_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_embeddings:test_openai_embedding_async_no_content",
+    scoped_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/acreate", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_embedding_async_no_content(loop, set_trace_info):
     set_trace_info()
     add_custom_attribute("llm.conversation_id", "my-awesome-id")
     add_custom_attribute("llm.foo", "bar")

--- a/tests/mlmodel_openai/test_embeddings_error.py
+++ b/tests/mlmodel_openai/test_embeddings_error.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -33,14 +31,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        del _event[1]["input"]
-    return new_event
-
 
 # Sync tests:
 embedding_recorded_events = [
@@ -106,7 +96,7 @@ def test_embeddings_invalid_request_error_no_model(set_trace_info):
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
     exact_attrs={
@@ -364,7 +354,7 @@ def test_embeddings_invalid_request_error_no_model_async(loop, set_trace_info):
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.InvalidRequestError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_embeddings_error_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_error_v1.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import sys
 
 import openai
 import pytest
+from conftest import disabled_ai_monitoring_record_content_settings, events_sans_content
 from testing_support.fixtures import (
     dt_enabled,
-    override_application_settings,
     reset_core_stats_engine,
     validate_custom_event_count,
 )
@@ -34,14 +33,6 @@ from testing_support.validators.validate_transaction_metrics import (
 
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        del _event[1]["input"]
-    return new_event
-
 
 # Sync tests:
 no_model_events = [
@@ -102,7 +93,7 @@ def test_embeddings_invalid_request_error_no_model(set_trace_info, sync_openai_c
 
 
 @dt_enabled
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @reset_core_stats_engine()
 @validate_error_trace_attributes(
     callable_name(TypeError),
@@ -272,7 +263,7 @@ def test_embeddings_invalid_request_error_invalid_model_async(set_trace_info, as
 
 @dt_enabled
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_error_trace_attributes(
     callable_name(openai.NotFoundError),
     exact_attrs={

--- a/tests/mlmodel_openai/test_embeddings_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_v1.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-
 import openai
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
-from testing_support.fixtures import (  # override_application_settings,
+from conftest import (  # pylint: disable=E0611
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    events_sans_content,
+)
+from testing_support.fixtures import (
     override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
@@ -28,14 +30,6 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.api.background_task import background_task
-
-
-def events_sans_content(event):
-    new_event = copy.deepcopy(event)
-    for _event in new_event:
-        del _event[1]["input"]
-    return new_event
-
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -92,7 +86,7 @@ def test_openai_embedding_sync(set_trace_info, sync_openai_client):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
@@ -166,7 +160,7 @@ def test_openai_embedding_async(loop, set_trace_info, async_openai_client):
 
 
 @reset_core_stats_engine()
-@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@disabled_ai_monitoring_record_content_settings
 @validate_custom_events(events_sans_content(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(

--- a/tests/mlmodel_openai/test_embeddings_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_v1.py
@@ -12,20 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import openai
+from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from testing_support.fixtures import (  # override_application_settings,
     override_application_settings,
     reset_core_stats_engine,
-    validate_custom_event_count,
     validate_attributes,
+    validate_custom_event_count,
 )
 from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_transaction_metrics import (
     validate_transaction_metrics,
 )
 
-from conftest import disabled_ai_monitoring_settings  # pylint: disable=E0611
 from newrelic.api.background_task import background_task
+
+
+def events_sans_content(event):
+    new_event = copy.deepcopy(event)
+    for _event in new_event:
+        del _event[1]["input"]
+    return new_event
+
 
 disabled_custom_insights_settings = {"custom_insights_events.enabled": False}
 
@@ -82,6 +92,26 @@ def test_openai_embedding_sync(set_trace_info, sync_openai_client):
 
 
 @reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(embedding_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_embeddings_v1:test_openai_embedding_sync_no_content",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_embedding_sync_no_content(set_trace_info, sync_openai_client):
+    set_trace_info()
+    sync_openai_client.embeddings.create(input="This is an embedding test.", model="text-embedding-ada-002")
+
+
+@reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 def test_openai_embedding_sync_outside_txn(sync_openai_client):
     sync_openai_client.embeddings.create(input="This is an embedding test.", model="text-embedding-ada-002")
@@ -128,6 +158,29 @@ def test_openai_embedding_sync_ai_monitoring_disabled(sync_openai_client):
 @validate_attributes("agent", ["llm"])
 @background_task()
 def test_openai_embedding_async(loop, set_trace_info, async_openai_client):
+    set_trace_info()
+
+    loop.run_until_complete(
+        async_openai_client.embeddings.create(input="This is an embedding test.", model="text-embedding-ada-002")
+    )
+
+
+@reset_core_stats_engine()
+@override_application_settings({"ai_monitoring.record_content.enabled": False})
+@validate_custom_events(events_sans_content(embedding_recorded_events))
+@validate_custom_event_count(count=1)
+@validate_transaction_metrics(
+    name="test_embeddings_v1:test_openai_embedding_async_no_content",
+    scoped_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    rollup_metrics=[("Llm/embedding/OpenAI/create", 1)],
+    custom_metrics=[
+        ("Supportability/Python/ML/OpenAI/%s" % openai.__version__, 1),
+    ],
+    background_task=True,
+)
+@validate_attributes("agent", ["llm"])
+@background_task()
+def test_openai_embedding_async_no_content(loop, set_trace_info, async_openai_client):
     set_trace_info()
 
     loop.run_until_complete(


### PR DESCRIPTION
# Overview
This PR adds the `ai_monitoring.record_content.enabled` flag, which obfuscates query content's input/outputs