### PR TITLE
Add Kinetica vectorstore to Langchain

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2277,6 +2277,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "langchain_community.vectorstores.kinetica",
+        "newrelic.hooks.mlmodel_langchain",
+        "instrument_langchain_vectorstore_similarity_search",
+    )
+
+    _process_module_definition(
         "langchain_community.vectorstores.lancedb",
         "newrelic.hooks.mlmodel_langchain",
         "instrument_langchain_vectorstore_similarity_search",

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -56,6 +56,7 @@ VECTORSTORE_CLASSES = {
     "langchain_community.vectorstores.hippo": "Hippo",
     "langchain_community.vectorstores.hologres": "Hologres",
     "langchain_community.vectorstores.kdbai": "KDBAI",
+    "langchain_community.vectorstores.kinetica": "Kinetica",
     "langchain_community.vectorstores.lancedb": "LanceDB",
     "langchain_community.vectorstores.lantern": "Lantern",
     "langchain_community.vectorstores.llm_rails": "LLMRails",


### PR DESCRIPTION
# Overview
This PR adds Kinetica to the list of vectorstores instrumented in Langchain.