### PR TITLE
Fix NewRelicContextFormatter bug

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -89,10 +89,11 @@ class NewRelicContextFormatter(logging.Formatter):
         output.update(get_linking_metadata())
 
         DEFAULT_LOG_RECORD_KEYS = cls.DEFAULT_LOG_RECORD_KEYS
-        if len(record.__dict__) > len(DEFAULT_LOG_RECORD_KEYS):
-            for key in record.__dict__:
-                if key not in DEFAULT_LOG_RECORD_KEYS:
-                    output["extra." + key] = getattr(record, key)
+        # If any keys are present in record that aren't in the default,
+        # add them to the output record.
+        keys_to_add = set(record.__dict__.keys()) - DEFAULT_LOG_RECORD_KEYS
+        for key in keys_to_add:
+            output["extra." + key] = getattr(record, key)
 
         if record.exc_info:
             output.update(format_exc_info(record.exc_info))


### PR DESCRIPTION
# Overview
In v9.5.0, a bug in the NewRelicContextFormatter was introduced where "message" was added to the default set of keys to exclude. This made the default key list (default keys + 1) in length. Since the logic check was based on the length, rather than presence of certain keys, anything that had one extra key than the default would not have that extra key added to the ouput because the length would match the (default keys + 1) length.

The length check that was previously used was a bit of an odd choice. Replace this with a check for keys not in the default keys list.