### PR TITLE
Add new vectorstores to Langchain

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2229,6 +2229,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "langchain_community.vectorstores.documentdbvectorsearch",
+        "newrelic.hooks.mlmodel_langchain",
+        "instrument_langchain_vectorstore_similarity_search",
+    )
+
+    _process_module_definition(
         "langchain_community.vectorstores.elastic_vector_search",
         "newrelic.hooks.mlmodel_langchain",
         "instrument_langchain_vectorstore_similarity_search",
@@ -2266,6 +2272,12 @@ def _process_module_builtin_defaults():
 
     _process_module_definition(
         "langchain_community.vectorstores.hologres",
+        "newrelic.hooks.mlmodel_langchain",
+        "instrument_langchain_vectorstore_similarity_search",
+    )
+
+    _process_module_definition(
+        "langchain_community.vectorstores.infinispanvs",
         "newrelic.hooks.mlmodel_langchain",
         "instrument_langchain_vectorstore_similarity_search",
     )

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2229,7 +2229,7 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
-        "langchain_community.vectorstores.documentdbvectorsearch",
+        "langchain_community.vectorstores.documentdb",
         "newrelic.hooks.mlmodel_langchain",
         "instrument_langchain_vectorstore_similarity_search",
     )

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -47,6 +47,7 @@ VECTORSTORE_CLASSES = {
     "langchain_community.vectorstores.databricks_vector_search": "DatabricksVectorSearch",
     "langchain_community.vectorstores.deeplake": "DeepLake",
     "langchain_community.vectorstores.dingo": "Dingo",
+    "langchain_community.vectorstores.documentdbvectorsearch": "DocumentDBVectorSearch",
     "langchain_community.vectorstores.elastic_vector_search": "ElasticVectorSearch",
     # "langchain_community.vectorstores.elastic_vector_search": "ElasticKnnSearch", # Deprecated
     "langchain_community.vectorstores.elasticsearch": "ElasticsearchStore",
@@ -55,6 +56,7 @@ VECTORSTORE_CLASSES = {
     "langchain_community.vectorstores.hanavector": "HanaDB",
     "langchain_community.vectorstores.hippo": "Hippo",
     "langchain_community.vectorstores.hologres": "Hologres",
+    "langchain_community.vectorstores.infinispanvs": "InfinispanVS",
     "langchain_community.vectorstores.kdbai": "KDBAI",
     "langchain_community.vectorstores.kinetica": "Kinetica",
     "langchain_community.vectorstores.lancedb": "LanceDB",

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -47,7 +47,7 @@ VECTORSTORE_CLASSES = {
     "langchain_community.vectorstores.databricks_vector_search": "DatabricksVectorSearch",
     "langchain_community.vectorstores.deeplake": "DeepLake",
     "langchain_community.vectorstores.dingo": "Dingo",
-    "langchain_community.vectorstores.documentdbvectorsearch": "DocumentDBVectorSearch",
+    "langchain_community.vectorstores.documentdb": "DocumentDBVectorSearch",
     "langchain_community.vectorstores.elastic_vector_search": "ElasticVectorSearch",
     # "langchain_community.vectorstores.elastic_vector_search": "ElasticKnnSearch", # Deprecated
     "langchain_community.vectorstores.elasticsearch": "ElasticsearchStore",


### PR DESCRIPTION
# Overview
This PR adds InfinispanVS and DocumentDBVectorSearch to the list of vectorstores in Langchain
