### PR TITLE
Remove pypy310 test envs from openai & langchain

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -143,11 +143,11 @@ envlist =
     python-logger_loguru-{py37,py38,py39,py310,py311,py312,pypy310}-logurulatest,
     python-logger_loguru-py39-loguru{06,05},
     python-logger_structlog-{py37,py38,py39,py310,py311,py312,pypy310}-structloglatest,
-    python-mlmodel_openai-openai0-{py37,py38,py39,py310,py311,py312,pypy310},
+    python-mlmodel_openai-openai0-{py37,py38,py39,py310,py311,py312},
     python-mlmodel_openai-openai107-py312,
-    python-mlmodel_openai-openailatest-{py37,py38,py39,py310,py311,py312,pypy310},
+    python-mlmodel_openai-openailatest-{py37,py38,py39,py310,py311,py312},
     ; langchain dependency faiss-cpu isn't compatible with 3.12 yet.
-    python-mlmodel_langchain-{py38,py39,py310,py311,pypy310},
+    python-mlmodel_langchain-{py38,py39,py310,py311},
     python-mlmodel_sklearn-{py37}-scikitlearn0101,
     python-mlmodel_sklearn-{py38,py39,py310,py311,py312}-scikitlearnlatest,
     python-template_genshi-{py27,py37,py38,py39,py310,py311,py312}-genshilatest,
@@ -401,7 +401,7 @@ commands =
 allowlist_externals={toxinidir}/.github/scripts/*
 
 install_command=
-    {toxinidir}/.github/scripts/retry.sh 3 pip install {opts} {packages}
+    pip install {opts} {packages}
 
 extras =
     agent_streaming: infinite-tracing

--- a/tox.ini
+++ b/tox.ini
@@ -401,7 +401,7 @@ commands =
 allowlist_externals={toxinidir}/.github/scripts/*
 
 install_command=
-    pip install {opts} {packages}
+    {toxinidir}/.github/scripts/retry.sh 3 pip install {opts} {packages}
 
 extras =
     agent_streaming: infinite-tracing


### PR DESCRIPTION
Neither langchain nor openai list support for pypy so do not run tests for them on a pypy env.