### PR TITLE
Test embedding streaming openai v1

### DIFF
--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -38,10 +38,14 @@ _logger = logging.getLogger(__name__)
 
 
 def wrap_embedding_sync(wrapped, instance, args, kwargs):
+    breakpoint()
     transaction = current_transaction()
-    if not transaction or kwargs.get("stream", False):
+    if (
+        not transaction
+        or kwargs.get("stream", False)
+        or (kwargs.get("extra_headers") or {}).get("X-Stainless-Raw-Response") == "stream"
+    ):
         return wrapped(*args, **kwargs)
-
     settings = transaction.settings if transaction.settings is not None else global_settings()
     if not settings.ai_monitoring.enabled:
         return wrapped(*args, **kwargs)

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -38,7 +38,6 @@ _logger = logging.getLogger(__name__)
 
 
 def wrap_embedding_sync(wrapped, instance, args, kwargs):
-    breakpoint()
     transaction = current_transaction()
     if (
         not transaction

--- a/tests/mlmodel_openai/conftest.py
+++ b/tests/mlmodel_openai/conftest.py
@@ -61,6 +61,7 @@ if get_openai_version() < (1, 0):
         "test_embeddings_error_v1.py",
         "test_chat_completion_stream_v1.py",
         "test_chat_completion_stream_error_v1.py",
+        "test_embeddings_stream_v1.py",
     ]
 else:
     collect_ignore = [
@@ -70,6 +71,7 @@ else:
         "test_chat_completion_error.py",
         "test_chat_completion_stream.py",
         "test_chat_completion_stream_error.py",
+        "test_embeddings_stream.py",
     ]
 
 

--- a/tests/mlmodel_openai/conftest.py
+++ b/tests/mlmodel_openai/conftest.py
@@ -71,7 +71,6 @@ else:
         "test_chat_completion_error.py",
         "test_chat_completion_stream.py",
         "test_chat_completion_stream_error.py",
-        "test_embeddings_stream.py",
     ]
 
 

--- a/tests/mlmodel_openai/test_embeddings_stream_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_stream_v1.py
@@ -1,0 +1,65 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from testing_support.fixtures import (
+    reset_core_stats_engine,
+    validate_custom_event_count,
+)
+
+from newrelic.api.background_task import background_task
+
+
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+@background_task()
+def test_openai_embedding_sync(set_trace_info, sync_openai_stream_client):
+    """
+    Does not instrument streamed embeddings.
+    """
+    set_trace_info()
+    with sync_openai_stream_client.embeddings.create(
+        input="This is an embedding test.", model="text-embedding-ada-002"
+    ) as response:
+        for resp in response.iter_lines():
+            assert resp
+
+
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+@background_task()
+def test_openai_embedding_async(loop, set_trace_info, async_openai_stream_client):
+    """
+    Does not instrumenting streamed embeddings.
+    """
+    set_trace_info()
+
+    async def test():
+        async with async_openai_stream_client.embeddings.create(
+            input="This is an embedding test.", model="text-embedding-ada-002"
+        ) as response:
+            async for resp in response.iter_lines():
+                assert resp
+
+    loop.run_until_complete(test())
+
+
+@pytest.fixture
+def sync_openai_stream_client(sync_openai_client):
+    return sync_openai_client.with_streaming_response
+
+
+@pytest.fixture
+def async_openai_stream_client(async_openai_client):
+    return async_openai_client.with_streaming_response


### PR DESCRIPTION
# Overview
Add early exit condition to not wrap embedding streaming in openai v1. It appears that streaming for embeddings isn't support in openai v0 though I'm keeping the early exit condition for that in place just in case.

Note no mocked response was added specifically for streamed embeddings. This is because the response in streamed vs unstreamed is the same format, it just sends the data in chunks instead of all at once. In other words: the non-streamed mock response will also work when mocking streaming mode.