### PR TITLE
Fix openai streaming wrong span bug

### DIFF
--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -746,6 +746,7 @@ def _record_stream_chunk(self, return_val):
 
 def _record_events_on_stop_iteration(self, transaction):
     if hasattr(self, "_nr_ft"):
+        linking_metadata = get_trace_linking_metadata()
         self._nr_ft.__exit__(None, None, None)
         try:
             openai_attrs = getattr(self, "_nr_openai_attrs", {})
@@ -755,7 +756,6 @@ def _record_events_on_stop_iteration(self, transaction):
                 return
 
             completion_id = str(uuid.uuid4())
-            linking_metadata = get_trace_linking_metadata()
             response_headers = openai_attrs.get("response_headers") or {}
             _record_completion_success(
                 transaction, linking_metadata, completion_id, openai_attrs, self._nr_ft, response_headers, None


### PR DESCRIPTION
# Overview
To reproduce:
```
import newrelic.agent


@newrelic.agent.background_task()
def streamingOpenAI(prompt):
    import openai

    print(f'prompt with openai: {prompt}')

    response = openai.chat.completions.create(
        model='gpt-3.5-turbo',
        messages=[
            {'role': 'user', 'content': prompt}
        ],
        temperature=0,
        stream=True,
    )

    message = ""
    i = 1
    for chunk in response:
        if 'choices' in chunk:
            i+=1
            for choice in chunk['choices']:
                if 'delta' in choice and 'content' in choice['delta']:
                    message += choice['delta']['content']

    print(f'output ({i}): {message}\n\n')

if __name__ == "__main__":
    # Enable New Relic Python agent
    newrelic.agent.initialize('newrelic.ini')
    newrelic.agent.register_application(timeout=10)

    prompt = "What is 2 + 2?"

    streamingOpenAI(prompt)
    # Allow the New Relic agent to send final messages as part of shutdown
    # The agent by default can send data up to a minute later
    newrelic.agent.shutdown_agent(60)

    print("Agent run finished!")

```
When you click on the AI details view of the openai span openai create, previously the details would error and not show up. After this fix they do.