### PR TITLE
Add NEW_RELIC_K8S_OPERATOR_ENABLED

### DIFF
--- a/newrelic/bootstrap/sitecustomize.py
+++ b/newrelic/bootstrap/sitecustomize.py
@@ -121,8 +121,9 @@ python_version_matches = expected_python_version == actual_python_version
 
 log_message("python_prefix_matches = %r", python_prefix_matches)
 log_message("python_version_matches = %r", python_version_matches)
+k8s_operator_enabled = os.environ.get("NEW_RELIC_K8S_OPERATOR_ENABLED", False)
 
-if python_prefix_matches and python_version_matches:
+if k8s_operator_enabled or (python_prefix_matches and python_version_matches):
     # We also need to skip agent initialisation if neither the license
     # key or config file environment variables are set. We do this as
     # some people like to use a common startup script which always uses

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -4363,24 +4363,9 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
-        "celery.execute.trace",
-        "newrelic.hooks.application_celery",
-        "instrument_celery_execute_trace",
-    )
-    _process_module_definition(
-        "celery.task.trace",
-        "newrelic.hooks.application_celery",
-        "instrument_celery_execute_trace",
-    )
-    _process_module_definition(
         "celery.app.base",
         "newrelic.hooks.application_celery",
         "instrument_celery_app_base",
-    )
-    _process_module_definition(
-        "celery.app.trace",
-        "newrelic.hooks.application_celery",
-        "instrument_celery_execute_trace",
     )
     _process_module_definition("billiard.pool", "newrelic.hooks.application_celery", "instrument_billiard_pool")
 

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -564,6 +564,7 @@ def _process_configuration(section):
     _process_setting(section, "ai_monitoring.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.record_content.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.streaming.enabled", "getboolean", None)
+    _process_setting(section, "k8s_operator.enabled", "getboolean", None)
     _process_setting(section, "package_reporting.enabled", "getboolean", None)
 
 

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -162,6 +162,10 @@ class AIMonitoringRecordContentSettings(Settings):
     pass
 
 
+class K8sOperatorSettings(Settings):
+    pass
+
+
 class PackageReportingSettings(Settings):
     pass
 
@@ -430,6 +434,7 @@ _settings.machine_learning.inference_events_value = MachineLearningInferenceEven
 _settings.ai_monitoring = AIMonitoringSettings()
 _settings.ai_monitoring.streaming = AIMonitoringStreamingSettings()
 _settings.ai_monitoring.record_content = AIMonitoringRecordContentSettings()
+_settings.k8s_operator = K8sOperatorSettings()
 _settings.package_reporting = PackageReportingSettings()
 _settings.attributes = AttributesSettings()
 _settings.browser_monitoring = BrowserMonitorSettings()
@@ -745,7 +750,9 @@ _settings.cross_application_tracer.enabled = False
 _settings.gc_runtime_metrics.enabled = False
 _settings.gc_runtime_metrics.top_object_count_limit = 5
 
-_settings.memory_runtime_pid_metrics.enabled = _environ_as_bool("NEW_RELIC_MEMORY_RUNTIME_METRICS_ENABLED", default=True)
+_settings.memory_runtime_pid_metrics.enabled = _environ_as_bool(
+    "NEW_RELIC_MEMORY_RUNTIME_METRICS_ENABLED", default=True
+)
 
 _settings.transaction_events.enabled = True
 _settings.transaction_events.attributes.enabled = True
@@ -953,6 +960,7 @@ _settings.ai_monitoring.record_content.enabled = _environ_as_bool(
     "NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED", default=True
 )
 _settings.ai_monitoring._llm_token_count_callback = None
+_settings.k8s_operator.enabled = _environ_as_bool("NEW_RELIC_K8S_OPERATOR_ENABLED", default=False)
 _settings.package_reporting.enabled = _environ_as_bool("NEW_RELIC_PACKAGE_REPORTING_ENABLED", default=True)
 _settings.ml_insights_events.enabled = _environ_as_bool("NEW_RELIC_ML_INSIGHTS_EVENTS_ENABLED", default=False)
 

--- a/tests/application_celery/_target_application.py
+++ b/tests/application_celery/_target_application.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from celery import Celery
+from celery import Celery, shared_task
 from testing_support.validators.validate_distributed_trace_accepted import (
     validate_distributed_trace_accepted,
 )
@@ -42,6 +42,11 @@ def tsum(nums):
 @app.task
 def nested_add(x, y):
     return add(x, y)
+
+
+@shared_task
+def shared_task_add(x, y):
+    return x + y
 
 
 @app.task

--- a/tests/application_celery/conftest.py
+++ b/tests/application_celery/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
     collector_agent_registration_fixture,
     collector_available_fixture,
@@ -27,3 +28,23 @@ _default_settings = {
 collector_agent_registration = collector_agent_registration_fixture(
     app_name="Python Agent Test (application_celery)", default_settings=_default_settings
 )
+
+
+@pytest.fixture(scope="session")
+def celery_config():
+    # Used by celery pytest plugin to configure Celery instance
+    return {
+        "broker_url": "memory://",
+        "result_backend": "cache+memory://",
+    }
+
+
+@pytest.fixture(scope="session")
+def celery_worker_parameters():
+    # Used by celery pytest plugin to configure worker instance
+    return {"shutdown_timeout": 120}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def celery_worker_available(celery_session_worker):
+    yield celery_session_worker

--- a/tests/application_celery/test_max_tasks_per_child.py
+++ b/tests/application_celery/test_max_tasks_per_child.py
@@ -17,11 +17,20 @@ from billiard import get_context
 from billiard.pool import Worker
 from testing_support.validators.validate_function_called import validate_function_called
 
+from newrelic.common.object_wrapper import transient_function_wrapper
+
 
 class OnExit(Exception):
     pass
 
 
+@transient_function_wrapper("newrelic.core.agent", "Agent.shutdown_agent")
+def mock_agent_shutdown(wrapped, instance, args, kwargs):
+    # Prevent agent from actually shutting down and blocking further tests
+    pass
+
+
+@mock_agent_shutdown
 @validate_function_called("newrelic.core.agent", "Agent.shutdown_agent")
 def test_max_tasks_per_child():
     def on_exit(*args, **kwargs):

--- a/tests/application_celery/test_task_methods.py
+++ b/tests/application_celery/test_task_methods.py
@@ -1,0 +1,307 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from _target_application import add, tsum
+from celery import chain, chord, group
+from testing_support.validators.validate_transaction_count import (
+    validate_transaction_count,
+)
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+FORGONE_TASK_METRICS = [("Function/_target_application.add", None), ("Function/_target_application.tsum", None)]
+
+
+def test_task_wrapping_detection():
+    """
+    Ensure celery detects our monkeypatching properly and will run our instrumentation
+    on __call__ and runs that instead of micro-optimizing it away to a run() call.
+
+    If this is not working, most other tests in this file will fail as the different ways
+    of running celery tasks will not all run our instrumentation.
+    """
+    from celery.app.trace import task_has_custom
+
+    assert task_has_custom(add, "__call__")
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_call():
+    """
+    Executes task in local process and returns the result directly.
+    """
+    result = add(3, 4)
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_apply():
+    """
+    Executes task in local process and returns an EagerResult.
+    """
+    result = add.apply((3, 4))
+    result = result.get()
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_delay():
+    """
+    Executes task on worker process and returns an AsyncResult.
+    """
+    result = add.delay(3, 4)
+    result = result.get()
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_apply_async():
+    """
+    Executes task on worker process and returns an AsyncResult.
+    """
+    result = add.apply_async((3, 4))
+    result = result.get()
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_app_send_task(celery_session_app):
+    """
+    Executes task on worker process and returns an AsyncResult.
+    """
+    result = celery_session_app.send_task("_target_application.add", (3, 4))
+    result = result.get()
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_signature():
+    """
+    Executes task on worker process and returns an AsyncResult.
+    """
+    result = add.s(3, 4).delay()
+    result = result.get()
+    assert result == 7
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+    index=-2,
+)
+@validate_transaction_count(2)
+def test_celery_task_link():
+    """
+    Executes multiple tasks on worker process and returns an AsyncResult.
+    """
+    result = add.apply_async((3, 4), link=[add.s(5)])
+    result = result.get()
+    assert result == 7  # Linked task result won't be returned
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+    index=-2,
+)
+@validate_transaction_count(2)
+def test_celery_chain():
+    """
+    Executes multiple tasks on worker process and returns an AsyncResult.
+    """
+    result = chain(add.s(3, 4), add.s(5))()
+
+    result = result.get()
+    assert result == 12
+
+
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+    index=-2,
+)
+@validate_transaction_count(2)
+def test_celery_group():
+    """
+    Executes multiple tasks on worker process and returns an AsyncResult.
+    """
+    result = group(add.s(3, 4), add.s(1, 2))()
+    result = result.get()
+    assert result == [7, 3]
+
+
+@validate_transaction_metrics(
+    name="_target_application.tsum",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+)
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+    index=-2,
+)
+@validate_transaction_metrics(
+    name="_target_application.add",
+    group="Celery",
+    scoped_metrics=FORGONE_TASK_METRICS,
+    rollup_metrics=FORGONE_TASK_METRICS,
+    background_task=True,
+    index=-3,
+)
+@validate_transaction_count(3)
+def test_celery_chord():
+    """
+    Executes 2 add tasks, followed by a tsum task on the worker process and returns an AsyncResult.
+    """
+    result = chord([add.s(3, 4), add.s(1, 2)])(tsum.s())
+    result = result.get()
+    assert result == 10
+
+
+@validate_transaction_metrics(
+    name="celery.map/_target_application.tsum",
+    group="Celery",
+    scoped_metrics=[("Function/_target_application.tsum", 2)],
+    rollup_metrics=[("Function/_target_application.tsum", 2)],
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_map():
+    """
+    Executes map task on worker process with original task as a subtask and returns an AsyncResult.
+    """
+    result = tsum.map([(3, 4), (1, 2)]).apply()
+    result = result.get()
+    assert result == [7, 3]
+
+
+@validate_transaction_metrics(
+    name="celery.starmap/_target_application.add",
+    group="Celery",
+    scoped_metrics=[("Function/_target_application.add", 2)],
+    rollup_metrics=[("Function/_target_application.add", 2)],
+    background_task=True,
+)
+@validate_transaction_count(1)
+def test_celery_task_starmap():
+    """
+    Executes starmap task on worker process with original task as a subtask and returns an AsyncResult.
+    """
+    result = add.starmap([(3, 4), (1, 2)]).apply_async()
+    result = result.get()
+    assert result == [7, 3]
+
+
+@validate_transaction_metrics(
+    name="celery.starmap/_target_application.add",
+    group="Celery",
+    scoped_metrics=[("Function/_target_application.add", 1)],
+    rollup_metrics=[("Function/_target_application.add", 1)],
+    background_task=True,
+)
+@validate_transaction_metrics(
+    name="celery.starmap/_target_application.add",
+    group="Celery",
+    scoped_metrics=[("Function/_target_application.add", 1)],
+    rollup_metrics=[("Function/_target_application.add", 1)],
+    background_task=True,
+    index=-2,
+)
+@validate_transaction_count(2)
+def test_celery_task_chunks():
+    """
+    Executes multiple tasks on worker process and returns an AsyncResult.
+    """
+    result = add.chunks([(3, 4), (1, 2)], n=1).apply_async()
+    result = result.get()
+    assert result == [[7], [3]]

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,8 @@ envlist =
     python-agent_streaming-py39-protobuf{03,0319}-{with,without}_extensions,
     python-agent_unittests-{py27,py37,py38,py39,py310,py311,py312}-{with,without}_extensions,
     python-agent_unittests-{pypy27,pypy310}-without_extensions,
-    python-application_celery-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy310},
+    python-application_celery-{py37,py38,py39,py310,py311,py312,pypy310}-celerylatest,
+    python-application_celery-py311-celery{0503,0502,0501},
     python-component_djangorestframework-{py37,py38,py39,py310,py311,py312}-djangorestframeworklatest,
     python-component_flask_rest-py37-flaskrestx110,
     python-component_flask_rest-{py38,py39,py310,py311,py312,pypy310}-flaskrestxlatest,
@@ -201,7 +202,10 @@ deps =
     agent_features: beautifulsoup4
     agent_features-{py37,py38,py39,py310,py311,py312,pypy310}: protobuf
     agent_features-{py27,pypy27}: protobuf<3.18.0
-    application_celery: celery[pytest]<6.0
+    application_celery-celerylatest: celery[pytest]
+    application_celery-celery0503: celery[pytest]<5.4
+    application_celery-celery0502: celery[pytest]<5.3
+    application_celery-celery0501: celery[pytest]<5.2
     application_celery-{py37,pypy310}: importlib-metadata<5.0
     mlmodel_sklearn: pandas
     mlmodel_sklearn: protobuf


### PR DESCRIPTION
# Overview
Add a configuration setting to indicate that the agent is being injected by the Kubernetes Agent Operator and that we should skip the python version safety check in sitecustomize.
See agent spec for details (open PR).