### PR TITLE
Add method to urllib3 trace

### DIFF
--- a/newrelic/hooks/external_urllib3.py
+++ b/newrelic/hooks/external_urllib3.py
@@ -14,25 +14,21 @@
 
 from newrelic.api.external_trace import ExternalTraceWrapper
 from newrelic.common.object_wrapper import wrap_function_wrapper
-from newrelic.hooks.external_httplib2 import (
-    _nr_wrapper_httplib2_endheaders_wrapper)
+from newrelic.hooks.external_httplib2 import _nr_wrapper_httplib2_endheaders_wrapper
 
 
 def _nr_wrapper_make_request_(wrapped, instance, args, kwargs):
-
     def _bind_params(conn, method, url, *args, **kwargs):
-        return "%s://%s:%s" % (instance.scheme, conn.host, conn.port)
+        return method, "%s://%s:%s" % (instance.scheme, conn.host, conn.port)
 
-    url_for_apm_ui = _bind_params(*args, **kwargs)
+    method, url_for_apm_ui = _bind_params(*args, **kwargs)
 
-    return ExternalTraceWrapper(wrapped, 'urllib3', url_for_apm_ui)(*args, **kwargs)
+    return ExternalTraceWrapper(wrapped, "urllib3", url_for_apm_ui, method=method)(*args, **kwargs)
 
 
 def instrument_urllib3_connectionpool(module):
-    wrap_function_wrapper(module, 'HTTPSConnectionPool._make_request',
-            _nr_wrapper_make_request_)
-    wrap_function_wrapper(module, 'HTTPConnectionPool._make_request',
-            _nr_wrapper_make_request_)
+    wrap_function_wrapper(module, "HTTPSConnectionPool._make_request", _nr_wrapper_make_request_)
+    wrap_function_wrapper(module, "HTTPConnectionPool._make_request", _nr_wrapper_make_request_)
 
 
 def instrument_urllib3_connection(module):
@@ -40,8 +36,10 @@ def instrument_urllib3_connection(module):
     # the 'connect' monkey patch separate, because it is also used to patch
     # urllib3 within the requests package.
 
-    wrap_function_wrapper(module, 'HTTPSConnection.endheaders',
-        _nr_wrapper_httplib2_endheaders_wrapper('urllib3', 'https'))
+    wrap_function_wrapper(
+        module, "HTTPSConnection.endheaders", _nr_wrapper_httplib2_endheaders_wrapper("urllib3", "https")
+    )
 
-    wrap_function_wrapper(module, 'HTTPConnection.endheaders',
-        _nr_wrapper_httplib2_endheaders_wrapper('urllib3', 'http'))
+    wrap_function_wrapper(
+        module, "HTTPConnection.endheaders", _nr_wrapper_httplib2_endheaders_wrapper("urllib3", "http")
+    )

--- a/tests/external_urllib3/test_urllib3.py
+++ b/tests/external_urllib3/test_urllib3.py
@@ -45,13 +45,13 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 
 @pytest.fixture(scope="session")
 def metrics(server):
-    scoped = [("External/localhost:%d/urllib3/" % server.port, 1)]
+    scoped = [("External/localhost:%d/urllib3/GET" % server.port, 1)]
 
     rollup = [
         ("External/all", 1),
         ("External/allOther", 1),
         ("External/localhost:%d/all" % server.port, 1),
-        ("External/localhost:%d/urllib3/" % server.port, 1),
+        ("External/localhost:%d/urllib3/GET" % server.port, 1),
     ]
 
     return scoped, rollup
@@ -162,13 +162,13 @@ def test_https_request_connection_pool_request(server, metrics):
 
 
 def test_port_included(server):
-    scoped = [("External/localhost:%d/urllib3/" % server.port, 1)]
+    scoped = [("External/localhost:%d/urllib3/GET" % server.port, 1)]
 
     rollup = [
         ("External/all", 1),
         ("External/allOther", 1),
         ("External/localhost:%d/all" % server.port, 1),
-        ("External/localhost:%d/urllib3/" % server.port, 1),
+        ("External/localhost:%d/urllib3/GET" % server.port, 1),
     ]
 
     @validate_transaction_errors(errors=[])


### PR DESCRIPTION
This PR explicitly adds `http.method` to urllib3 traces