### PR TITLE
Drop Python 3.7 for jinja testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -154,6 +154,7 @@ envlist =
     python-mlmodel_sklearn-{py37}-scikitlearn0101,
     python-mlmodel_sklearn-{py38,py39,py310,py311,py312}-scikitlearnlatest,
     python-template_genshi-{py27,py37,py38,py39,py310,py311,py312}-genshilatest,
+    python-template_jinja2-py37-jinja2030103,
     python-template_jinja2-{py38,py39,py310,py311,py312}-jinja2latest,
     python-template_mako-{py27,py37,py38,py39,py310,py311,py312},
     rabbitmq-messagebroker_pika-{py37,py38,py39,py310,py311,py312,pypy310}-pikalatest,
@@ -380,6 +381,7 @@ deps =
     messagebroker_kafkapython-kafkapython020000: kafka-python<2.0.1
     template_genshi-genshilatest: genshi
     template_jinja2-jinja2latest: Jinja2
+    template_jinja2-jinja2030103: Jinja2<3.1.4
     template_mako: mako
 
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,7 @@ envlist =
     python-mlmodel_sklearn-{py37}-scikitlearn0101,
     python-mlmodel_sklearn-{py38,py39,py310,py311,py312}-scikitlearnlatest,
     python-template_genshi-{py27,py37,py38,py39,py310,py311,py312}-genshilatest,
-    python-template_jinja2-{py37,py38,py39,py310,py311,py312}-jinja2latest,
+    python-template_jinja2-{py38,py39,py310,py311,py312}-jinja2latest,
     python-template_mako-{py27,py37,py38,py39,py310,py311,py312},
     rabbitmq-messagebroker_pika-{py37,py38,py39,py310,py311,py312,pypy310}-pikalatest,
     redis-datastore_redis-{py37,py38,py39,py310,py311,py312,pypy310}-redis{0400,latest},


### PR DESCRIPTION
Jinja no longer supports Python 3.7 since April 23rd, so we are dropping it from being tested against the latest version.