### PR TITLE
Add support for llama3

### DIFF
--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -438,7 +438,7 @@ MODEL_EXTRACTORS = [  # Order is important here, avoiding dictionaries
         extract_bedrock_claude_model_streaming_response,
     ),
     (
-        "meta.llama2",
+        "meta.llama",
         extract_bedrock_llama_model_request,
         extract_bedrock_llama_model_response,
         extract_bedrock_llama_model_streaming_response,


### PR DESCRIPTION
# Overview
llama3 is the same parsing as llama2 so just drop the number from the key to support both.
