### PR TITLE
Fix sklearn ensemble tests.

### DIFF
--- a/tests/mlmodel_sklearn/test_ensemble_models.py
+++ b/tests/mlmodel_sklearn/test_ensemble_models.py
@@ -232,7 +232,6 @@ def test_above_v1_1_model_methods_wrapped_in_function_trace(ensemble_model_name,
             ("Function/MLModel/Sklearn/Named/HistGradientBoostingClassifier.fit", 1),
             ("Function/MLModel/Sklearn/Named/HistGradientBoostingClassifier.predict", 2),
             ("Function/MLModel/Sklearn/Named/HistGradientBoostingClassifier.score", 1),
-            ("Function/MLModel/Sklearn/Named/HistGradientBoostingClassifier.predict_proba", 3),
         ],
         "HistGradientBoostingRegressor": [
             ("Function/MLModel/Sklearn/Named/HistGradientBoostingRegressor.fit", 1),


### PR DESCRIPTION
This PR updates the expected metrics for sklearn's `HistGradientBoostingClassifier`. In v1.5.0, calls to `predict_proba` [were removed](https://github.com/scikit-learn/scikit-learn/pull/27844) for performance reasons. 
