### PR TITLE
Fix LLM event durations

### DIFF
--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -543,7 +543,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
                 )
 
                 ft.__exit__(*sys.exc_info())
-                error_attributes["duration"] = ft.duration
+                error_attributes["duration"] = ft.duration * 1000
 
                 if operation == "embedding":
                     handle_embedding_event(transaction, error_attributes)
@@ -594,7 +594,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
             # Read and replace response streaming bodies
             response_body = response["body"].read()
             ft.__exit__(None, None, None)
-            bedrock_attrs["duration"] = ft.duration
+            bedrock_attrs["duration"] = ft.duration * 1000
             response["body"] = StreamingBody(BytesIO(response_body), len(response_body))
 
             # Run response extractor for non-streaming responses
@@ -677,7 +677,7 @@ def record_events_on_stop_iteration(self, transaction):
             return
 
         try:
-            bedrock_attrs["duration"] = self._nr_ft.duration
+            bedrock_attrs["duration"] = self._nr_ft.duration * 1000
             handle_chat_completion_event(transaction, bedrock_attrs)
         except Exception:
             _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
@@ -709,7 +709,7 @@ def record_error(self, transaction, exc):
             )
 
             ft.__exit__(*sys.exc_info())
-            error_attributes["duration"] = ft.duration
+            error_attributes["duration"] = ft.duration * 1000
 
             handle_chat_completion_event(transaction, error_attributes)
 

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -220,7 +220,7 @@ def wrap_similarity_search(wrapped, instance, args, kwargs):
 def _record_vector_search_success(transaction, linking_metadata, ft, search_id, args, kwargs, response):
     settings = transaction.settings if transaction.settings is not None else global_settings()
     request_query, request_k = bind_similarity_search(*args, **kwargs)
-    duration = ft.duration
+    duration = ft.duration * 1000
     response_number_of_documents = len(response)
     llm_metadata_dict = _get_llm_metadata(transaction)
     span_id = linking_metadata.get("span.id")
@@ -424,7 +424,7 @@ def _record_tool_success(
             "trace_id": linking_metadata.get("trace.id"),
             "vendor": "langchain",
             "ingest_source": "Python",
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "tags": tags or None,
         }
     )
@@ -473,7 +473,7 @@ def _record_tool_error(
             "trace_id": linking_metadata.get("trace.id"),
             "vendor": "langchain",
             "ingest_source": "Python",
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "tags": tags or None,
             "error": True,
         }
@@ -559,7 +559,9 @@ async def wrap_chain_async_run(wrapped, instance, args, kwargs):
             }
         )
         ft.__exit__(*sys.exc_info())
-        _create_error_chain_run_events(transaction, instance, run_args, completion_id, linking_metadata, ft.duration)
+        _create_error_chain_run_events(
+            transaction, instance, run_args, completion_id, linking_metadata, ft.duration * 1000
+        )
         raise
     ft.__exit__(None, None, None)
 
@@ -567,7 +569,7 @@ async def wrap_chain_async_run(wrapped, instance, args, kwargs):
         return response
 
     _create_successful_chain_run_events(
-        transaction, instance, run_args, completion_id, response, linking_metadata, ft.duration
+        transaction, instance, run_args, completion_id, response, linking_metadata, ft.duration * 1000
     )
     return response
 
@@ -605,7 +607,9 @@ def wrap_chain_sync_run(wrapped, instance, args, kwargs):
             }
         )
         ft.__exit__(*sys.exc_info())
-        _create_error_chain_run_events(transaction, instance, run_args, completion_id, linking_metadata, ft.duration)
+        _create_error_chain_run_events(
+            transaction, instance, run_args, completion_id, linking_metadata, ft.duration * 1000
+        )
         raise
     ft.__exit__(None, None, None)
 
@@ -613,7 +617,7 @@ def wrap_chain_sync_run(wrapped, instance, args, kwargs):
         return response
 
     _create_successful_chain_run_events(
-        transaction, instance, run_args, completion_id, response, linking_metadata, ft.duration
+        transaction, instance, run_args, completion_id, response, linking_metadata, ft.duration * 1000
     )
     return response
 

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -277,7 +277,7 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
             ),
             "request.model": kwargs.get("model") or kwargs.get("engine"),
             "request_id": request_id,
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "response.model": response_model,
             "response.organization": organization,
             "response.headers.llmVersion": response_headers.get("openai-version"),
@@ -370,7 +370,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
             "vendor": "openai",
             "ingest_source": "Python",
             "response.organization": exc_organization,
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "error": True,
         }
         if settings.ai_monitoring.record_content.enabled:
@@ -491,7 +491,7 @@ def _record_completion_success(transaction, linking_metadata, completion_id, kwa
             "vendor": "openai",
             "ingest_source": "Python",
             "request_id": request_id,
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "response.model": response_model,
             "response.organization": organization,
             "response.choices.finish_reason": finish_reason,
@@ -607,7 +607,7 @@ def _record_completion_error(transaction, linking_metadata, completion_id, kwarg
             "vendor": "openai",
             "ingest_source": "Python",
             "response.organization": exc_organization,
-            "duration": ft.duration,
+            "duration": ft.duration * 1000,
             "error": True,
         }
         llm_metadata = _get_llm_attributes(transaction)


### PR DESCRIPTION
# Overview
In order to match behavior across agents, the python agent should report the `duration` field on AI Monitoring events in milliseconds rather than seconds.

# Testing
The test suite does not currently check the `duration` field because the integration tests have variability between runs
