### PR TITLE
Fix bug in ASGI when no content-length header

### DIFF
--- a/newrelic/api/asgi_application.py
+++ b/newrelic/api/asgi_application.py
@@ -175,7 +175,7 @@ class ASGIBrowserMiddleware(object):
 
                     try:
                         content_length = int(header_value)
-                    except ValueError:
+                    except (TypeError, ValueError):
                         # Invalid content length results in an abort
                         await self.send_buffered()
                         return

--- a/tests/agent_features/test_asgi_browser.py
+++ b/tests/agent_features/test_asgi_browser.py
@@ -688,7 +688,7 @@ def test_html_insertion_invalid_content_length():
 
 
 @override_application_settings(_test_html_insertion_invalid_content_length_settings)
-def test_html_insertion_invalid_content_length():
+def test_html_insertion_no_content_length():
     response = target_application_no_content_length.get("/")
     assert response.status == 200
 


### PR DESCRIPTION
# Overview
Previously, if there was no content length header and browser injection was enabled, the ASGI wrapper would fail with a TypeError as the header_value would be None. Now, the except clause catches both type and value errors.

Fixes #1150.