### PR TITLE
Update flask tests and enable flaskmaster

### DIFF
--- a/tests/framework_flask/_test_blueprints.py
+++ b/tests/framework_flask/_test_blueprints.py
@@ -13,70 +13,82 @@
 # limitations under the License.
 
 import webtest
-
-from flask import Flask
-from flask import Blueprint
-from werkzeug.routing import Rule
-
 from conftest import is_flask_v2 as nested_blueprint_support
+from conftest import is_not_flask_v2_3 as before_app_first_request_support
+from flask import Blueprint, Flask
+from werkzeug.routing import Rule
 
 # Blueprints are only available in 0.7.0 onwards.
 
-blueprint = Blueprint('blueprint', __name__)
+blueprint = Blueprint("blueprint", __name__)
 
 application = Flask(__name__)
 
-@blueprint.route('/index')
+
+@blueprint.route("/index")
 def index_page():
-    return 'BLUEPRINT INDEX RESPONSE'
+    return "BLUEPRINT INDEX RESPONSE"
 
-@blueprint.endpoint('endpoint')
+
+@blueprint.endpoint("endpoint")
 def endpoint_page():
-    return 'BLUEPRINT ENDPOINT RESPONSE'
+    return "BLUEPRINT ENDPOINT RESPONSE"
 
-@blueprint.before_app_first_request
-def before_app_first_request():
-    pass
+
+# < Flask v2.3.0
+if before_app_first_request_support:
+
+    @blueprint.before_app_first_request
+    def before_app_first_request():
+        pass
+
 
 @blueprint.before_request
 def before_request():
     pass
 
+
 @blueprint.before_app_request
 def before_app_request():
     pass
+
 
 @blueprint.after_request
 def after_request(response):
     return response
 
+
 @blueprint.after_app_request
 def after_app_request(response):
     return response
+
 
 @blueprint.teardown_request
 def teardown_request(exc):
     pass
 
+
 @blueprint.teardown_app_request
 def teardown_app_request(exc):
     pass
 
+
 # Support for nested blueprints was added in Flask 2.0
 if nested_blueprint_support:
-    parent = Blueprint('parent', __name__, url_prefix='/parent')
-    child = Blueprint('child', __name__, url_prefix='/child')
+    parent = Blueprint("parent", __name__, url_prefix="/parent")
+    child = Blueprint("child", __name__, url_prefix="/child")
 
     parent.register_blueprint(child)
 
-    @child.route('/nested')
+    @child.route("/nested")
     def nested_page():
-        return 'PARENT NESTED RESPONSE'
+        return "PARENT NESTED RESPONSE"
+
     application.register_blueprint(parent)
 
 application.register_blueprint(blueprint)
 
 
-application.url_map.add(Rule('/endpoint', endpoint='endpoint'))
+application.url_map.add(Rule("/endpoint", endpoint="endpoint"))
 
 _test_application = webtest.TestApp(application)

--- a/tests/framework_flask/_test_middleware.py
+++ b/tests/framework_flask/_test_middleware.py
@@ -13,33 +13,48 @@
 # limitations under the License.
 
 import webtest
-
+from conftest import is_not_flask_v2_3 as before_first_request_support
 from flask import Flask
 
 application = Flask(__name__)
 
-@application.before_first_request
-def before_first_request():
-    pass
+# < Flask v2.3.0
+if before_first_request_support:
+
+    @application.before_first_request
+    def before_first_request():
+        pass
+
+
+# >= Flask v2.3.0
+def application_app_context():
+    with application.app_context():
+        pass
+
 
 @application.before_request
 def before_request():
     pass
 
+
 @application.after_request
 def after_request(response):
     return response
+
 
 @application.teardown_request
 def teardown_request(exc):
     pass
 
+
 @application.teardown_appcontext
 def teardown_appcontext(exc):
     pass
 
-@application.route('/middleware')
+
+@application.route("/middleware")
 def index_page():
-    return 'INDEX RESPONSE'
+    return "INDEX RESPONSE"
+
 
 _test_application = webtest.TestApp(application)

--- a/tests/framework_flask/conftest.py
+++ b/tests/framework_flask/conftest.py
@@ -15,29 +15,43 @@
 import platform
 
 import pytest
-from flask import __version__ as flask_version
+from flask import (
+    __version__ as flask_version,  # required for python 3.7 in lieu of get_package_version_tuple
+)
 
-from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture  # noqa: F401; pylint: disable=W0611
+from newrelic.common.package_version_utils import get_package_version_tuple
 
+try:
+    FLASK_VERSION = tuple(int(v) for v in flask_version.split("."))
+except:
+    # This does not work for Python 3.7 for v2.2.5
+    # This only works for flaskmaster
+    FLASK_VERSION = get_package_version_tuple("flask")
+
+from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+    collector_agent_registration_fixture,
+    collector_available_fixture,
+)
 
 _default_settings = {
-    'transaction_tracer.explain_threshold': 0.0,
-    'transaction_tracer.transaction_threshold': 0.0,
-    'transaction_tracer.stack_trace_threshold': 0.0,
-    'debug.log_data_collector_payloads': True,
-    'debug.record_transaction_failure': True,
-    'debug.log_autorum_middleware': True,
+    "transaction_tracer.explain_threshold": 0.0,
+    "transaction_tracer.transaction_threshold": 0.0,
+    "transaction_tracer.stack_trace_threshold": 0.0,
+    "debug.log_data_collector_payloads": True,
+    "debug.record_transaction_failure": True,
+    "debug.log_autorum_middleware": True,
 }
 
 collector_agent_registration = collector_agent_registration_fixture(
-        app_name='Python Agent Test (framework_flask)',
-        default_settings=_default_settings)
+    app_name="Python Agent Test (framework_flask)", default_settings=_default_settings
+)
 
 
-is_flask_v2 = int(flask_version.split('.')[0]) >= 2
+is_flask_v2 = FLASK_VERSION[0] >= 2
+is_not_flask_v2_3 = FLASK_VERSION < (2, 3, 0)
 is_pypy = platform.python_implementation() == "PyPy"
 async_handler_support = is_flask_v2 and not is_pypy
 skip_if_not_async_handler_support = pytest.mark.skipif(
     not async_handler_support,
-    reason="Requires async handler support. (Flask >=v2.0.0)",
+    reason="Requires async handler support. (Flask >=v2.0.0, CPython)",
 )

--- a/tests/framework_flask/test_blueprints.py
+++ b/tests/framework_flask/test_blueprints.py
@@ -13,18 +13,20 @@
 # limitations under the License.
 
 import pytest
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
-
-from newrelic.packages import six
-
 from conftest import is_flask_v2 as nested_blueprint_support
+from testing_support.validators.validate_code_level_metrics import (
+    validate_code_level_metrics,
+)
+from testing_support.validators.validate_transaction_errors import (
+    validate_transaction_errors,
+)
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
 
-skip_if_not_nested_blueprint_support = pytest.mark.skipif(not nested_blueprint_support,
-        reason="Requires nested blueprint support. (Flask >=v2.0.0)")
+skip_if_not_nested_blueprint_support = pytest.mark.skipif(
+    not nested_blueprint_support, reason="Requires nested blueprint support. (Flask >=v2.0.0)"
+)
 
 
 def target_application():
@@ -38,29 +40,32 @@ def target_application():
     # showing <local> scope in path.
 
     from _test_blueprints import _test_application
+
     return _test_application
 
+
 _test_blueprints_index_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/_test_blueprints:index_page', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/_test_blueprints:before_app_request', 1),
-        ('Function/_test_blueprints:before_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/_test_blueprints:after_request', 1),
-        ('Function/_test_blueprints:after_app_request', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/_test_blueprints:teardown_app_request', 1),
-        ('Function/_test_blueprints:teardown_request', 1),
-        ('Function/flask.app:Flask.do_teardown_appcontext', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/_test_blueprints:index_page", 1),
+    ("Function/flask.app:Flask.preprocess_request", 1),
+    ("Function/_test_blueprints:before_app_request", 1),
+    ("Function/_test_blueprints:before_request", 1),
+    ("Function/flask.app:Flask.process_response", 1),
+    ("Function/_test_blueprints:after_request", 1),
+    ("Function/_test_blueprints:after_app_request", 1),
+    ("Function/flask.app:Flask.do_teardown_request", 1),
+    ("Function/_test_blueprints:teardown_app_request", 1),
+    ("Function/_test_blueprints:teardown_request", 1),
+    ("Function/flask.app:Flask.do_teardown_appcontext", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
+]
+
 
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_blueprints:index_page',
-        scoped_metrics=_test_blueprints_index_scoped_metrics)
+@validate_transaction_metrics("_test_blueprints:index_page", scoped_metrics=_test_blueprints_index_scoped_metrics)
 @validate_code_level_metrics("_test_blueprints", "index_page")
 @validate_code_level_metrics("_test_blueprints", "before_app_request")
 @validate_code_level_metrics("_test_blueprints", "before_request")
@@ -70,60 +75,61 @@ _test_blueprints_index_scoped_metrics = [
 @validate_code_level_metrics("_test_blueprints", "teardown_request")
 def test_blueprints_index():
     application = target_application()
-    response = application.get('/index')
-    response.mustcontain('BLUEPRINT INDEX RESPONSE')
+    response = application.get("/index")
+    response.mustcontain("BLUEPRINT INDEX RESPONSE")
+
 
 _test_blueprints_endpoint_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/_test_blueprints:endpoint_page', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/_test_blueprints:before_app_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/_test_blueprints:after_app_request', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/_test_blueprints:teardown_app_request', 1),
-        ('Function/flask.app:Flask.do_teardown_appcontext', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/_test_blueprints:endpoint_page", 1),
+    ("Function/flask.app:Flask.preprocess_request", 1),
+    ("Function/_test_blueprints:before_app_request", 1),
+    ("Function/flask.app:Flask.process_response", 1),
+    ("Function/_test_blueprints:after_app_request", 1),
+    ("Function/flask.app:Flask.do_teardown_request", 1),
+    ("Function/_test_blueprints:teardown_app_request", 1),
+    ("Function/flask.app:Flask.do_teardown_appcontext", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
+]
+
 
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_blueprints:endpoint_page',
-        scoped_metrics=_test_blueprints_endpoint_scoped_metrics)
+@validate_transaction_metrics("_test_blueprints:endpoint_page", scoped_metrics=_test_blueprints_endpoint_scoped_metrics)
 @validate_code_level_metrics("_test_blueprints", "endpoint_page")
 @validate_code_level_metrics("_test_blueprints", "before_app_request")
 @validate_code_level_metrics("_test_blueprints", "after_app_request")
 @validate_code_level_metrics("_test_blueprints", "teardown_app_request")
 def test_blueprints_endpoint():
     application = target_application()
-    response = application.get('/endpoint')
-    response.mustcontain('BLUEPRINT ENDPOINT RESPONSE')
+    response = application.get("/endpoint")
+    response.mustcontain("BLUEPRINT ENDPOINT RESPONSE")
 
 
 _test_blueprints_nested_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/_test_blueprints:nested_page', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/_test_blueprints:before_app_request', 1),
-        ('Function/_test_blueprints:before_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/_test_blueprints:after_request', 1),
-        ('Function/_test_blueprints:after_app_request', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/_test_blueprints:teardown_app_request', 1),
-        ('Function/_test_blueprints:teardown_request', 1),
-        ('Function/flask.app:Flask.do_teardown_appcontext', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/_test_blueprints:nested_page", 1),
+    ("Function/flask.app:Flask.preprocess_request", 1),
+    ("Function/_test_blueprints:before_app_request", 1),
+    ("Function/flask.app:Flask.process_response", 1),
+    ("Function/_test_blueprints:after_app_request", 1),
+    ("Function/flask.app:Flask.do_teardown_request", 1),
+    ("Function/_test_blueprints:teardown_app_request", 1),
+    ("Function/flask.app:Flask.do_teardown_appcontext", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
+]
+
 
 @skip_if_not_nested_blueprint_support
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_blueprints:nested_page')
+@validate_transaction_metrics("_test_blueprints:nested_page", scoped_metrics=_test_blueprints_nested_scoped_metrics)
 @validate_code_level_metrics("_test_blueprints", "nested_page")
 def test_blueprints_nested():
-        application = target_application()
-        response = application.get('/parent/child/nested')
-        response.mustcontain('PARENT NESTED RESPONSE')
+    application = target_application()
+    response = application.get("/parent/child/nested")
+    response.mustcontain("PARENT NESTED RESPONSE")

--- a/tests/framework_flask/test_middleware.py
+++ b/tests/framework_flask/test_middleware.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+from testing_support.validators.validate_code_level_metrics import (
+    validate_code_level_metrics,
+)
+from testing_support.validators.validate_transaction_errors import (
+    validate_transaction_errors,
+)
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
 
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 
 def target_application():
     # We need to delay Flask application creation because of ordering
@@ -30,36 +34,38 @@ def target_application():
     # showing <local> scope in path.
 
     from _test_middleware import _test_application
+
     return _test_application
 
+
 _test_application_app_middleware_scoped_metrics = [
-        ('Function/flask.app:Flask.wsgi_app', 1),
-        ('Python/WSGI/Application', 1),
-        ('Python/WSGI/Response', 1),
-        ('Python/WSGI/Finalize', 1),
-        ('Function/_test_middleware:index_page', 1),
-        ('Function/flask.app:Flask.try_trigger_before_first_request_functions', 1),
-        ('Function/_test_middleware:before_first_request', 1),
-        ('Function/flask.app:Flask.preprocess_request', 1),
-        ('Function/_test_middleware:before_request', 1),
-        ('Function/flask.app:Flask.process_response', 1),
-        ('Function/_test_middleware:after_request', 1),
-        ('Function/flask.app:Flask.do_teardown_request', 1),
-        ('Function/_test_middleware:teardown_request', 1),
-        ('Function/flask.app:Flask.do_teardown_appcontext', 1),
-        ('Function/_test_middleware:teardown_appcontext', 1),
-        ('Function/werkzeug.wsgi:ClosingIterator.close', 1)]
+    ("Function/flask.app:Flask.wsgi_app", 1),
+    ("Python/WSGI/Application", 1),
+    ("Python/WSGI/Response", 1),
+    ("Python/WSGI/Finalize", 1),
+    ("Function/_test_middleware:index_page", 1),
+    ("Function/flask.app:Flask.preprocess_request", 1),
+    ("Function/_test_middleware:before_request", 1),
+    ("Function/flask.app:Flask.process_response", 1),
+    ("Function/_test_middleware:after_request", 1),
+    ("Function/flask.app:Flask.do_teardown_request", 1),
+    ("Function/_test_middleware:teardown_request", 1),
+    ("Function/flask.app:Flask.do_teardown_appcontext", 1),
+    ("Function/_test_middleware:teardown_appcontext", 1),
+    ("Function/werkzeug.wsgi:ClosingIterator.close", 1),
+]
+
 
 @validate_transaction_errors(errors=[])
-@validate_transaction_metrics('_test_middleware:index_page',
-        scoped_metrics=_test_application_app_middleware_scoped_metrics)
+@validate_transaction_metrics(
+    "_test_middleware:index_page", scoped_metrics=_test_application_app_middleware_scoped_metrics
+)
 @validate_code_level_metrics("_test_middleware", "index_page")
-@validate_code_level_metrics("_test_middleware", "before_first_request")
 @validate_code_level_metrics("_test_middleware", "before_request")
 @validate_code_level_metrics("_test_middleware", "after_request")
 @validate_code_level_metrics("_test_middleware", "teardown_request")
 @validate_code_level_metrics("_test_middleware", "teardown_appcontext")
 def test_application_app_middleware():
     application = target_application()
-    response = application.get('/middleware')
-    response.mustcontain('INDEX RESPONSE')
+    response = application.get("/middleware")
+    response.mustcontain("INDEX RESPONSE")

--- a/tox.ini
+++ b/tox.ini
@@ -128,8 +128,8 @@ envlist =
     python-framework_falcon-{py37,py312}-falcon0300,
     python-framework_falcon-{py37,py38,py39,py310,py311,py312,pypy310}-falcon{latest,master},
     python-framework_fastapi-{py37,py38,py39,py310,py311,py312},
-    ; temporarily disabling flaskmaster tests
-    python-framework_flask-{py37,py38,py39,py310,py311,py312,pypy310}-flasklatest,
+    python-framework_flask-py37-flask020205,
+    python-framework_flask-{py38,py39,py310,py311,py312,pypy310}-flask{020205,latest,master},
     python-framework_graphene-{py37,py38,py39,py310,py311,py312}-graphenelatest,
     python-framework_graphql-{py37,py38,py39,py310,py311,py312,pypy310}-graphql03,
     ; temporarily disabling graphqlmaster tests
@@ -143,8 +143,7 @@ envlist =
     python-framework_starlette-{py37,py38,py39,py310,py311,py312,pypy310}-starlettelatest,
     python-framework_starlette-{py37,py38}-starlette{002001},
     python-framework_strawberry-{py37,py38,py39,py310,py311,py312}-strawberrylatest,
-    python-framework_tornado-{py38,py39,py310,py311,py312}-tornadolatest,
-    python-framework_tornado-{py38,py39,py310,py311,py312}-tornadomaster,
+    python-framework_tornado-{py38,py39,py310,py311,py312}-tornado{latest,master},
     python-logger_logging-{py27,py37,py38,py39,py310,py311,py312,pypy27,pypy310},
     python-logger_loguru-{py37,py38,py39,py310,py311,py312,pypy310}-logurulatest,
     python-logger_loguru-py39-loguru{06,05},
@@ -312,9 +311,11 @@ deps =
     framework_falcon-falconmaster: https://github.com/falconry/falcon/archive/master.zip
     framework_fastapi: fastapi
     framework_fastapi: asyncio
-    framework_flask: markupsafe<2.1
-    framework_flask: jinja2<3.1
     framework_flask: Flask-Compress
+    framework_flask-flask020205: jinja2<3.1.3
+    framework_flask-flask020205: flask[async]<2.3
+    framework_flask-flasklatest: markupsafe
+    framework_flask-flasklatest: jinja2
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
     framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]

--- a/tox.ini
+++ b/tox.ini
@@ -318,7 +318,7 @@ deps =
     framework_flask-flasklatest: jinja2
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
-    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip#egg=flask[async]
+    framework_flask-flaskmaster: flask[async]@https://github.com/pallets/flask/archive/main.zip
     framework_graphene-graphenelatest: graphene
     framework_graphql-graphqllatest: graphql-core
     framework_graphql-graphql03: graphql-core<4

--- a/tox.ini
+++ b/tox.ini
@@ -318,7 +318,8 @@ deps =
     framework_flask-flasklatest: jinja2
     framework_flask-flasklatest: flask[async]
     framework_flask-flaskmaster: https://github.com/pallets/werkzeug/archive/main.zip
-    framework_flask-flaskmaster: flask[async]@https://github.com/pallets/flask/archive/main.zip
+    framework_flask-flaskmaster: https://github.com/pallets/flask/archive/main.zip
+    framework_flask-flaskmaster: asgiref
     framework_graphene-graphenelatest: graphene
     framework_graphql-graphqllatest: graphql-core
     framework_graphql-graphql03: graphql-core<4


### PR DESCRIPTION
This PR enables the testing of flaskmaster (pulls repo from main branch as well as latest) as well as updating Flask tests.  More information found here on why extras were installed separately from archive: https://github.com/pypa/pip/pull/11617

Because jinja2 was pinned to v3.0.3, flasklatest was actually installing Flask v2.1.3 (which is still compatible with that version of jinja2) instead of the actual latest version.