### PR TITLE
Fix Environment Scraping Logic

### DIFF
--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -235,15 +235,16 @@ def environment_settings():
                 continue
 
             # Don't attempt to look up version information for our hooks
+            version = None
             if not nr_hook:
                 try:
                     version = get_package_version(name)
                 except Exception:
-                    version = None
+                    pass
 
             # If it has no version it's likely not a real package so don't report it unless
             # it's a new relic hook.
-            if version or nr_hook:
+            if nr_hook or version:
                 plugins.append("%s (%s)" % (name, version))
 
     env.append(("Plugin List", plugins))


### PR DESCRIPTION
# Overview

* Fix the following error where the name `version` could be unbound.

```
  File "/__w/newrelic-python-agent/newrelic-python-agent/.tox/python-agent_unittests-py27-with_extensions/lib/python2.7/site-packages/newrelic/core/environment.py", line 246, in environment_settings
    if version or nr_hook:
UnboundLocalError: local variable 'version' referenced before assignment
```
