### PR TITLE
Change Langchain->LangChain per agent spec

### DIFF
--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -156,12 +156,12 @@ async def wrap_asimilarity_search(wrapped, instance, args, kwargs):
     if not settings.ai_monitoring.enabled:
         return await wrapped(*args, **kwargs)
 
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     search_id = str(uuid.uuid4())
 
-    ft = FunctionTrace(name=wrapped.__name__, group="Llm/vectorstore/Langchain")
+    ft = FunctionTrace(name=wrapped.__name__, group="Llm/vectorstore/LangChain")
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()
     try:
@@ -193,12 +193,12 @@ def wrap_similarity_search(wrapped, instance, args, kwargs):
     if not settings.ai_monitoring.enabled:
         return wrapped(*args, **kwargs)
 
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     search_id = str(uuid.uuid4())
 
-    ft = FunctionTrace(name=wrapped.__name__, group="Llm/vectorstore/Langchain")
+    ft = FunctionTrace(name=wrapped.__name__, group="Llm/vectorstore/LangChain")
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()
     try:
@@ -277,14 +277,14 @@ def wrap_tool_sync_run(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     # Framework metric also used for entity tagging in the UI
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     tool_id, metadata, tags, tool_input, tool_name, tool_description, run_args = _capture_tool_info(
         instance, wrapped, args, kwargs
     )
 
-    ft = FunctionTrace(name=wrapped.__name__, group="Llm/tool/Langchain")
+    ft = FunctionTrace(name=wrapped.__name__, group="Llm/tool/LangChain")
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()
     try:
@@ -334,14 +334,14 @@ async def wrap_tool_async_run(wrapped, instance, args, kwargs):
         return await wrapped(*args, **kwargs)
 
     # Framework metric also used for entity tagging in the UI
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     tool_id, metadata, tags, tool_input, tool_name, tool_description, run_args = _capture_tool_info(
         instance, wrapped, args, kwargs
     )
 
-    ft = FunctionTrace(name=wrapped.__name__, group="Llm/tool/Langchain")
+    ft = FunctionTrace(name=wrapped.__name__, group="Llm/tool/LangChain")
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()
     try:
@@ -536,7 +536,7 @@ async def wrap_chain_async_run(wrapped, instance, args, kwargs):
         return await wrapped(*args, **kwargs)
 
     # Framework metric also used for entity tagging in the UI
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     run_args = bind_args(wrapped, args, kwargs)
@@ -546,7 +546,7 @@ async def wrap_chain_async_run(wrapped, instance, args, kwargs):
     # The trace group will reflect from where it has started.
     # The AgentExecutor class has an attribute "agent" that does
     # not exist within the Chain class
-    group_name = "Llm/agent/Langchain" if hasattr(instance, "agent") else "Llm/chain/Langchain"
+    group_name = "Llm/agent/LangChain" if hasattr(instance, "agent") else "Llm/chain/LangChain"
     ft = FunctionTrace(name=wrapped.__name__, group=group_name)
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()
@@ -584,7 +584,7 @@ def wrap_chain_sync_run(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
     # Framework metric also used for entity tagging in the UI
-    transaction.add_ml_model_info("Langchain", LANGCHAIN_VERSION)
+    transaction.add_ml_model_info("LangChain", LANGCHAIN_VERSION)
     transaction._add_agent_attribute("llm", True)
 
     run_args = bind_args(wrapped, args, kwargs)
@@ -594,7 +594,7 @@ def wrap_chain_sync_run(wrapped, instance, args, kwargs):
     # The trace group will reflect from where it has started.
     # The AgentExecutor class has an attribute "agent" that does
     # not exist within the Chain class
-    group_name = "Llm/agent/Langchain" if hasattr(instance, "agent") else "Llm/chain/Langchain"
+    group_name = "Llm/agent/LangChain" if hasattr(instance, "agent") else "Llm/chain/LangChain"
     ft = FunctionTrace(name=wrapped.__name__, group=group_name)
     ft.__enter__()
     linking_metadata = get_trace_linking_metadata()

--- a/tests/mlmodel_langchain/test_agent.py
+++ b/tests/mlmodel_langchain/test_agent.py
@@ -59,10 +59,10 @@ def prompt():
 @reset_core_stats_engine()
 @validate_transaction_metrics(
     name="test_agent:test_sync_agent",
-    scoped_metrics=[("Llm/agent/Langchain/invoke", 1)],
-    rollup_metrics=[("Llm/agent/Langchain/invoke", 1)],
+    scoped_metrics=[("Llm/agent/LangChain/invoke", 1)],
+    rollup_metrics=[("Llm/agent/LangChain/invoke", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -78,10 +78,10 @@ def test_sync_agent(chat_openai_client, tools, prompt):
 @reset_core_stats_engine()
 @validate_transaction_metrics(
     name="test_agent:test_async_agent",
-    scoped_metrics=[("Llm/agent/Langchain/ainvoke", 1)],
-    rollup_metrics=[("Llm/agent/Langchain/ainvoke", 1)],
+    scoped_metrics=[("Llm/agent/LangChain/ainvoke", 1)],
+    rollup_metrics=[("Llm/agent/LangChain/ainvoke", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )

--- a/tests/mlmodel_langchain/test_chain.py
+++ b/tests/mlmodel_langchain/test_chain.py
@@ -480,10 +480,10 @@ chat_completion_recorded_events_error_in_langchain = [
 @validate_custom_event_count(count=7)
 @validate_transaction_metrics(
     name="test_chain:test_langchain_chain_list_response",
-    scoped_metrics=[("Llm/chain/Langchain/invoke", 1)],
-    rollup_metrics=[("Llm/chain/Langchain/invoke", 1)],
+    scoped_metrics=[("Llm/chain/LangChain/invoke", 1)],
+    rollup_metrics=[("Llm/chain/LangChain/invoke", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -608,10 +608,10 @@ def test_langchain_chain(
     @validate_custom_event_count(count=8)
     @validate_transaction_metrics(
         name="test_chain:test_langchain_chain.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -682,10 +682,10 @@ def test_langchain_chain_no_content(
     @validate_custom_event_count(count=8)
     @validate_transaction_metrics(
         name="test_chain:test_langchain_chain_no_content.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -781,10 +781,10 @@ def test_langchain_chain_error_in_openai(
     @validate_custom_event_count(count=6)
     @validate_transaction_metrics(
         name="test_chain:test_langchain_chain_error_in_openai.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -858,10 +858,10 @@ def test_langchain_chain_error_in_langchain(
     @validate_custom_event_count(count=2)
     @validate_transaction_metrics(
         name="test_chain:test_langchain_chain_error_in_langchain.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -936,10 +936,10 @@ def test_langchain_chain_error_in_langchain_no_content(
     @validate_custom_event_count(count=2)
     @validate_transaction_metrics(
         name="test_chain:test_langchain_chain_error_in_langchain_no_content.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -1005,10 +1005,10 @@ def test_langchain_chain_ai_monitoring_disabled(
 @validate_custom_event_count(count=7)
 @validate_transaction_metrics(
     name="test_chain:test_async_langchain_chain_list_response",
-    scoped_metrics=[("Llm/chain/Langchain/ainvoke", 1)],
-    rollup_metrics=[("Llm/chain/Langchain/ainvoke", 1)],
+    scoped_metrics=[("Llm/chain/LangChain/ainvoke", 1)],
+    rollup_metrics=[("Llm/chain/LangChain/ainvoke", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -1050,10 +1050,10 @@ def test_async_langchain_chain_list_response(
 @validate_custom_event_count(count=7)
 @validate_transaction_metrics(
     name="test_chain:test_async_langchain_chain_list_response_no_content",
-    scoped_metrics=[("Llm/chain/Langchain/ainvoke", 1)],
-    rollup_metrics=[("Llm/chain/Langchain/ainvoke", 1)],
+    scoped_metrics=[("Llm/chain/LangChain/ainvoke", 1)],
+    rollup_metrics=[("Llm/chain/LangChain/ainvoke", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -1186,10 +1186,10 @@ def test_async_langchain_chain(
     @validate_custom_event_count(count=8)
     @validate_transaction_metrics(
         name="test_chain:test_async_langchain_chain.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -1285,10 +1285,10 @@ def test_async_langchain_chain_error_in_openai(
     @validate_custom_event_count(count=6)
     @validate_transaction_metrics(
         name="test_chain:test_async_langchain_chain_error_in_openai.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -1361,10 +1361,10 @@ def test_async_langchain_chain_error_in_langchain(
     @validate_custom_event_count(count=2)
     @validate_transaction_metrics(
         name="test_chain:test_async_langchain_chain_error_in_langchain.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -1438,10 +1438,10 @@ def test_async_langchain_chain_error_in_langchain_no_content(
     @validate_custom_event_count(count=2)
     @validate_transaction_metrics(
         name="test_chain:test_async_langchain_chain_error_in_langchain_no_content.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 1)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 1)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )
@@ -1541,10 +1541,10 @@ def test_multiple_async_langchain_chain(
     @validate_custom_event_count(count=16)
     @validate_transaction_metrics(
         name="test_chain:test_multiple_async_langchain_chain.<locals>._test",
-        scoped_metrics=[("Llm/chain/Langchain/%s" % call_function, 2)],
-        rollup_metrics=[("Llm/chain/Langchain/%s" % call_function, 2)],
+        scoped_metrics=[("Llm/chain/LangChain/%s" % call_function, 2)],
+        rollup_metrics=[("Llm/chain/LangChain/%s" % call_function, 2)],
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )

--- a/tests/mlmodel_langchain/test_tool.py
+++ b/tests/mlmodel_langchain/test_tool.py
@@ -97,10 +97,10 @@ single_arg_tool_recorded_events = [
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_single_arg_tool",
-    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/run", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/run", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -117,10 +117,10 @@ def test_langchain_single_arg_tool(set_trace_info, single_arg_tool):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_single_arg_tool_no_content",
-    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/run", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/run", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -136,10 +136,10 @@ def test_langchain_single_arg_tool_no_content(set_trace_info, single_arg_tool):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_single_arg_tool_async",
-    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/arun", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/arun", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -156,10 +156,10 @@ def test_langchain_single_arg_tool_async(set_trace_info, single_arg_tool, loop):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_single_arg_tool_async_no_content",
-    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/arun", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/arun", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -198,10 +198,10 @@ multi_arg_tool_recorded_events = [
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_multi_arg_tool",
-    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/run", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/run", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -222,10 +222,10 @@ def test_langchain_multi_arg_tool(set_trace_info, multi_arg_tool):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_multi_arg_tool_async",
-    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/arun", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/arun", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -280,10 +280,10 @@ multi_arg_error_recorded_events = [
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_error_in_run",
-    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/run", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/run", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -312,10 +312,10 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_error_in_run_no_content",
-    scoped_metrics=[("Llm/tool/Langchain/run", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/run", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/run", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/run", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -343,10 +343,10 @@ def test_langchain_error_in_run_no_content(set_trace_info, multi_arg_tool):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_error_in_run_async",
-    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/arun", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/arun", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -377,10 +377,10 @@ def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_tool:test_langchain_error_in_run_async_no_content",
-    scoped_metrics=[("Llm/tool/Langchain/arun", 1)],
-    rollup_metrics=[("Llm/tool/Langchain/arun", 1)],
+    scoped_metrics=[("Llm/tool/LangChain/arun", 1)],
+    rollup_metrics=[("Llm/tool/LangChain/arun", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -451,7 +451,7 @@ def test_langchain_multiple_async_calls(set_trace_info, single_arg_tool, multi_a
     @validate_transaction_metrics(
         name="test_tool:test_langchain_multiple_async_calls.<locals>._test",
         custom_metrics=[
-            ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+            ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
         ],
         background_task=True,
     )

--- a/tests/mlmodel_langchain/test_vectorstore.py
+++ b/tests/mlmodel_langchain/test_vectorstore.py
@@ -130,10 +130,10 @@ def test_vectorstore_modules_instrumented():
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(
     name="test_vectorstore:test_pdf_pagesplitter_vectorstore_in_txn",
-    scoped_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -161,10 +161,10 @@ def test_pdf_pagesplitter_vectorstore_in_txn(set_trace_info, embedding_openai_cl
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(
     name="test_vectorstore:test_pdf_pagesplitter_vectorstore_in_txn_no_content",
-    scoped_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -221,10 +221,10 @@ def test_pdf_pagesplitter_vectorstore_ai_monitoring_disabled(set_trace_info, emb
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(
     name="test_vectorstore:test_async_pdf_pagesplitter_vectorstore_in_txn",
-    scoped_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -256,10 +256,10 @@ def test_async_pdf_pagesplitter_vectorstore_in_txn(loop, set_trace_info, embeddi
 @validate_custom_event_count(count=4)
 @validate_transaction_metrics(
     name="test_vectorstore:test_async_pdf_pagesplitter_vectorstore_in_txn_no_content",
-    scoped_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -346,10 +346,10 @@ vectorstore_error_events = [
 @validate_custom_events(vectorstore_error_events)
 @validate_transaction_metrics(
     name="test_vectorstore:test_vectorstore_error",
-    scoped_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -374,10 +374,10 @@ def test_vectorstore_error(set_trace_info, embedding_openai_client, loop):
 @validate_custom_events(vectorstore_events_sans_content(vectorstore_error_events))
 @validate_transaction_metrics(
     name="test_vectorstore:test_vectorstore_error_no_content",
-    scoped_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/similarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/similarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -401,10 +401,10 @@ def test_vectorstore_error_no_content(set_trace_info, embedding_openai_client):
 @validate_custom_events(vectorstore_error_events)
 @validate_transaction_metrics(
     name="test_vectorstore:test_async_vectorstore_error",
-    scoped_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )
@@ -434,10 +434,10 @@ def test_async_vectorstore_error(loop, set_trace_info, embedding_openai_client):
 @validate_custom_events(vectorstore_events_sans_content(vectorstore_error_events))
 @validate_transaction_metrics(
     name="test_vectorstore:test_async_vectorstore_error_no_content",
-    scoped_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
-    rollup_metrics=[("Llm/vectorstore/Langchain/asimilarity_search", 1)],
+    scoped_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
+    rollup_metrics=[("Llm/vectorstore/LangChain/asimilarity_search", 1)],
     custom_metrics=[
-        ("Supportability/Python/ML/Langchain/%s" % langchain.__version__, 1),
+        ("Supportability/Python/ML/LangChain/%s" % langchain.__version__, 1),
     ],
     background_task=True,
 )


### PR DESCRIPTION
# Overview
Previously, when using langchain only (no bedrock or openai), the metric name was not correct so the AI tab would not show up. This has been fixed.
