### PR TITLE
Add tags to forwarded logs

### DIFF
--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -702,6 +702,8 @@ def get_service_linking_metadata(application=None, settings=None):
         if entity_guid:
             metadata["entity.guid"] = entity_guid
         metadata["hostname"] = platform.uname()[1]
+        for label in settings.labels:
+            metadata["tags." + label["label_type"]] = label["label_value"]
 
     return metadata
 


### PR DESCRIPTION


# Overview
This adds any tags defined in `NEW_RELIC_LABELS` as `tags.*` attributes in the forwarded logs captured by the agent. This brings some parity to the attributes included in transactions, so logs can be tagged without setting up a separate log forwarder.

This is implemented by adding the tag attributes to the `get_linking_metadata()` API so they are available in a few different places that forward logs, as well as included in the output of the `NewRelicContextFormatter` if manual instrumentation is used.

I haven't put this behind a new setting, but would be happy to do that if you think it's necessary (a suggestion for a suitable name would be appreciated in that case).

# Testing
There's 1 test added, feedback definitely welcome there on the approach I took.
