### PR TITLE
Fix params not getting passed bug

### DIFF
--- a/newrelic/api/message_trace.py
+++ b/newrelic/api/message_trace.py
@@ -140,7 +140,7 @@ def MessageTraceWrapper(
             _operation,
             _destination_type,
             _destination_name,
-            params={},
+            params=params,
             terminal=terminal,
             parent=parent,
             source=wrapped,


### PR DESCRIPTION
# Overview
Fix bug where params aren't getting passed into MessageTrace call.
