### PR TITLE
Add env var for GC runtime metrics.

### DIFF
--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -747,9 +747,7 @@ _settings.attributes.include = []
 _settings.thread_profiler.enabled = True
 _settings.cross_application_tracer.enabled = False
 
-_settings.gc_runtime_metrics.enabled = _environ_as_bool(
-    "NEW_RELIC_GC_RUNTIME_METRICS_ENABLED", default=False
-)
+_settings.gc_runtime_metrics.enabled = _environ_as_bool("NEW_RELIC_GC_RUNTIME_METRICS_ENABLED", default=False)
 _settings.gc_runtime_metrics.top_object_count_limit = 5
 
 _settings.memory_runtime_pid_metrics.enabled = _environ_as_bool(

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -747,7 +747,9 @@ _settings.attributes.include = []
 _settings.thread_profiler.enabled = True
 _settings.cross_application_tracer.enabled = False
 
-_settings.gc_runtime_metrics.enabled = False
+_settings.gc_runtime_metrics.enabled = _environ_as_bool(
+    "NEW_RELIC_GC_RUNTIME_METRICS_ENABLED", default=False
+)
 _settings.gc_runtime_metrics.top_object_count_limit = 5
 
 _settings.memory_runtime_pid_metrics.enabled = _environ_as_bool(


### PR DESCRIPTION
This PR adds an env var for the setting to control whether GC runtime metrics are enabled.
