### PR TITLE
Use replace instead of lstrip to strip dns://

### DIFF
--- a/newrelic/hooks/framework_grpc.py
+++ b/newrelic/hooks/framework_grpc.py
@@ -24,7 +24,7 @@ from newrelic.common.object_wrapper import wrap_function_wrapper
 
 
 def _get_uri_method(instance, *args, **kwargs):
-    target = instance._channel.target().decode("utf-8").lstrip("dns:///")
+    target = instance._channel.target().decode("utf-8").replace("dns:///", "")
     method = instance._method.decode("utf-8").lstrip("/")
     uri = "grpc://%s/%s" % (target, method)
     return (uri, method)
@@ -43,7 +43,6 @@ def _prepare_request_stream(transaction, guid, request_iterator, *args, **kwargs
 
 
 def wrap_call(module, object_path, prepare):
-
     def _call_wrapper(wrapped, instance, args, kwargs):
         transaction = current_transaction()
         if transaction is None:
@@ -58,7 +57,6 @@ def wrap_call(module, object_path, prepare):
 
 
 def wrap_future(module, object_path, prepare):
-
     def _future_wrapper(wrapped, instance, args, kwargs):
         transaction = current_transaction()
         if transaction is None:

--- a/tests/framework_grpc/test_get_url.py
+++ b/tests/framework_grpc/test_get_url.py
@@ -18,32 +18,28 @@ import pytest
 
 from newrelic.hooks.framework_grpc import _get_uri_method
 
-
 _test_get_url_unary_unary = [
-        ('localhost:1234', '/sample/method',
-            'grpc://localhost:1234/sample/method'),
-        ('localhost:1234', 'method/without/leading/slash',
-            'grpc://localhost:1234/method/without/leading/slash'),
-        ('localhost', '/no/port',
-            'grpc://localhost/no/port'),
+    ("localhost:1234", "/sample/method", "grpc://localhost:1234/sample/method"),
+    ("localhost:1234", "method/without/leading/slash", "grpc://localhost:1234/method/without/leading/slash"),
+    ("localhost", "/no/port", "grpc://localhost/no/port"),
+    ("newrelic-otel-productcatalogservice", "/no/port", "grpc://newrelic-otel-productcatalogservice/no/port"),
 ]
 
 _test_channel_types = [
-        ('unary_unary', grpc._channel._UnaryUnaryMultiCallable),
-        ('unary_stream', grpc._channel._UnaryStreamMultiCallable),
-        ('stream_unary', grpc._channel._StreamUnaryMultiCallable),
-        ('stream_stream', grpc._channel._StreamStreamMultiCallable),
+    ("unary_unary", grpc._channel._UnaryUnaryMultiCallable),
+    ("unary_stream", grpc._channel._UnaryStreamMultiCallable),
+    ("stream_unary", grpc._channel._StreamUnaryMultiCallable),
+    ("stream_stream", grpc._channel._StreamStreamMultiCallable),
 ]
 
 
-@pytest.mark.parametrize('url,method,expected', _test_get_url_unary_unary)
-@pytest.mark.parametrize('channel_type,channel_class', _test_channel_types)
-def test_get_url_method(url, method, expected, channel_type,
-        channel_class):
+@pytest.mark.parametrize("url,method,expected", _test_get_url_unary_unary)
+@pytest.mark.parametrize("channel_type,channel_class", _test_channel_types)
+def test_get_url_method(url, method, expected, channel_type, channel_class):
     channel = grpc.insecure_channel(url)
     unary_unary = getattr(channel, channel_type)(method)
-    assert type(unary_unary) == channel_class
+    assert isinstance(unary_unary, channel_class)
 
     actual_url, actual_method = _get_uri_method(unary_unary)
     assert actual_url == expected
-    assert actual_method == method.lstrip('/')
+    assert actual_method == method.lstrip("/")


### PR DESCRIPTION
lstrip strips all the characters from the beginning of the string so strings that begin in d, n, or s get the first character(s) stripped. Replace is actually what we want in this case.