### PR TITLE
Add Dispatcher Information for uvicorn-worker Package

### DIFF
--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -152,7 +152,7 @@ def environment_settings():
             dispatcher.append(("Dispatcher", "gunicorn (gevent)"))
         elif "gunicorn.workers.geventlet" in sys.modules:
             dispatcher.append(("Dispatcher", "gunicorn (eventlet)"))
-        elif "uvicorn.workers" in sys.modules:
+        elif "uvicorn.workers" in sys.modules or "uvicorn_worker" in sys.modules:
             dispatcher.append(("Dispatcher", "gunicorn (uvicorn)"))
             uvicorn = sys.modules.get("uvicorn")
             if hasattr(uvicorn, "__version__"):

--- a/tests/agent_unittests/test_environment.py
+++ b/tests/agent_unittests/test_environment.py
@@ -113,6 +113,17 @@ def test_plugin_list_uses_no_sys_modules_iterator(monkeypatch):
             "1.2.3",
             "4.5.6",
         ),
+        # New replacement module uvicorn_worker should function the same
+        (
+            {
+                "gunicorn": module("1.2.3"),
+                "uvicorn": module("4.5.6"),
+                "uvicorn_worker": object(),
+            },
+            "gunicorn (uvicorn)",
+            "1.2.3",
+            "4.5.6",
+        ),
         ({"uvicorn": object()}, "uvicorn", None, None),
         (
             {


### PR DESCRIPTION
# Overview

`uvicorn.workers` has been moved to a separate package called `uvicorn_worker`. Check for both names of this module when reporting dispatcher information.

# Related Github Issue

Discovered thanks to issue #1208.

Unrelated to the problem that issue reported however.