### PR TITLE
Fix AI test failures & do not run graphqlmaster tests

### DIFF
--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -696,7 +696,7 @@ def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
     @validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
     @validate_custom_event_count(count=2)
     @validate_error_trace_attributes(
-        "botocore.eventstream:InvalidHeadersLength",
+        "botocore.eventstream:ChecksumMismatch",
         exact_attrs={
             "agent": {},
             "intrinsic": {},
@@ -723,7 +723,7 @@ def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
     def _test():
         model = "amazon.titan-text-express-v1"
         body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
-        with pytest.raises(botocore.eventstream.InvalidHeadersLength):
+        with pytest.raises(botocore.eventstream.ChecksumMismatch):
             set_trace_info()
             add_custom_attribute("llm.conversation_id", "my-awesome-id")
             add_custom_attribute("llm.foo", "bar")

--- a/tests/mlmodel_langchain/test_chain.py
+++ b/tests/mlmodel_langchain/test_chain.py
@@ -523,7 +523,7 @@ recorded_events_retrieval_chain_response = [
             "vendor": "langchain",
             "ingest_source": "Python",
             "virtual_llm": True,
-            "content": "{'input': 'math', 'context': [Document(page_content='What is 2 + 4?')]}",
+            "content": "{'input': 'math', 'context': [Document(metadata={}, page_content='What is 2 + 4?')]}",
         },
     ],
     [
@@ -555,7 +555,7 @@ recorded_events_retrieval_chain_response = [
             "ingest_source": "Python",
             "is_response": True,
             "virtual_llm": True,
-            "content": "{'input': 'math', 'context': [Document(page_content='What is 2 + 4?')], 'answer': '```html\\n<!DOCTYPE html>\\n<html>\\n<head>\\n  <title>Math Quiz</title>\\n</head>\\n<body>\\n  <h2>Math Quiz Questions</h2>\\n  <ol>\\n    <li>What is the result of 5 + 3?</li>\\n      <ul>\\n        <li>A) 7</li>\\n        <li>B) 8</li>\\n        <li>C) 9</li>\\n        <li>D) 10</li>\\n      </ul>\\n    <li>What is the product of 6 x 7?</li>\\n      <ul>\\n        <li>A) 36</li>\\n        <li>B) 42</li>\\n        <li>C) 48</li>\\n        <li>D) 56</li>\\n      </ul>\\n    <li>What is the square root of 64?</li>\\n      <ul>\\n        <li>A) 6</li>\\n        <li>B) 7</li>\\n        <li>C) 8</li>\\n        <li>D) 9</li>\\n      </ul>\\n    <li>What is the result of 12 / 4?</li>\\n      <ul>\\n        <li>A) 2</li>\\n        <li>B) 3</li>\\n        <li>C) 4</li>\\n        <li>D) 5</li>\\n      </ul>\\n    <li>What is the sum of 15 + 9?</li>\\n      <ul>\\n        <li>A) 22</li>\\n        <li>B) 23</li>\\n        <li>C) 24</li>\\n        <li>D) 25</li>\\n      </ul>\\n  </ol>\\n</body>\\n</html>\\n```'}",
+            "content": "{'input': 'math', 'context': [Document(metadata={}, page_content='What is 2 + 4?')], 'answer': '```html\\n<!DOCTYPE html>\\n<html>\\n<head>\\n  <title>Math Quiz</title>\\n</head>\\n<body>\\n  <h2>Math Quiz Questions</h2>\\n  <ol>\\n    <li>What is the result of 5 + 3?</li>\\n      <ul>\\n        <li>A) 7</li>\\n        <li>B) 8</li>\\n        <li>C) 9</li>\\n        <li>D) 10</li>\\n      </ul>\\n    <li>What is the product of 6 x 7?</li>\\n      <ul>\\n        <li>A) 36</li>\\n        <li>B) 42</li>\\n        <li>C) 48</li>\\n        <li>D) 56</li>\\n      </ul>\\n    <li>What is the square root of 64?</li>\\n      <ul>\\n        <li>A) 6</li>\\n        <li>B) 7</li>\\n        <li>C) 8</li>\\n        <li>D) 9</li>\\n      </ul>\\n    <li>What is the result of 12 / 4?</li>\\n      <ul>\\n        <li>A) 2</li>\\n        <li>B) 3</li>\\n        <li>C) 4</li>\\n        <li>D) 5</li>\\n      </ul>\\n    <li>What is the sum of 15 + 9?</li>\\n      <ul>\\n        <li>A) 22</li>\\n        <li>B) 23</li>\\n        <li>C) 24</li>\\n        <li>D) 25</li>\\n      </ul>\\n  </ol>\\n</body>\\n</html>\\n```'}",
         },
     ],
 ]

--- a/tests/mlmodel_langchain/test_tool.py
+++ b/tests/mlmodel_langchain/test_tool.py
@@ -17,7 +17,7 @@ import copy
 import uuid
 
 import langchain
-import pydantic
+import pydantic_core
 import pytest
 from langchain.tools import tool
 from mock import patch
@@ -269,7 +269,7 @@ multi_arg_error_recorded_events = [
 @reset_core_stats_engine()
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
-    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    callable_name(pydantic_core._pydantic_core.ValidationError),
     exact_attrs={
         "agent": {},
         "intrinsic": {},
@@ -289,7 +289,7 @@ multi_arg_error_recorded_events = [
 )
 @background_task()
 def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
-    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+    with pytest.raises(pydantic_core._pydantic_core.ValidationError):
         set_trace_info()
         # Only one argument is provided while the tool expects two to create an error
         multi_arg_tool.run(
@@ -301,7 +301,7 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 @disabled_ai_monitoring_record_content_settings
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
-    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    callable_name(pydantic_core._pydantic_core.ValidationError),
     exact_attrs={
         "agent": {},
         "intrinsic": {},
@@ -321,7 +321,7 @@ def test_langchain_error_in_run(set_trace_info, multi_arg_tool):
 )
 @background_task()
 def test_langchain_error_in_run_no_content(set_trace_info, multi_arg_tool):
-    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+    with pytest.raises(pydantic_core._pydantic_core.ValidationError):
         set_trace_info()
         # Only one argument is provided while the tool expects two to create an error
         multi_arg_tool.run(
@@ -332,7 +332,7 @@ def test_langchain_error_in_run_no_content(set_trace_info, multi_arg_tool):
 @reset_core_stats_engine()
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
-    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    callable_name(pydantic_core._pydantic_core.ValidationError),
     exact_attrs={
         "agent": {},
         "intrinsic": {},
@@ -352,7 +352,7 @@ def test_langchain_error_in_run_no_content(set_trace_info, multi_arg_tool):
 )
 @background_task()
 def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
-    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+    with pytest.raises(pydantic_core._pydantic_core.ValidationError):
         set_trace_info()
         # Only one argument is provided while the tool expects two to create an error
         loop.run_until_complete(
@@ -366,7 +366,7 @@ def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
 @disabled_ai_monitoring_record_content_settings
 @validate_transaction_error_event_count(1)
 @validate_error_trace_attributes(
-    callable_name(pydantic.v1.error_wrappers.ValidationError),
+    callable_name(pydantic_core._pydantic_core.ValidationError),
     exact_attrs={
         "agent": {},
         "intrinsic": {},
@@ -386,7 +386,7 @@ def test_langchain_error_in_run_async(set_trace_info, multi_arg_tool, loop):
 )
 @background_task()
 def test_langchain_error_in_run_async_no_content(set_trace_info, multi_arg_tool, loop):
-    with pytest.raises(pydantic.v1.error_wrappers.ValidationError):
+    with pytest.raises(pydantic_core._pydantic_core.ValidationError):
         set_trace_info()
         # Only one argument is provided while the tool expects two to create an error
         loop.run_until_complete(

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,8 @@ envlist =
     python-framework_flask-{py38,py39,py310,py311,py312,pypy310}-flask{020205,latest,master},
     python-framework_graphene-{py37,py38,py39,py310,py311,py312}-graphenelatest,
     python-framework_graphql-{py37,py38,py39,py310,py311,py312,pypy310}-graphql03,
-    python-framework_graphql-{py37,py38,py39,py310,py311,py312,pypy310}-graphql{latest,master},
+    ; Remove graphqlmaster tests.
+    python-framework_graphql-{py37,py38,py39,py310,py311,py312,pypy310}-graphql{latest},
     python-framework_graphql-py37-graphql{0301,0302},
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,pypy310}-Pyramidlatest,
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,pypy310}-Pyramid0110-cornice,

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,7 @@ envlist =
     python-logger_loguru-{py37,py38,py39,py310,py311,py312,pypy310}-logurulatest,
     python-logger_loguru-py39-loguru{06,05},
     python-logger_structlog-{py37,py38,py39,py310,py311,py312,pypy310}-structloglatest,
-    python-mlmodel_langchain-{py38,py39,py310,py311,py312},
+    python-mlmodel_langchain-{py39,py310,py311,py312},
     python-mlmodel_openai-openai0-{py37,py38,py39,py310,py311,py312},
     python-mlmodel_openai-openai107-py312,
     python-mlmodel_openai-openailatest-{py37,py38,py39,py310,py311,py312},


### PR DESCRIPTION
# Overview
Fix the following AI test failures:
* Bedrock changed the order of payload assertions in commit: https://github.com/boto/botocore/commit/db41663ea2fa84cb77d548934c92d3d5c26c2c05 which resulted in the expected error being different due to the validator order change.
* Langchain added metadata to Document interface so update expected events with this field.
* pydantic ValidationError moved locations so adjust the path to the error in the tests.
* Langchain doesn't list support for Python3.8 so do not test it on Python3.8.
* Graphql main tests are failing so comment these out for now.
