### PR TITLE
Add support for kafka-python-ng

### DIFF
--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -49,7 +49,9 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
     topic, value, key, headers, partition, timestamp_ms = _bind_send(*args, **kwargs)
     headers = list(headers) if headers else []
 
-    transaction.add_messagebroker_info("Kafka-Python", get_package_version("kafka-python"))
+    transaction.add_messagebroker_info(
+        "Kafka-Python", get_package_version("kafka-python") or get_package_version("kafka-python-ng")
+    )
 
     with MessageTrace(
         library="Kafka",
@@ -152,7 +154,9 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             name = "Named/%s" % destination_name
             transaction.record_custom_metric("%s/%s/Received/Bytes" % (group, name), received_bytes)
             transaction.record_custom_metric("%s/%s/Received/Messages" % (group, name), message_count)
-            transaction.add_messagebroker_info("Kafka-Python", get_package_version("kafka-python"))
+            transaction.add_messagebroker_info(
+                "Kafka-Python", get_package_version("kafka-python") or get_package_version("kafka-python-ng")
+            )
 
     return record
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ envlist =
     kafka-messagebroker_confluentkafka-{py39}-confluentkafka{0108},
     kafka-messagebroker_kafkapython-{py27,py38}-kafkapython{020001,020000},
     kafka-messagebroker_kafkapython-{pypy27,py27,py37,py38,pypy310}-kafkapythonlatest,
+    kafka-messagebroker_kafkapython-{py38,py39,py310,py311,py312,pypy310}-kafkapythonnglatest,
     memcached-datastore_bmemcached-{pypy27,py27,py37,py38,py39,py310,py311,py312}-memcached030,
     memcached-datastore_aiomcache-{py38,py39,py310,py311,py312}-memcached030,
     memcached-datastore_memcache-{py37,py38,py39,py310,py311,py312,pypy310}-memcached01,
@@ -393,6 +394,7 @@ deps =
     messagebroker_confluentkafka-confluentkafka0108: confluent-kafka<1.9
     messagebroker_confluentkafka-confluentkafka0107: confluent-kafka<1.8
     messagebroker_confluentkafka-confluentkafka0106: confluent-kafka<1.7
+    messagebroker_kafkapython-kafkapythonnglatest: kafka-python-ng
     messagebroker_kafkapython-kafkapythonlatest: kafka-python
     messagebroker_kafkapython-kafkapython020001: kafka-python<2.0.2
     messagebroker_kafkapython-kafkapython020000: kafka-python<2.0.1


### PR DESCRIPTION
# Overview
[kafka-python](https://github.com/dpkp/kafka-python) has moved to [kafka-python-ng](https://github.com/wbarnha/kafka-python-ng/) due to lack of response from the original maintainer of the package.