### PR TITLE
Pin gRPC version supported in Python 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ envlist =
     elasticsearchserver07-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch07,
     elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch08,
     firestore-datastore_firestore-{py37,py38,py39,py310,py311,py312,py313},
-    grpc0167-framework_grpc-py37-grpc0167,
+    grpc-framework_grpc-py37-grpc0167,
     grpc-framework_grpc-{py38,py39,py310,py311,py312,py313}-grpclatest,
     kafka-messagebroker_confluentkafka-py39-confluentkafka{0108,0107,0106},
     kafka-messagebroker_confluentkafka-{py37,py38,py39,py310,py311,py312}-confluentkafkalatest,

--- a/tox.ini
+++ b/tox.ini
@@ -217,6 +217,9 @@ deps =
     adapter_waitress-waitresslatest: waitress
     agent_features: beautifulsoup4
     agent_features: protobuf
+    agent_streaming-protobuf04: protobuf<5
+    agent_streaming-protobuf03: protobuf<4
+    agent_streaming-protobuf0319: protobuf<3.20
     application_celery-celerylatest: celery[pytest]
     application_celery-celery0504: celery[pytest]<5.5
     application_celery-celery0503: celery[pytest]<5.4
@@ -343,12 +346,9 @@ deps =
     framework_grpc-grpclatest: protobuf
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
-    grpc0167: grpcio<1.67
-    grpc0167: grpcio-tools<1.67
-    grpc0167: protobuf<5.28.2
-    protobuf0319: protobuf<3.20
-    protobuf03: protobuf<4
-    protobuf04: protobuf<5
+    framework_grpc-grpc0167: grpcio<1.67
+    framework_grpc-grpc0167: grpcio-tools<1.67
+    framework_grpc-grpc0167: protobuf<5
     framework_pyramid: routes
     framework_pyramid-cornice: cornice!=5.0.0
     framework_pyramid-Pyramidlatest: Pyramid

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,8 @@ envlist =
     elasticsearchserver07-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch07,
     elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch08,
     firestore-datastore_firestore-{py37,py38,py39,py310,py311,py312,py313},
-    grpc-framework_grpc-{py37,py38,py39,py310,py311,py312,py313}-grpclatest,
+    grpc0167-framework_grpc-py37-grpc0167,
+    grpc-framework_grpc-{py38,py39,py310,py311,py312,py313}-grpclatest,
     kafka-messagebroker_confluentkafka-py39-confluentkafka{0108,0107,0106},
     kafka-messagebroker_confluentkafka-{py37,py38,py39,py310,py311,py312}-confluentkafkalatest,
     ;; Package not ready for Python 3.13 (missing wheel)
@@ -342,9 +343,9 @@ deps =
     framework_grpc-grpclatest: protobuf
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
-    grpc0125: grpcio<1.26
-    grpc0125: grpcio-tools<1.26
-    grpc0125: protobuf<3.18.0
+    grpc0167: grpcio<1.67
+    grpc0167: grpcio-tools<1.67
+    grpc0167: protobuf<5.28.2
     protobuf0319: protobuf<3.20
     protobuf03: protobuf<4
     protobuf04: protobuf<5


### PR DESCRIPTION
The [latest release of gRPC](https://github.com/grpc/grpc/releases/tag/v1.67.0) does not support Python 3.7 ([as seen here](https://github.com/grpc/grpc/pull/37643))