### PR TITLE
Drop grpc 3.7 testing version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,6 @@ envlist =
     elasticsearchserver07-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch07,
     elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch08,
     firestore-datastore_firestore-{py37,py38,py39,py310,py311,py312,py313},
-    grpc-framework_grpc-py37-grpc0162,
     grpc-framework_grpc-{py38,py39,py310,py311,py312,py313}-grpclatest,
     kafka-messagebroker_confluentkafka-py39-confluentkafka{0108,0107,0106},
     kafka-messagebroker_confluentkafka-{py37,py38,py39,py310,py311,py312}-confluentkafkalatest,

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ envlist =
     elasticsearchserver07-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch07,
     elasticsearchserver08-datastore_elasticsearch-{py37,py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch08,
     firestore-datastore_firestore-{py37,py38,py39,py310,py311,py312,py313},
-    grpc-framework_grpc-py37-grpc0167,
+    grpc-framework_grpc-py37-grpc0162,
     grpc-framework_grpc-{py38,py39,py310,py311,py312,py313}-grpclatest,
     kafka-messagebroker_confluentkafka-py39-confluentkafka{0108,0107,0106},
     kafka-messagebroker_confluentkafka-{py37,py38,py39,py310,py311,py312}-confluentkafkalatest,
@@ -346,9 +346,9 @@ deps =
     framework_grpc-grpclatest: protobuf
     framework_grpc-grpclatest: grpcio
     framework_grpc-grpclatest: grpcio-tools
-    framework_grpc-grpc0167: grpcio<1.67
-    framework_grpc-grpc0167: grpcio-tools<1.67
-    framework_grpc-grpc0167: protobuf<5
+    framework_grpc-grpc0162: grpcio<1.63
+    framework_grpc-grpc0162: grpcio-tools<1.63
+    framework_grpc-grpc0162: protobuf<4.25
     framework_pyramid: routes
     framework_pyramid-cornice: cornice!=5.0.0
     framework_pyramid-Pyramidlatest: Pyramid


### PR DESCRIPTION
# Overview

* Older version of grpc for Python 3.7 testing is conflicting with latest grpc versions when installed, so drop it in favor of just testing supported versions of Python on the latest grpc version.
