### PR TITLE
Disable flaskmaster-py38

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -186,8 +186,7 @@ deps =
     {py38,py39,py310,py311,py312,py313,pypy310}: pytest==8.3.2
     py37: pytest==7.4.4
     iniconfig
-    {py39,py310,py311,py312,py313,pypy310}: coverage
-    {py37,py38}: coverage==7.6.1
+    coverage
     WebTest==3.0.0
     py313: legacy-cgi==2.6.1  # cgi was removed from the stdlib in 3.13, and is required for WebTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,9 @@ envlist =
     python-framework_fastapi-{py37,py38,py39,py310,py311,py312,py313},
     python-framework_flask-py37-flask020205,
     python-framework_flask-{py38,py39,py310,py311,py312,pypy310}-flask02,
-    python-framework_flask-{py38,py39,py310,py311,py312,py313,pypy310}-flask{latest,master},
+    ; python-framework_flask-py38-flaskmaster fails, even with Flask-Compress pinned to <1.16
+    python-framework_flask-py38-flasklatest,
+    python-framework_flask-{py39,py310,py311,py312,py313,pypy310}-flask{latest,master},
     python-framework_graphene-{py37,py38,py39,py310,py311,py312,py313}-graphenelatest,
     python-framework_graphql-{py37,py38,py39,py310,py311,py312,py313,pypy310}-graphql03,
     python-framework_graphql-{py37,py38,py39,py310,py311,py312,py313,pypy310}-graphql{latest},
@@ -184,7 +186,8 @@ deps =
     {py38,py39,py310,py311,py312,py313,pypy310}: pytest==8.3.2
     py37: pytest==7.4.4
     iniconfig
-    coverage
+    {py39,py310,py311,py312,py313,pypy310}: coverage
+    py38: coverage==7.6.1
     WebTest==3.0.0
     py313: legacy-cgi==2.6.1  # cgi was removed from the stdlib in 3.13, and is required for WebTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,7 @@ envlist =
     python-framework_fastapi-{py37,py38,py39,py310,py311,py312,py313},
     python-framework_flask-py37-flask020205,
     python-framework_flask-{py38,py39,py310,py311,py312,pypy310}-flask02,
-    ; python-framework_flask-py38-flaskmaster fails, even with Flask-Compress pinned to <1.16
+    ; python-framework_flask-py38-flaskmaster fails, even with Flask-Compress<1.16 and coverage==7.61 for py37,py38
     python-framework_flask-py38-flasklatest,
     python-framework_flask-{py39,py310,py311,py312,py313,pypy310}-flask{latest,master},
     python-framework_graphene-{py37,py38,py39,py310,py311,py312,py313}-graphenelatest,

--- a/tox.ini
+++ b/tox.ini
@@ -187,7 +187,7 @@ deps =
     py37: pytest==7.4.4
     iniconfig
     {py39,py310,py311,py312,py313,pypy310}: coverage
-    py38: coverage==7.6.1
+    {py37,py38}: coverage==7.6.1
     WebTest==3.0.0
     py313: legacy-cgi==2.6.1  # cgi was removed from the stdlib in 3.13, and is required for WebTest
 


### PR DESCRIPTION
This PR temporarily disables flaskmaster tests for Python 3.8