### PR TITLE
Add cloud.aws.account_id config setting

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -51,6 +51,11 @@ __all__ = ["initialize", "filter_app_factory"]
 
 _logger = logging.getLogger(__name__)
 
+
+def _map_aws_account_id(s):
+    return newrelic.core.config._map_aws_account_id(s, _logger)
+
+
 # Register our importer which implements post import hooks for
 # triggering of callbacks to monkey patch modules before import
 # returns them to caller.
@@ -560,6 +565,7 @@ def _process_configuration(section):
     _process_setting(section, "ai_monitoring.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.record_content.enabled", "getboolean", None)
     _process_setting(section, "ai_monitoring.streaming.enabled", "getboolean", None)
+    _process_setting(section, "cloud.aws.account_id", "get", _map_aws_account_id)
     _process_setting(section, "k8s_operator.enabled", "getboolean", None)
     _process_setting(section, "azure_operator.enabled", "getboolean", None)
     _process_setting(section, "package_reporting.enabled", "getboolean", None)

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -73,6 +73,21 @@ _logger = logging.getLogger(__name__)
 _logger.addHandler(_NullHandler())
 
 
+def _map_aws_account_id(s, logger):
+    # The AWS account id must be a 12 digit number.
+    # See https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#awsaccountid.
+    if s and len(s) == 12:
+        if s.isdecimal():
+            account_id = int(s)
+            return account_id
+    # Only log a warning if s is set.
+    if s:
+        logger.warning(
+            "Improper configuration. cloud.aws.account_id = %s will be ignored because it is not a 12 digit number.", s
+        )
+    return None
+
+
 # The Settings objects and the global default settings. We create a
 # distinct type for each sub category of settings that the agent knows
 # about so that an error when accessing a non-existent setting is more
@@ -121,6 +136,14 @@ class TopLevelSettings(Settings):
     @otlp_host.setter
     def otlp_host(self, value):
         self._otlp_host = value
+
+
+class CloudSettings(Settings):
+    pass
+
+
+class AWSSettings(Settings):
+    pass
 
 
 class AttributesSettings(Settings):
@@ -433,6 +456,8 @@ _settings.application_logging.forwarding.context_data = ApplicationLoggingForwar
 _settings.application_logging.metrics = ApplicationLoggingMetricsSettings()
 _settings.application_logging.local_decorating = ApplicationLoggingLocalDecoratingSettings()
 _settings.application_logging.metrics = ApplicationLoggingMetricsSettings()
+_settings.cloud = CloudSettings()
+_settings.cloud.aws = AWSSettings()
 _settings.machine_learning = MachineLearningSettings()
 _settings.machine_learning.inference_events_value = MachineLearningInferenceEventsValueSettings()
 _settings.ai_monitoring = AIMonitoringSettings()
@@ -966,6 +991,7 @@ _settings.application_logging.metrics.enabled = _environ_as_bool(
 _settings.application_logging.local_decorating.enabled = _environ_as_bool(
     "NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED", default=False
 )
+_settings.cloud.aws.account_id = _map_aws_account_id(os.environ.get("NEW_RELIC_CLOUD_AWS_ACCOUNT_ID"), _logger)
 _settings.machine_learning.enabled = _environ_as_bool("NEW_RELIC_MACHINE_LEARNING_ENABLED", default=False)
 _settings.machine_learning.inference_events_value.enabled = _environ_as_bool(
     "NEW_RELIC_MACHINE_LEARNING_INFERENCE_EVENT_VALUE_ENABLED", default=False

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -13,16 +13,13 @@
 # limitations under the License.
 
 import collections
+import logging
 import copy
 import sys
 import tempfile
-
 import urllib.parse as urlparse
 
 import pytest
-
-import logging
-
 from testing_support.fixtures import override_generic_settings
 
 from newrelic.api.exceptions import ConfigurationError
@@ -37,6 +34,7 @@ from newrelic.config import (
 )
 from newrelic.core.config import (
     Settings,
+    _map_aws_account_id,
     apply_config_setting,
     apply_server_side_settings,
     fetch_config_setting,
@@ -972,6 +970,27 @@ def test_initialize_developer_mode(section, expect_error, logger):
         assert "CONFIGURATION ERROR" in logger.caplog.records
     else:
         assert "CONFIGURATION ERROR" not in logger.caplog.records
+
+
+@pytest.mark.parametrize(
+    "account_id,expected_account_id",
+    (
+        ("012345678901", 12345678901),
+        ("0123456789.1", None),
+        ("01234567890", None),
+        ("01²345678901", None),
+        ("0xb101010101", None),
+        ("fooooooooooo", None),
+    ),
+)
+def test_map_aws_account_id(account_id, expected_account_id, logger):
+    message = f"Improper configuration. cloud.aws.account_id = {account_id} will be ignored because it is not a 12 digit number."
+
+    return_val = _map_aws_account_id(account_id, logger)
+
+    assert return_val == expected_account_id
+    if not expected_account_id:
+        assert message in logger.caplog.records
 
 
 newrelic_toml_contents = b"""

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import collections
-import logging
 import copy
+import logging
 import sys
 import tempfile
 import urllib.parse as urlparse
@@ -43,7 +43,6 @@ from newrelic.core.config import (
     global_settings_dump,
 )
 
-
 SKIP_IF_NOT_PY311 = pytest.mark.skipif(sys.version_info < (3, 11), reason="TOML not in the standard library.")
 
 
@@ -61,7 +60,7 @@ def restore_settings_fixture():
 
     # Run tests
     yield
-    
+
     # Restore settings after tests run
     original_settings.__dict__.clear()
     original_settings.__dict__.update(backup)


### PR DESCRIPTION
# Overview
Add cloud.aws.account_id configuration setting. This is not used in this PR but will be used in future AWS linking for the user to provide the account_id when it cannot be derived by the instrumentation. See the Entity-Relationships agent spec.
