### PR TITLE
Daphne HTTP/2 Testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1202,12 +1202,12 @@ jobs:
 
   valkey:
     env:
-      TOTAL_GROUPS: 2
+      TOTAL_GROUPS: 1
 
     strategy:
       fail-fast: false
       matrix:
-        group-number: [1, 2]
+        group-number: [1]
 
     runs-on: ubuntu-latest
     container:

--- a/tests/adapter_daphne/test_daphne.py
+++ b/tests/adapter_daphne/test_daphne.py
@@ -14,10 +14,9 @@
 
 import asyncio
 import threading
-from urllib.request import HTTPError, urlopen
 
-import niquests
 import daphne.server
+import niquests
 import pytest
 from testing_support.certs import CERT_PATH
 from testing_support.fixtures import (

--- a/tests/adapter_daphne/test_daphne.py
+++ b/tests/adapter_daphne/test_daphne.py
@@ -16,13 +16,16 @@ import asyncio
 import threading
 from urllib.request import HTTPError, urlopen
 
+import niquests
 import daphne.server
 import pytest
+from testing_support.certs import CERT_PATH
 from testing_support.fixtures import (
     override_application_settings,
     raise_background_exceptions,
     wait_for_background_threads,
 )
+from testing_support.http_23_testing import make_request
 from testing_support.sample_asgi_applications import (
     AppWithCall,
     AppWithCallRaw,
@@ -38,8 +41,12 @@ from testing_support.validators.validate_transaction_metrics import (
 )
 
 from newrelic.common.object_names import callable_name
+from newrelic.common.package_version_utils import (
+    get_package_version,
+    get_package_version_tuple,
+)
 
-DAPHNE_VERSION = tuple(int(v) for v in daphne.__version__.split(".")[:2])
+DAPHNE_VERSION = get_package_version_tuple("daphne")
 skip_asgi_3_unsupported = pytest.mark.skipif(DAPHNE_VERSION < (3, 0), reason="ASGI3 unsupported")
 skip_asgi_2_unsupported = pytest.mark.skipif(DAPHNE_VERSION >= (3, 0), reason="ASGI2 unsupported")
 
@@ -98,7 +105,7 @@ def server_and_port():
 
         server = daphne.server.Server(
             fake_app,
-            endpoints=[f"tcp:{port}:interface=127.0.0.1"],
+            endpoints=[f"ssl:{port}:privateKey={CERT_PATH}:certKey={CERT_PATH}:interface=127.0.0.1"],
             ready_callable=on_ready,
             signal_handlers=False,
             verbosity=9,
@@ -119,32 +126,35 @@ def server_and_port():
         raise RuntimeError("Thread failed to exit in time.")
 
 
+@pytest.mark.parametrize("http_version", [1, 2], ids=["HTTP/1", "HTTP/2"])
 @override_application_settings({"transaction_name.naming_scheme": "framework"})
-def test_daphne_200(port, app):
+def test_daphne_200(port, app, http_version):
+    daphne_version = get_package_version("daphne")
+    assert daphne_version is not None
+
     @validate_transaction_metrics(
         callable_name(app),
         custom_metrics=[
-            (f"Python/Dispatcher/Daphne/{daphne.__version__}", 1),
+            (f"Python/Dispatcher/Daphne/{daphne_version}", 1),
         ],
     )
     @raise_background_exceptions()
     @wait_for_background_threads()
     def response():
-        return urlopen(f"http://localhost:{port}", timeout=10)  # nosec
+        return make_request(host="localhost", port=port, path="/", http_version=http_version, timeout=10)
 
-    assert response().status == 200
+    response().raise_for_status()
 
 
+@pytest.mark.parametrize("http_version", [1, 2], ids=["HTTP/1", "HTTP/2"])
 @override_application_settings({"transaction_name.naming_scheme": "framework"})
-@validate_transaction_errors(["builtins:ValueError"])
-def test_daphne_500(port, app):
+def test_daphne_500(port, app, http_version):
+    @validate_transaction_errors(["builtins:ValueError"])
     @validate_transaction_metrics(callable_name(app))
     @raise_background_exceptions()
     @wait_for_background_threads()
     def _test():
-        try:
-            urlopen(f"http://localhost:{port}/exc")  # nosec
-        except HTTPError:
-            pass
+        with pytest.raises(niquests.exceptions.HTTPError):
+            make_request(host="localhost", port=port, path="/exc", http_version=http_version, timeout=10)
 
     _test()

--- a/tests/adapter_hypercorn/test_hypercorn.py
+++ b/tests/adapter_hypercorn/test_hypercorn.py
@@ -142,6 +142,7 @@ def wait_for_port(port, retries=10):
 @override_application_settings({"transaction_name.naming_scheme": "framework"})
 def test_hypercorn_200(port, app, http_version):
     hypercorn_version = get_package_version("hypercorn")
+    assert hypercorn_version is not None
 
     @validate_transaction_metrics(
         callable_name(app),

--- a/tox.ini
+++ b/tox.ini
@@ -199,6 +199,8 @@ deps =
     adapter_asgiref-asgiref0307: asgiref<3.8
     adapter_cheroot: cheroot
     adapter_daphne-daphnelatest: daphne
+    adapter_daphne-daphnelatest: Twisted[tls,http2]
+    adapter_daphne: niquests
     adapter_gevent: WSGIProxy2
     adapter_gevent: gevent
     adapter_gevent: urllib3


### PR DESCRIPTION
# Overview

* Add tests to Daphne that exercise the HTTP/2 server capabilities.
  * Identical to the tests for Hypercorn.