### PR TITLE
fix(NewRelicContextFormatter): add cause and context to stack traces

### DIFF
--- a/newrelic/api/log.py
+++ b/newrelic/api/log.py
@@ -16,7 +16,7 @@ import json
 import logging
 import re
 import warnings
-from traceback import format_tb
+from traceback import format_exception
 
 from newrelic.api.application import application_instance
 from newrelic.api.time_trace import get_linking_metadata
@@ -87,7 +87,7 @@ class NewRelicContextFormatter(logging.Formatter):
 
         if stack_trace_limit is None or stack_trace_limit > 0:
             if exc_info[2] is not None:
-                stack_trace = "".join(format_tb(exc_info[2], limit=stack_trace_limit)) or None
+                stack_trace = "".join(format_exception(*exc_info, limit=stack_trace_limit)) or None
             else:
                 stack_trace = None
             formatted["error.stack_trace"] = stack_trace


### PR DESCRIPTION
# Overview
`NewRelicContextFormatter` logs stack traces without causes which makes many errors hard to debug.

Let's take a look at the following code:

```python
try:
    try:
        raise ValueError("First exception")
    except:
        raise ValueError("Second exception")
except Exception as e:
    logging.error("Encountered error", exc_info=e)
```

Before the PR, the exception message looked as follows:

```
  File ".../newrelic_exception_cause.py", line 60, in <module>
    raise ValueError("Second exception")
```

After the PR, it shows more details on the first cause:

```
Traceback (most recent call last):
  File ".../newrelic_exception_cause.py", line 58, in <module>
    raise ValueError("First exception")
ValueError: First exception
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File ".../newrelic_exception_cause.py", line 60, in <module>
    raise ValueError("Second exception")
ValueError: Second exception
```

# Related Github Issue
No Github issue created.

# Testing
Tests were updated to test a particular case where exception has a cause.
