### PR TITLE
Fix Pathlike objects not accepted by newrelic.initialize()

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -977,6 +977,9 @@ def _load_configuration(
 
     _configuration_done = True
 
+    # Normalize configuration file into a string path
+    config_file = os.fsdecode(config_file) if config_file is not None else config_file
+
     # Update global variables tracking what configuration file and
     # environment was used, plus whether errors are to be ignored.
 

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -1063,7 +1063,27 @@ def test_toml_parse_production():
 @pytest.mark.parametrize(
     "pathtype", [str, lambda s: s.encode("utf-8"), pathlib.Path], ids=["str", "bytes", "pathlib.Path"]
 )
-def test_config_file_path_types(pathtype):
+def test_config_file_path_types_ini(pathtype):
+    settings = global_settings()
+    _reset_configuration_done()
+    _reset_config_parser()
+    _reset_instrumentation_done()
+
+    with tempfile.NamedTemporaryFile(suffix=".ini") as f:
+        f.write(newrelic_ini_contents)
+        f.seek(0)
+
+        config_file = pathtype(f.name)
+        initialize(config_file=config_file)
+        value = fetch_config_setting(settings, "app_name")
+        assert value == "Python Agent Test (agent_features)"
+
+
+@pytest.mark.parametrize(
+    "pathtype", [str, lambda s: s.encode("utf-8"), pathlib.Path], ids=["str", "bytes", "pathlib.Path"]
+)
+@SKIP_IF_NOT_PY311
+def test_config_file_path_types_toml(pathtype):
     settings = global_settings()
     _reset_configuration_done()
     _reset_config_parser()

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -1060,7 +1060,9 @@ def test_toml_parse_production():
         assert value.enabled is False
 
 
-@pytest.mark.parametrize("pathtype", [str, lambda s: s.encode("utf-8"), pathlib.Path], ids=["str", "bytes", "pathlib.Path"])
+@pytest.mark.parametrize(
+    "pathtype", [str, lambda s: s.encode("utf-8"), pathlib.Path], ids=["str", "bytes", "pathlib.Path"]
+)
 def test_config_file_path_types(pathtype):
     settings = global_settings()
     _reset_configuration_done()

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -15,6 +15,7 @@
 import collections
 import copy
 import logging
+import pathlib
 import sys
 import tempfile
 import urllib.parse as urlparse
@@ -1057,6 +1058,23 @@ def test_toml_parse_production():
         assert value == "test11 (Production)"
         value = fetch_config_setting(settings, "distributed_tracing")
         assert value.enabled is False
+
+
+@pytest.mark.parametrize("pathtype", [str, lambda s: s.encode("utf-8"), pathlib.Path], ids=["str", "bytes", "pathlib.Path"])
+def test_config_file_path_types(pathtype):
+    settings = global_settings()
+    _reset_configuration_done()
+    _reset_config_parser()
+    _reset_instrumentation_done()
+
+    with tempfile.NamedTemporaryFile(suffix=".toml") as f:
+        f.write(newrelic_toml_contents)
+        f.seek(0)
+
+        config_file = pathtype(f.name)
+        initialize(config_file=config_file)
+        value = fetch_config_setting(settings, "app_name")
+        assert value == "test11"
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

* Fixes bug where only str is accepted by `newrelic.initialize()` after update and not all `pathlib.Pathlike` object types (`str`, `bytes`, `PosixPath`, etc.).

# Related Github Issue

Fixes #1267