### PR TITLE
Fix OpenAI 1.7.2 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -377,6 +377,7 @@ deps =
     framework_tornado-tornadomaster: https://github.com/tornadoweb/tornado/archive/master.zip
     mlmodel_openai-openai0: openai[datalib]<1.0
     mlmodel_openai-openai107: openai[datalib]<1.8
+    mlmodel_openai-openai107: httpx<0.28
     mlmodel_openai-openailatest: openai[datalib]
     ; Required for openai testing
     mlmodel_openai: protobuf


### PR DESCRIPTION
Pin httpx version for openai v1.7.2 to resolve error: `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`