### PR TITLE
Disable Mergify Queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,21 +14,16 @@ shared:
 
 queue_rules:
   - name: default
-    conditions:
+    queue_conditions:
+      - and: *pr_ready_checks
+      - "-head~=^develop"
+    merge_conditions:
       - and: *pr_ready_checks
     merge_method: squash
 
+
 pull_request_rules:
   # Merge Queue PR Rules
-  - name: Regular PRs - Add to merge queue on approval (squash)
-    conditions:
-      - and: *pr_ready_checks
-      - "-head~=^develop" # Don't include PRs from develop branches
-    actions:
-      queue:
-        method: squash
-
-  # Automatic PR Updates
   - name: Automatic PR branch updates
     conditions:
       - "queue-position=-1" # Not queued
@@ -36,8 +31,6 @@ pull_request_rules:
       - "-merged"
     actions:
       update:
-
-  # Automatic Labeling
   - name: Clean up after merge
     conditions:
       - merged
@@ -78,3 +71,7 @@ pull_request_rules:
       label:
         remove:
           - "tests-failing"
+  - name: Regular PRs - Add to merge queue on approval (squash)
+    conditions: []
+    actions:
+      queue:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,31 +1,9 @@
 # For condition grammar see: https://docs.mergify.com/conditions/#grammar
 
-shared:
-  conditions:
-    - and: &pr_ready_checks
-        - "#approved-reviews-by>=1" # A '#' pulls the length of the underlying list
-        - "label=ready-to-merge"
-        - "check-success=tests"
-        - "-draft" # Don't include draft PRs
-        - "-merged"
-        - or: # Only handle branches that target main or develop branches
-            - "base=main"
-            - "base~=^develop"
-
-queue_rules:
-  - name: default
-    queue_conditions:
-      - and: *pr_ready_checks
-      - "-head~=^develop"
-    merge_conditions:
-      - and: *pr_ready_checks
-    merge_method: squash
-
 pull_request_rules:
-  # Merge Queue PR Rules
+  # Automatic PR Updates
   - name: Automatic PR branch updates
     conditions:
-      - "queue-position=-1" # Not queued
       - "-draft" # Don't include draft PRs
       - "-merged"
     actions:
@@ -70,7 +48,3 @@ pull_request_rules:
       label:
         remove:
           - "tests-failing"
-  - name: Regular PRs - Add to merge queue on approval (squash)
-    conditions: []
-    actions:
-      queue:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,7 +21,6 @@ queue_rules:
       - and: *pr_ready_checks
     merge_method: squash
 
-
 pull_request_rules:
   # Merge Queue PR Rules
   - name: Automatic PR branch updates

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,8 @@ pull_request_rules:
       - "-merged"
     actions:
       update:
+
+  # Automatic Labeling
   - name: Clean up after merge
     conditions:
       - merged


### PR DESCRIPTION
# Overview

* Disables mergify merge queue (replaced by GitHub's own merge queue)
* Updates mergify config 

# Related Github Issue

* Closes #1264 