### PR TITLE
Add Tablestore VectorStore

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2720,6 +2720,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "langchain_community.vectorstores.tablestore",
+        "newrelic.hooks.mlmodel_langchain",
+        "instrument_langchain_vectorstore_similarity_search",
+    )
+
+    _process_module_definition(
         "langchain_core.tools",
         "newrelic.hooks.mlmodel_langchain",
         "instrument_langchain_core_tools",

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -105,6 +105,7 @@ VECTORSTORE_CLASSES = {
     "langchain_community.vectorstores.starrocks": "StarRocks",
     "langchain_community.vectorstores.supabase": "SupabaseVectorStore",
     "langchain_community.vectorstores.surrealdb": "SurrealDBStore",
+    "langchain_community.vectorstores.tablestore": "TablestoreVectorStore",
     "langchain_community.vectorstores.tair": "Tair",
     "langchain_community.vectorstores.tencentvectordb": "TencentVectorDB",
     "langchain_community.vectorstores.tidb_vector": "TiDBVectorStore",


### PR DESCRIPTION
This PR adds the TablestoreVectorStore to the list of VectorStores to be instrumented by LangChain