### PR TITLE
Check for ExceptionMiddlware removal in starlette.exceptions

### DIFF
--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -252,7 +252,9 @@ def instrument_starlette_middleware_exceptions(module):
 def instrument_starlette_exceptions(module):
     # ExceptionMiddleware was moved to starlette.middleware.exceptions, need to check
     # that it isn't being imported through a deprecation and double wrapped.
-    if not hasattr(module, "__deprecated__"):
+
+    # After v0.45.0, the import proxy for ExceptionMiddleware was removed from starlette.exceptions
+    if hasattr(module, "ExceptionMiddleware") and not hasattr(module, "__deprecated__"):
 
         wrap_function_wrapper(module, "ExceptionMiddleware.__call__", error_middleware_wrapper)
 

--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -254,7 +254,7 @@ def instrument_starlette_exceptions(module):
     # that it isn't being imported through a deprecation and double wrapped.
 
     # After v0.45.0, the import proxy for ExceptionMiddleware was removed from starlette.exceptions
-    if hasattr(module, "ExceptionMiddleware") and not hasattr(module, "__deprecated__"):
+    if not hasattr(module, "__deprecated__") and hasattr(module, "ExceptionMiddleware"):
 
         wrap_function_wrapper(module, "ExceptionMiddleware.__call__", error_middleware_wrapper)
 


### PR DESCRIPTION
After [Starlette v0.45.0](https://github.com/encode/starlette/releases/tag/0.45.0) the import proxy for `ExceptionMiddleware` was removed from `starlette.exceptions` (and now only resides in `starlette.middleware.exceptions`).  

This PR adds an additional checker to make sure that, when checking for double instrumentation, the import proxy exists (which is when this particular issue would occur).