### PR TITLE
Fix Sanic Testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -138,7 +138,8 @@ envlist =
     python-framework_graphql-py37-graphql{0301,0302},
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,py313,pypy310}-Pyramidlatest,
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,py313,pypy310}-Pyramid0110-cornice,
-    python-framework_sanic-{py37,py38,py39,py310,py311,py312,py313,pypy310}-saniclatest,
+    python-framework_sanic-{py37,py38}-sanic2406,
+    python-framework_sanic-{py39,py310,py311,py312,py313,pypy310}-saniclatest,
     python-framework_sanic-{py38,pypy310}-sanic{200904,210300,2109,2112,2203,2290},
     python-framework_starlette-{py310,pypy310}-starlette{0014,0015,0019,0028},
     python-framework_starlette-{py37,py38,py39,py310,py311,py312,py313,pypy310}-starlettelatest,
@@ -359,6 +360,7 @@ deps =
     framework_sanic-sanic2112: sanic<21.13
     framework_sanic-sanic2203: sanic<22.4
     framework_sanic-sanic2290: sanic<22.9.1
+    framework_sanic-sanic2406: sanic<24.07
     framework_sanic-saniclatest: sanic
     framework_sanic-sanic{200904,210300,2109,2112,2203,2290}: websockets<11
     ; For test_exception_in_middleware test, anyio is used:


### PR DESCRIPTION
# Overview

* Newer versions of sanic are incompatible with Python <=3.8 due to syntax errors. Pin older Python tests to the last supported sanic version.