### PR TITLE
Add additional metadata to vectorstore results

### DIFF
--- a/tests/mlmodel_langchain/test_vectorstore.py
+++ b/tests/mlmodel_langchain/test_vectorstore.py
@@ -83,6 +83,7 @@ vectorstore_recorded_events = [
             "ingest_source": "Python",
             "metadata.source": os.path.join(os.path.dirname(__file__), "hello.pdf"),
             "metadata.page": 0,
+            "metadata.page_label": "1",
         },
     ),
 ]


### PR DESCRIPTION
This PR adds `metadata.page_label` search result to the vectorstore events tests