### PR TITLE
Add max three app name status for agent control health check

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -597,7 +597,7 @@ def _process_app_name_setting():
     # primary application name and link it with the other applications.
     # When activating the application the linked names will be sent
     # along to the core application where the association will be
-    # created if the do not exist.
+    # created if it does not exist.
 
     app_name_list = _settings.app_name.split(";")
     name = app_name_list[0].strip() or "Python Application"
@@ -606,7 +606,7 @@ def _process_app_name_setting():
         agent_control_health.set_health_status(HealthStatus.MAX_APP_NAME.value)
 
     linked = []
-    for altname in _settings.app_name.split(";")[1:]:
+    for altname in app_name_list[1:]:
         altname = altname.strip()
         if altname:
             linked.append(altname)

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -599,7 +599,11 @@ def _process_app_name_setting():
     # along to the core application where the association will be
     # created if the do not exist.
 
-    name = _settings.app_name.split(";")[0].strip() or "Python Application"
+    app_name_list = _settings.app_name.split(";")
+    name = app_name_list[0].strip() or "Python Application"
+
+    if len(app_name_list) > 3:
+        agent_control_health.set_health_status(HealthStatus.MAX_APP_NAME.value)
 
     linked = []
     for altname in _settings.app_name.split(";")[1:]:

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -42,14 +42,17 @@ import newrelic.core.config
 from newrelic.common.log_file import initialize_logging
 from newrelic.common.object_names import callable_name, expand_builtin_exception_name
 from newrelic.core import trace_cache
+from newrelic.core.agent_control_health import (
+    HealthStatus,
+    agent_control_health_instance,
+    agent_control_healthcheck_loop,
+)
 from newrelic.core.config import (
     Settings,
     apply_config_setting,
     default_host,
     fetch_config_setting,
 )
-from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance, agent_control_healthcheck_loop
-
 
 __all__ = ["initialize", "filter_app_factory"]
 
@@ -4837,7 +4840,9 @@ def _setup_agent_console():
         newrelic.core.agent.Agent.run_on_startup(_startup_agent_console)
 
 
-agent_control_health_thread = threading.Thread(name="Agent-Control-Health-Main-Thread", target=agent_control_healthcheck_loop)
+agent_control_health_thread = threading.Thread(
+    name="Agent-Control-Health-Main-Thread", target=agent_control_healthcheck_loop
+)
 agent_control_health_thread.daemon = True
 
 

--- a/newrelic/core/agent_control_health.py
+++ b/newrelic/core/agent_control_health.py
@@ -21,8 +21,8 @@ import uuid
 from enum import IntEnum
 from pathlib import Path
 from urllib.parse import urlparse
-from newrelic.core.config import _environ_as_bool, _environ_as_int
 
+from newrelic.core.config import _environ_as_bool, _environ_as_int
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/agent_control_health.py
+++ b/newrelic/core/agent_control_health.py
@@ -65,6 +65,7 @@ LICENSE_KEY_ERROR_CODES = frozenset([HealthStatus.INVALID_LICENSE.value, HealthS
 
 NR_CONNECTION_ERROR_CODES = frozenset([HealthStatus.FAILED_NR_CONNECTION.value, HealthStatus.FORCED_DISCONNECT.value])
 
+
 def is_valid_file_delivery_location(file_uri):
     # Verify whether file directory provided to agent via env var is a valid file URI to determine whether health
     # check should run

--- a/tests/agent_features/test_agent_control_health_check.py
+++ b/tests/agent_features/test_agent_control_health_check.py
@@ -12,24 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import time
 import re
-import pytest
 import threading
+import time
 
-from newrelic.core.config import finalize_application_settings
+import pytest
+from testing_support.fixtures import initialize_agent
 from testing_support.http_client_recorder import HttpClientRecorder
+
+from newrelic.config import _reset_configuration_done, initialize
 from newrelic.core.agent_control_health import (
     HealthStatus,
-    is_valid_file_delivery_location,
     agent_control_health_instance,
+    is_valid_file_delivery_location,
 )
-from newrelic.config import initialize, _reset_configuration_done
 from newrelic.core.agent_protocol import AgentProtocol
 from newrelic.core.application import Application
+from newrelic.core.config import finalize_application_settings, global_settings
 from newrelic.network.exceptions import DiscardDataForRequest
-from testing_support.fixtures import initialize_agent
-from newrelic.core.config import global_settings
 
 
 def get_health_file_contents(tmp_path):

--- a/tests/agent_features/test_agent_control_health_check.py
+++ b/tests/agent_features/test_agent_control_health_check.py
@@ -15,6 +15,7 @@ import os
 import time
 import re
 import pytest
+import tempfile
 import threading
 
 from newrelic.core.config import finalize_application_settings
@@ -133,6 +134,38 @@ def test_health_check_running_threads(monkeypatch, tmp_path):
     # Two expected threads: One main agent thread and one main health thread since we have no additional active sessions
     assert len(running_threads) == 2
     assert running_threads[1].name == "Agent-Control-Health-Main-Thread"
+
+
+def test_max_app_name_status(monkeypatch, tmp_path):
+    # Setup expected env vars to run agent control health check
+    monkeypatch.setenv("NEW_RELIC_AGENT_CONTROL_FLEET_ID", "1234")
+    file_path = tmp_path.as_uri()
+    monkeypatch.setenv("NEW_RELIC_AGENT_CONTROL_HEALTH_DELIVERY_LOCATION", file_path)
+
+    max_app_name_ini = b"""
+    [newrelic]
+    app_name = "test1;test2;test3;test4"
+    monitor_mode = true
+    """
+
+    _reset_configuration_done()
+
+    with tempfile.NamedTemporaryFile(suffix=".ini") as f:
+        f.write(max_app_name_ini)
+        f.seek(0)
+
+        initialize(config_file=f.name)
+
+    # Give time for the scheduler to kick in and write to the health file
+    time.sleep(5)
+
+    contents = get_health_file_contents(tmp_path)
+
+    # Assert on contents of health file
+    assert len(contents) == 5
+    assert contents[0] == "healthy: False\n"
+    assert contents[1] == "status: The maximum number of configured app names (3) exceeded\n"
+    assert contents[4] == "last_error: NR-APM-006\n"
 
 
 def test_proxy_error_status(monkeypatch, tmp_path):


### PR DESCRIPTION
This PR adds a new status code to the agent that sets health check reporting to unhealthy when a user has configured more than 3 app names.
