### PR TITLE
Rollback to Ubuntu-22 Runners

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1

--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-linux-py3-legacy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +56,7 @@ jobs:
           retention-days: 1
 
   build-linux-py3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +101,7 @@ jobs:
           retention-days: 1
 
   build-sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
         with:
@@ -133,7 +133,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs:
       - build-linux-py3-legacy

--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -23,6 +23,7 @@ jobs:
   build-linux-py3-legacy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         wheel:
           - cp37-manylinux
@@ -57,6 +58,7 @@ jobs:
   build-linux-py3:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         wheel:
           - cp38-manylinux

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     name: Mega-Linter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # Git Checkout
       - name: Checkout Code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   # Aggregate job that provides a single check for all tests passing
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - python
       - cassandra
@@ -102,7 +102,7 @@ jobs:
   # Combine and upload coverage data
   coverage:
     if: success() || failure() # Does not run on cancelled workflows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - tests
 
@@ -164,7 +164,7 @@ jobs:
             20,
           ]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -213,7 +213,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -262,7 +262,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -325,7 +325,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -389,7 +389,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -453,7 +453,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -520,7 +520,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -587,7 +587,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -690,7 +690,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -752,7 +752,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -816,7 +816,7 @@ jobs:
       matrix:
         group-number: [1, 2]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -878,7 +878,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -941,7 +941,7 @@ jobs:
       matrix:
         group-number: [1, 2, 3, 4]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1015,7 +1015,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1077,7 +1077,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1139,7 +1139,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1206,7 +1206,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1270,7 +1270,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1335,7 +1335,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-
@@ -1404,7 +1404,7 @@ jobs:
       matrix:
         group-number: [1]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
       options: >-


### PR DESCRIPTION
# Overview

* Pin all GHA runners to `ubuntu-22.04`
* Disable `fail-fast` strategy for deployment jobs.