### PR TITLE
Use name instead of ref

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -185,9 +185,9 @@ jobs:
 
       - name: Create release tags for Lambda and K8s Init Containers
         run: |
-          RELEASE_TITLE="New Relic Python Agent ${GITHUB_REF}.0"
-          RELEASE_TAG="${GITHUB_REF}.0_python"
-          RELEASE_NOTES="Automated release for [Python Agent ${GITHUB_REF}](https://github.com/newrelic/newrelic-python-agent/releases/tag/${GITHUB_REF})"
+          RELEASE_TITLE="New Relic Python Agent ${GITHUB_REF_NAME}.0"
+          RELEASE_TAG="${GITHUB_REF_NAME}.0_python"
+          RELEASE_NOTES="Automated release for [Python Agent ${GITHUB_REF_NAME}](https://github.com/newrelic/newrelic-python-agent/releases/tag/${GITHUB_REF_NAME})"
           gh auth login --with-token <<< $GH_RELEASE_TOKEN
           echo "newrelic/newrelic-lambda-layers - Releasing \"${RELEASE_TITLE}\" with tag ${RELEASE_TAG}"
           gh release create "${RELEASE_TAG}" --title="${RELEASE_TITLE}" --repo=newrelic/newrelic-lambda-layers --notes="${RELEASE_NOTES}"


### PR DESCRIPTION
# Overview
Previously the workflow was using GITHUB_REF which is `refs/heads/tag-name` instead of `tag-name`. This has been fixed.