### PR TITLE
AWS Kinesis Delivery Streams (Firehose) Entity Mapping

### DIFF
--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -1293,6 +1293,12 @@ CUSTOM_TRACE_POINTS = {
         extract_agent_attrs=extract_firehose_agent_attrs,
         library="Firehose",
     ),
+    ("firehose", "put_record"): aws_function_trace(
+        "put_record", extract_firehose, extract_agent_attrs=extract_firehose_agent_attrs, library="Firehose"
+    ),
+    ("firehose", "put_record_batch"): aws_function_trace(
+        "put_record_batch", extract_firehose, extract_agent_attrs=extract_firehose_agent_attrs, library="Firehose"
+    ),
     ("firehose", "start_delivery_stream_encryption"): aws_function_trace(
         "start_delivery_stream_encryption",
         extract_firehose,
@@ -1313,12 +1319,6 @@ CUSTOM_TRACE_POINTS = {
     ),
     ("firehose", "update_destination"): aws_function_trace(
         "update_destination", extract_firehose, extract_agent_attrs=extract_firehose_agent_attrs, library="Firehose"
-    ),
-    ("firehose", "put_record"): aws_message_trace(
-        "Produce", "Stream", extract_firehose, extract_agent_attrs=extract_firehose_agent_attrs, library="Firehose"
-    ),
-    ("firehose", "put_record_batch"): aws_message_trace(
-        "Produce", "Stream", extract_firehose, extract_agent_attrs=extract_firehose_agent_attrs, library="Firehose"
     ),
     ("sqs", "send_message"): aws_message_trace(
         "Produce", "Queue", extract_sqs, extract_agent_attrs=extract_sqs_agent_attrs, library="SQS"

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -128,7 +128,7 @@ def extract_firehose_agent_attrs(instance, *args, **kwargs):
             region = instance._client_config.region_name
         if stream_name and account_id and region:
             agent_attrs["cloud.platform"] = "aws_kinesis_delivery_streams"
-            agent_attrs["cloud.resource_id"] = f"arn:aws:firehose:{region}:{account_id}:stream/{stream_name}"
+            agent_attrs["cloud.resource_id"] = f"arn:aws:firehose:{region}:{account_id}:deliverystream/{stream_name}"
     except Exception as e:
         _logger.debug("Failed to capture AWS Kinesis Delivery Stream (Firehose) info.", exc_info=True)
     return agent_attrs

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -60,10 +60,10 @@ def extract_sqs(*args, **kwargs):
 
 def extract_kinesis(*args, **kwargs):
     # The stream name can be passed as the StreamName or as part of the StreamARN.
-    stream_value = kwargs.get("StreamName", "Unknown")
-    if stream_value == "Unknown":
+    stream_value = kwargs.get("StreamName", None)
+    if stream_value is not None:
         arn = kwargs.get("StreamARN", None)
-        if arn:
+        if arn is not None:
             stream_value = arn.split("/", 1)[-1]
     return stream_value
 
@@ -1080,7 +1080,7 @@ def aws_message_trace(
         _library = library
         _operation = operation
         _destination_type = destination_type
-        _destination_name = destination_name(*args, **kwargs)
+        _destination_name = destination_name(*args, **kwargs) or "Unknown"
 
         trace = MessageTrace(
             _library,
@@ -1175,9 +1175,7 @@ CUSTOM_TRACE_POINTS = {
         extract_agent_attrs=extract_kinesis_agent_attrs,
         library="Kinesis",
     ),
-    ("kinesis", "delete_resource_policy"): aws_function_trace(
-        "delete_resource_policy", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "delete_resource_policy"): aws_function_trace("delete_resource_policy", library="Kinesis"),
     ("kinesis", "delete_stream"): aws_function_trace(
         "delete_stream", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
@@ -1187,9 +1185,7 @@ CUSTOM_TRACE_POINTS = {
         extract_agent_attrs=extract_kinesis_agent_attrs,
         library="Kinesis",
     ),
-    ("kinesis", "describe_limits"): aws_function_trace(
-        "describe_limits", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "describe_limits"): aws_function_trace("describe_limits", library="Kinesis"),
     ("kinesis", "describe_stream"): aws_function_trace(
         "describe_stream", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
@@ -1211,9 +1207,7 @@ CUSTOM_TRACE_POINTS = {
         extract_agent_attrs=extract_kinesis_agent_attrs,
         library="Kinesis",
     ),
-    ("kinesis", "get_resource_policy"): aws_function_trace(
-        "get_resource_policy", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "get_resource_policy"): aws_function_trace("get_resource_policy", library="Kinesis"),
     ("kinesis", "get_shard_iterator"): aws_function_trace(
         "get_shard_iterator", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
@@ -1229,18 +1223,14 @@ CUSTOM_TRACE_POINTS = {
     ("kinesis", "list_stream_consumers"): aws_function_trace(
         "list_stream_consumers", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
-    ("kinesis", "list_streams"): aws_function_trace(
-        "list_streams", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "list_streams"): aws_function_trace("list_streams", library="Kinesis"),
     ("kinesis", "list_tags_for_stream"): aws_function_trace(
         "list_tags_for_stream", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
     ("kinesis", "merge_shards"): aws_function_trace(
         "merge_shards", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
-    ("kinesis", "put_resource_policy"): aws_function_trace(
-        "put_resource_policy", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "put_resource_policy"): aws_function_trace("put_resource_policy", library="Kinesis"),
     ("kinesis", "register_stream_consumer"): aws_function_trace(
         "register_stream_consumer", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
@@ -1256,9 +1246,7 @@ CUSTOM_TRACE_POINTS = {
     ("kinesis", "stop_stream_encryption"): aws_function_trace(
         "stop_stream_encryption", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),
-    ("kinesis", "subscribe_to_shard"): aws_function_trace(
-        "subscribe_to_shard", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
-    ),
+    ("kinesis", "subscribe_to_shard"): aws_function_trace("subscribe_to_shard", library="Kinesis"),
     ("kinesis", "update_shard_count"): aws_function_trace(
         "update_shard_count", extract_kinesis, extract_agent_attrs=extract_kinesis_agent_attrs, library="Kinesis"
     ),

--- a/tests/external_botocore/test_boto3_firehose.py
+++ b/tests/external_botocore/test_boto3_firehose.py
@@ -53,6 +53,7 @@ _firehose_scoped_metrics = [
     (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
     (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/list_delivery_streams", 1),
     (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
     (f"External/{URL}/botocore/POST", 3),
 ]
@@ -61,6 +62,7 @@ _firehose_rollup_metrics = [
     (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
     (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/list_delivery_streams", 1),
     (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
     ("External/all", 4),  # Includes creating S3 bucket
     ("External/allOther", 4),
@@ -138,6 +140,10 @@ def test_firehose(firehose_destination):
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
     assert resp["DeliveryStreamDescription"]["DeliveryStreamARN"] == TEST_STREAM_ARN
+
+    # Call describe on delivery stream
+    resp = client.list_delivery_streams(Limit=123)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     # Send message
     resp = client.put_record(Record={"Data": b"foo1"}, DeliveryStreamName=TEST_STREAM)

--- a/tests/external_botocore/test_boto3_firehose.py
+++ b/tests/external_botocore/test_boto3_firehose.py
@@ -50,32 +50,34 @@ AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec
 AWS_REGION = "us-east-1"
 
 _firehose_scoped_metrics = [
-    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/put_record/{TEST_STREAM}", 1),
+    (f"Firehose/put_record_batch/{TEST_STREAM}", 1),
     (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
     (f"Firehose/list_delivery_streams", 1),
     (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
-    (f"External/{URL}/botocore/POST", 3),
+    (f"External/{URL}/botocore/POST", 6),
 ]
 
 _firehose_rollup_metrics = [
-    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/put_record/{TEST_STREAM}", 1),
+    (f"Firehose/put_record_batch/{TEST_STREAM}", 1),
     (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
     (f"Firehose/list_delivery_streams", 1),
     (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
-    ("External/all", 4),  # Includes creating S3 bucket
-    ("External/allOther", 4),
-    (f"External/{URL}/all", 3),
-    (f"External/{URL}/botocore/POST", 3),
+    ("External/all", 7),  # Includes creating S3 bucket
+    ("External/allOther", 7),
+    (f"External/{URL}/all", 6),
+    (f"External/{URL}/botocore/POST", 6),
 ]
 
 _firehose_scoped_metrics_error = [
-    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 1),
+    (f"Firehose/put_record/{TEST_STREAM}", 1),
 ]
 
 _firehose_rollup_metrics_error = [
-    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 1),
+    (f"Firehose/put_record/{TEST_STREAM}", 1),
 ]
 
 

--- a/tests/external_botocore/test_boto3_firehose.py
+++ b/tests/external_botocore/test_boto3_firehose.py
@@ -127,7 +127,6 @@ def test_firehose(firehose_destination):
     resp = client.create_delivery_stream(
         DeliveryStreamName=TEST_STREAM,
         DeliveryStreamType="DirectPut",
-        DirectPutSourceConfiguration={"ThroughputHintInMBs": 123},
         **destination_kwargs,
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -175,7 +174,6 @@ def test_firehose_error(firehose_destination):
     resp = client.create_delivery_stream(
         DeliveryStreamName=TEST_STREAM,
         DeliveryStreamType="DirectPut",
-        DirectPutSourceConfiguration={"ThroughputHintInMBs": 123},
         **destination_kwargs,
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/external_botocore/test_boto3_firehose.py
+++ b/tests/external_botocore/test_boto3_firehose.py
@@ -34,13 +34,14 @@ BOTOCORE_VERSION = get_package_version_tuple("boto3")
 
 URL = "firehose.us-east-1.amazonaws.com"
 TEST_STREAM = f"python-agent-test-{uuid.uuid4()}"
+TEST_STREAM_ARN = f"arn:aws:firehose:us-east-1:123456789012:deliverystream/{TEST_STREAM}"
 TEST_S3_BUCKET = f"python-agent-test-{uuid.uuid4()}"
 TEST_S3_BUCKET_ARN = f"arn:aws:s3:::{TEST_S3_BUCKET}"
 TEST_S3_ROLE_ARN = f"arn:aws:iam::123456789012:role/test-role"
 EXPECTED_AGENT_ATTRS = {
     "exact_agents": {
         "cloud.platform": "aws_kinesis_delivery_streams",
-        "cloud.resource_id": f"arn:aws:firehose:us-east-1:123456789012:stream/{TEST_STREAM}",
+        "cloud.resource_id": TEST_STREAM_ARN,
     },
 }
 
@@ -137,6 +138,7 @@ def test_firehose(firehose_destination):
         Limit=123,
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert resp["DeliveryStreamDescription"]["DeliveryStreamARN"] == TEST_STREAM_ARN
 
     # Send message
     resp = client.put_record(Record={"Data": b"foo1"}, DeliveryStreamName=TEST_STREAM)

--- a/tests/external_botocore/test_boto3_firehose.py
+++ b/tests/external_botocore/test_boto3_firehose.py
@@ -1,0 +1,207 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import uuid
+
+import boto3
+import botocore
+import pytest
+from moto import mock_aws
+from testing_support.fixtures import dt_enabled, override_application_settings
+from testing_support.validators.validate_span_events import validate_span_events
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+from newrelic.api.background_task import background_task
+from newrelic.common.package_version_utils import get_package_version_tuple
+from newrelic.hooks.external_botocore import CUSTOM_TRACE_POINTS
+
+MOTO_VERSION = get_package_version_tuple("moto")
+BOTOCORE_VERSION = get_package_version_tuple("boto3")
+
+URL = "firehose.us-east-1.amazonaws.com"
+TEST_STREAM = f"python-agent-test-{uuid.uuid4()}"
+TEST_S3_BUCKET = f"python-agent-test-{uuid.uuid4()}"
+TEST_S3_BUCKET_ARN = f"arn:aws:s3:::{TEST_S3_BUCKET}"
+TEST_S3_ROLE_ARN = f"arn:aws:iam::123456789012:role/test-role"
+EXPECTED_AGENT_ATTRS = {
+    "exact_agents": {
+        "cloud.platform": "aws_kinesis_delivery_streams",
+        "cloud.resource_id": f"arn:aws:firehose:us-east-1:123456789012:stream/{TEST_STREAM}",
+    },
+}
+
+AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
+AWS_SECRET_ACCESS_KEY = "AAAAAASECRETKEY"  # nosec
+AWS_REGION = "us-east-1"
+
+_firehose_scoped_metrics = [
+    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
+    (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
+    (f"External/{URL}/botocore/POST", 3),
+]
+
+_firehose_rollup_metrics = [
+    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 2),
+    (f"Firehose/create_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/describe_delivery_stream/{TEST_STREAM}", 1),
+    (f"Firehose/delete_delivery_stream/{TEST_STREAM}", 1),
+    ("External/all", 4),  # Includes creating S3 bucket
+    ("External/allOther", 4),
+    (f"External/{URL}/all", 3),
+    (f"External/{URL}/botocore/POST", 3),
+]
+
+_firehose_scoped_metrics_error = [
+    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 1),
+]
+
+_firehose_rollup_metrics_error = [
+    (f"MessageBroker/Firehose/Stream/Produce/Named/{TEST_STREAM}", 1),
+]
+
+
+@background_task()
+@mock_aws
+def test_instrumented_firehose_methods():
+    client = boto3.client(
+        "firehose",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+
+    ignored_methods = set(
+        ("firehose", method)
+        for method in ("generate_presigned_url", "close", "get_waiter", "can_paginate", "get_paginator")
+    )
+    client_methods = inspect.getmembers(client, predicate=inspect.ismethod)
+    methods = {("firehose", name) for (name, method) in client_methods if not name.startswith("_")}
+
+    uninstrumented_methods = methods - set(CUSTOM_TRACE_POINTS.keys()) - ignored_methods
+    assert not uninstrumented_methods
+
+
+@override_application_settings({"cloud.aws.account_id": 123456789012})
+@dt_enabled
+@validate_span_events(exact_agents={"aws.operation": "CreateDeliveryStream"}, count=1)
+@validate_span_events(
+    **EXPECTED_AGENT_ATTRS,
+    count=5,
+)
+@validate_span_events(exact_agents={"aws.operation": "DeleteDeliveryStream"}, count=1)
+@validate_transaction_metrics(
+    "test_boto3_firehose:test_firehose",
+    scoped_metrics=_firehose_scoped_metrics,
+    rollup_metrics=_firehose_rollup_metrics,
+    background_task=True,
+)
+@background_task()
+@mock_aws
+def test_firehose(firehose_destination):
+    client = boto3.client(
+        "firehose",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+    destination_kwargs = firehose_destination()
+
+    # Create stream
+    resp = client.create_delivery_stream(
+        DeliveryStreamName=TEST_STREAM,
+        DeliveryStreamType="DirectPut",
+        DirectPutSourceConfiguration={"ThroughputHintInMBs": 123},
+        **destination_kwargs,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Call describe on delivery stream
+    resp = client.describe_delivery_stream(
+        DeliveryStreamName=TEST_STREAM,
+        Limit=123,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Send message
+    resp = client.put_record(Record={"Data": b"foo1"}, DeliveryStreamName=TEST_STREAM)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Send messages
+    resp = client.put_record_batch(Records=[{"Data": b"foo2"}, {"Data": b"foo3"}], DeliveryStreamName=TEST_STREAM)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Delete stream
+    resp = client.delete_delivery_stream(DeliveryStreamName=TEST_STREAM)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@dt_enabled
+@validate_transaction_metrics(
+    "test_boto3_firehose:test_firehose_error",
+    scoped_metrics=_firehose_scoped_metrics_error,
+    rollup_metrics=_firehose_rollup_metrics_error,
+    background_task=True,
+)
+@background_task()
+@mock_aws
+def test_firehose_error(firehose_destination):
+    client = boto3.client(
+        "firehose",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+    destination_kwargs = firehose_destination()
+
+    # Create stream
+    resp = client.create_delivery_stream(
+        DeliveryStreamName=TEST_STREAM,
+        DeliveryStreamType="DirectPut",
+        DirectPutSourceConfiguration={"ThroughputHintInMBs": 123},
+        **destination_kwargs,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Malformed send message, uses arg instead of kwarg
+    with pytest.raises(TypeError):
+        resp = client.put_record({"Data": b"foo"}, DeliveryStreamName=TEST_STREAM)
+
+    # Delete stream
+    resp = client.delete_delivery_stream(DeliveryStreamName=TEST_STREAM)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@pytest.fixture(scope="session")
+def firehose_destination():
+    def create_firehose_destination():
+        import boto3
+
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            region_name=AWS_REGION,
+        )
+
+        resp = s3.create_bucket(Bucket=TEST_S3_BUCKET)
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        return {"S3DestinationConfiguration": {"RoleARN": TEST_S3_ROLE_ARN, "BucketARN": TEST_S3_BUCKET_ARN}}
+
+    return create_firehose_destination

--- a/tests/external_botocore/test_boto3_kinesis.py
+++ b/tests/external_botocore/test_boto3_kinesis.py
@@ -49,44 +49,48 @@ _kinesis_scoped_metrics = [
     (f"MessageBroker/Kinesis/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"MessageBroker/Kinesis/Stream/Consume/Named/{TEST_STREAM}", 1),
     (f"Kinesis/create_stream/{TEST_STREAM}", 1),
+    (f"Kinesis/list_streams", 1),
     (f"Kinesis/describe_stream/{TEST_STREAM}", 1),
     (f"Kinesis/get_shard_iterator/{TEST_STREAM}", 1),
     (f"Kinesis/delete_stream/{TEST_STREAM}", 1),
-    (f"External/{URL}/botocore/POST", 2),
+    (f"External/{URL}/botocore/POST", 3),
 ]
 if BOTOCORE_VERSION < (1, 29, 0):
     _kinesis_scoped_metrics = [
         (f"MessageBroker/Kinesis/Stream/Produce/Named/{TEST_STREAM}", 2),
         (f"Kinesis/create_stream/{TEST_STREAM}", 1),
+        (f"Kinesis/list_streams", 1),
         (f"Kinesis/describe_stream/{TEST_STREAM}", 1),
         (f"Kinesis/get_shard_iterator/{TEST_STREAM}", 1),
         (f"Kinesis/delete_stream/{TEST_STREAM}", 1),
-        (f"External/{URL}/botocore/POST", 4),
+        (f"External/{URL}/botocore/POST", 5),
     ]
 
 _kinesis_rollup_metrics = [
     (f"MessageBroker/Kinesis/Stream/Produce/Named/{TEST_STREAM}", 2),
     (f"MessageBroker/Kinesis/Stream/Consume/Named/{TEST_STREAM}", 1),
     (f"Kinesis/create_stream/{TEST_STREAM}", 1),
+    (f"Kinesis/list_streams", 1),
     (f"Kinesis/describe_stream/{TEST_STREAM}", 1),
     (f"Kinesis/get_shard_iterator/{TEST_STREAM}", 1),
     (f"Kinesis/delete_stream/{TEST_STREAM}", 1),
-    ("External/all", 4),
-    ("External/allOther", 4),
-    (f"External/{URL}/all", 2),
-    (f"External/{URL}/botocore/POST", 2),
+    ("External/all", 5),
+    ("External/allOther", 5),
+    (f"External/{URL}/all", 3),
+    (f"External/{URL}/botocore/POST", 3),
 ]
 if BOTOCORE_VERSION < (1, 29, 0):
     _kinesis_rollup_metrics = [
         (f"MessageBroker/Kinesis/Stream/Produce/Named/{TEST_STREAM}", 2),
         (f"Kinesis/create_stream/{TEST_STREAM}", 1),
+        (f"Kinesis/list_streams", 1),
         (f"Kinesis/describe_stream/{TEST_STREAM}", 1),
         (f"Kinesis/get_shard_iterator/{TEST_STREAM}", 1),
         (f"Kinesis/delete_stream/{TEST_STREAM}", 1),
-        ("External/all", 4),
-        ("External/allOther", 4),
-        (f"External/{URL}/all", 4),
-        (f"External/{URL}/botocore/POST", 4),
+        ("External/all", 5),
+        ("External/allOther", 5),
+        (f"External/{URL}/all", 5),
+        (f"External/{URL}/botocore/POST", 5),
     ]
 
 _kinesis_scoped_metrics_error = [
@@ -144,6 +148,10 @@ def test_kinesis():
     )
     # Create stream
     resp = client.create_stream(StreamName=TEST_STREAM, ShardCount=123, StreamModeDetails={"StreamMode": "on-demand"})
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # List streams
+    resp = client.list_streams(Limit=123)
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     # Stream ARN is needed for rest of methods.

--- a/tests/external_botocore/test_s3transfer.py
+++ b/tests/external_botocore/test_s3transfer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import uuid
 
 import boto3
@@ -80,5 +81,6 @@ def test_s3_context_propagation():
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     # Upload file
-    client.upload_file(Filename="_test_file.txt", Bucket=TEST_BUCKET, Key="_test_file.txt")
+    test_file = os.path.join(os.path.dirname(__file__), "_test_file.txt")
+    client.upload_file(Filename=test_file, Bucket=TEST_BUCKET, Key="_test_file.txt")
     # No return value to check for this function currently

--- a/tox.ini
+++ b/tox.ini
@@ -298,7 +298,9 @@ deps =
     external_botocore-botocorelatest: boto3
     external_botocore-botocorelatest-langchain: langchain
     external_botocore-botocore0128: botocore<1.29
+    external_botocore-botocore0128: boto3<1.26
     external_botocore-botocore0125: botocore<1.26
+    external_botocore-botocore0125: boto3<1.23
     external_botocore: moto
     external_botocore: docker
     external_feedparser-feedparser06: feedparser<7

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ envlist =
     python-external_botocore-{py38,py39,py310,py311,py312,py313}-botocorelatest,
     python-external_botocore-{py311}-botocorelatest-langchain,
     python-external_botocore-py310-botocore0125,
-    python-external_botocore-py311-botocore128,
+    python-external_botocore-py311-botocore0128,
     python-external_feedparser-{py37,py38,py39,py310,py311,py312,py313}-feedparser06,
     python-external_http-{py37,py38,py39,py310,py311,py312,py313},
     python-external_httplib-{py37,py38,py39,py310,py311,py312,py313,pypy310},
@@ -297,7 +297,7 @@ deps =
     external_botocore-botocorelatest: botocore
     external_botocore-botocorelatest: boto3
     external_botocore-botocorelatest-langchain: langchain
-    external_botocore-botocore128: botocore<1.29
+    external_botocore-botocore0128: botocore<1.29
     external_botocore-botocore0125: botocore<1.26
     external_botocore: moto
     external_botocore: docker


### PR DESCRIPTION
# Overview

* Add instrumentation and tests for AWS Firehose.
* Correct AWS Kinesis Instrumentation naming when no stream target is present.
* Tweak boto3/botocore in tox file.
* Fix S3Transfer test missing absolute path.

# Related Github Issue

Currently depends on #1283 but will be rebased.