### PR TITLE
Change Main Linter to Ruff

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -43,6 +43,8 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+          PYTHON_RUFF_ARGUMENTS: "--config='output-format=\"github\"'"
+          PYTHON_RUFF_FORMAT_ARGUMENTS: "--config='output-format=\"github\"'"
 
       # Upload Mega-Linter artifacts
       - name: Archive production artifacts

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -13,11 +13,8 @@ FILTER_REGEX_EXCLUDE: "(.*/?packages/.*)" # Ignore packages directories
 ENABLE_LINTERS: # If you use ENABLE_LINTERS variable, all other linters will be disabled by default
   - MARKDOWN_MARKDOWN_LINK_CHECK
   - MARKDOWN_MARKDOWNLINT
-  - PYTHON_BANDIT
-  - PYTHON_BLACK
-  - PYTHON_FLAKE8
-  - PYTHON_ISORT
-  - PYTHON_PYLINT
+  - PYTHON_RUFF
+  - PYTHON_RUFF_FORMAT
   - RST_RST_LINT
   - RST_RSTCHECK
   - RST_RSTFMT
@@ -25,14 +22,5 @@ ENABLE_LINTERS: # If you use ENABLE_LINTERS variable, all other linters will be 
   - YAML_V8R
   - YAML_YAMLLINT
 
-PYTHON_FLAKE8_CONFIG_FILE: setup.cfg
-PYTHON_BLACK_CONFIG_FILE: pyproject.toml
-PYTHON_PYLINT_CONFIG_FILE: pyproject.toml
-PYTHON_ISORT_CONFIG_FILE: pyproject.toml
-PYTHON_BANDIT_CONFIG_FILE: pyproject.toml
-PYTHON_BANDIT_FILTER_REGEX_EXCLUDE: "tests"
-PYTHON_BANDIT_PRE_COMMANDS:
-  - command: "pip install bandit[toml]"
-    cwd: "workspace"
-
-PYTHON_PYLINT_ARGUMENTS: "--fail-under=0 --fail-on=E"
+PYTHON_RUFF_CONFIG_FILE: pyproject.toml
+PYTHON_RUFF_FORMAT_CONFIG_FILE: pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,107 @@
+[tool.ruff]
+output-format = "grouped"
+line-length = 120
+target-version = "py37"
+extend-exclude = [
+    "newrelic/packages/",
+    "setup.py",
+]
+namespace-packages = ["testing_support"]
+
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+
+[tool.ruff.lint]
+isort.split-on-trailing-comma=false
+select = [
+    # Enabled linters and rules
+    "F",  # Pyflakes
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "I",  # isort
+    "N",  # pep8-naming
+    "D",  # pydocstyle
+    "UP",  # pyupgrade
+    "YTT",  # flake8-2020
+    "ANN",  # flake8-annotations
+    "ASYNC",  # flake8-async
+    "S",  # flake8-bandit
+    "BLE",  # flake8-blind-except
+    "FBT",  # flake8-boolean-trap
+    "B",  # flake8-bugbear
+    "A",  # flake8-builtins
+    "COM",  # flake8-commas
+    "C4",  # flake8-comprehensions
+    "T10",  # flake8-debugger
+    "EM",  # flake8-errmsg
+    "FA",  # flake8-future-annotations
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "LOG",  # flake8-logging
+    "G",  # flake8-logging-format
+    "INP",  # flake8-no-pep420
+    "PYI",  # flake8-pyi
+    "PT",  # flake8-pytest-style
+    "Q",  # flake8-quotes
+    "RSE",  # flake8-raise
+    "RET",  # flake8-return
+    "SLF",  # flake8-self
+    "SLOT",  # flake8-slots
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    "INT",  # flake8-gettext
+    "ARG",  # flake8-unused-arguments
+    "PTH",  # flake8-use-pathlib
+    "PGH",  # pygrep-hooks
+    "PL",  # Pylint
+    "TRY",  # tryceratops
+    "FLY",  # flynt
+    "PERF",  # Perflint
+    "FURB",  # refurb
+    "RUF",  # Ruff-specific rules
+]
+
+# Disabled Linters
+# "C90",  # mccabe
+# "CPY",  # flake8-copyright
+# "DTZ",  # flake8-datetimez
+# "DJ",  # flake8-django
+# "EXE",  # flake8-executable
+# "PIE",  # flake8-pie
+# "T20",  # flake8-print
+# "TC",  # flake8-type-checking
+# "TD",  # flake8-todos
+# "FIX",  # flake8-fixme
+# "ERA",  # eradicate
+# "PD",  # pandas-vet
+# "NPY",  # NumPy-specific rules
+# "FAST",  # FastAPI
+# "AIR",  # Airflow
+# "DOC",  # pydoclint
+
+ignore = [
+    # Ruff recommended linter rules to disable when using formatter
+    "W191",  # tab-indentation
+    "E111",  # indentation-with-invalid-multiple
+    "E114",  # indentation-with-invalid-multiple-comment
+    "E117",  # over-indented
+    "D206",  # docstring-tab-indentation
+    "D300",  # triple-single-quotes
+    "Q000",  # bad-quotes-inline-string
+    "Q001",  # bad-quotes-multiline-string
+    "Q002",  # bad-quotes-docstring
+    "Q003",  # avoidable-escaped-quote
+    "COM812",  # missing-trailing-comma
+    "COM819",  # prohibited-trailing-comma
+    # Additional disabled rules
+    "D203",  # incorrect-blank-line-before-class
+    "D213",  # multi-line-summary-second-line
+]
+
+[tool.ruff.lint.per-file-ignores]
+"conftest.py" = ["F401"]
+
+# Alternate linters and formatters
 [tool.black]
 line-length = 120
 include = '\.pyi?$'


### PR DESCRIPTION
# Overview

With ruff being added to `megalinter` there is little reason to stick with a host collection of older linters when ruff is quite literally 1000x faster. This should replace our existing linter setup completely with just `ruff format` and `ruff check` (`--fix` optionally).

* Swap main linter to ruff in CI.
* Add configuration for ruff that mimics existing linter configs.
* Massively expand list of linters and plugins used. 
  * (Should be collaboratively pruned with use of any that aren't helpful.)
