### PR TITLE
Add attribute check

### DIFF
--- a/newrelic/samplers/gc_data.py
+++ b/newrelic/samplers/gc_data.py
@@ -25,7 +25,7 @@ from newrelic.samplers.decorators import data_source_factory
 
 
 @data_source_factory(name="Garbage Collector Metrics")
-class _GCDataSource():
+class _GCDataSource:
     def __init__(self, settings, environ):
         self.gc_time_metrics = CustomMetrics()
         self.start_time = 0.0
@@ -37,8 +37,11 @@ class _GCDataSource():
         settings = global_settings()
         if platform.python_implementation() == "PyPy" or not settings:
             return False
-        else:
+        # This might be inheriting from Settings instead of TopLevelSettings
+        elif settings and hasattr(settings, "gc_runtime_metrics"):
             return settings.gc_runtime_metrics.enabled
+        else:
+            return False
 
     @property
     def top_object_count_limit(self):


### PR DESCRIPTION
This PR adds an attribute check for the GC runtime metrics check.

`settings.gc_runtime_metrics` is of type `GCRuntimeMetricsSettings()` and this inherits from `Settings()`
`global_settings()` uses `TopLevelSettings()` which also inherits from `Settings()`

`global_settings` may not necessarily have access to the `gc_runtime_metrics` and these instances result in an attribute error for this enable check.