### PR TITLE
Add support for streaming in async Bedrock

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -4694,6 +4694,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "aiobotocore.client",
+        "newrelic.hooks.external_aiobotocore",
+        "instrument_aiobotocore_client",
+    )
+
+    _process_module_definition(
         "botocore.endpoint",
         "newrelic.hooks.external_botocore",
         "instrument_botocore_endpoint",

--- a/newrelic/hooks/external_aiobotocore.py
+++ b/newrelic/hooks/external_aiobotocore.py
@@ -162,7 +162,6 @@ async def wrap_client__make_api_call(wrapped, instance, args, kwargs):
         ft.__exit__(None, None, None)
         bedrock_attrs["duration"] = ft.duration * 1000
         response["body"] = StreamingBody(AsyncBytesIO(response_body), len(response_body))
-        # response_body = await response["body"].read()
 
         # Run response extractor for non-streaming responses
         try:

--- a/newrelic/hooks/external_aiobotocore.py
+++ b/newrelic/hooks/external_aiobotocore.py
@@ -12,8 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import aiohttp
+import aiofiles
+import traceback
+import sys
+from aiobotocore.response import StreamingBody
+from io import BytesIO
+
+from newrelic.api.transaction import current_transaction
+from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.external_trace import ExternalTrace
 from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.api.time_trace import current_trace, get_trace_linking_metadata
+from newrelic.hooks.external_botocore import (
+    bedrock_error_attributes,
+    handle_embedding_event,
+    EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE,
+    RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE,
+    handle_chat_completion_event,
+    REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE,
+    MODEL_EXTRACTORS,
+    UNSUPPORTED_MODEL_WARNING_SENT,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class AsyncBytesIO(BytesIO):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.content = self
+
+    async def read(self, amt=-1):
+        if amt == -1:  # aiohttp to regular response
+            amt = None
+        return super().read(amt)
 
 
 def _bind_make_request_params(operation_model, request_dict, *args, **kwargs):
@@ -44,5 +78,113 @@ async def wrap_endpoint_make_request(wrapped, instance, args, kwargs):
         return result
 
 
+async def wrap_client__make_api_call(wrapped, instance, args, kwargs):
+    trace_id = instance._nr_trace_id
+    span_id = instance._nr_span_id
+    model = args[1].get("modelId")
+    is_embedding = "embed" in model
+    request_body = args[1].get("body")
+
+    request_extractor = instance._nr_request_extractor
+    response_extractor = instance._nr_response_extractor
+    transaction = instance._txn
+
+    operation = "embedding" if is_embedding else "completion"
+    function_name = wrapped.__name__
+
+    ft = FunctionTrace(name=function_name, group=f"Llm/{operation}/Bedrock")
+    ft.__enter__()
+
+    try:
+        response = await wrapped(*args, **kwargs)
+    except Exception as exc:
+        try:
+            bedrock_attrs = {
+                "model": model,
+                "span_id": span_id,
+                "trace_id": trace_id,
+            }
+            try:
+                request_extractor(request_body, bedrock_attrs)
+            except json.decoder.JSONDecodeError:
+                pass
+            except Exception:
+                _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+
+            error_attributes = bedrock_error_attributes(exc, bedrock_attrs)
+            notice_error_attributes = {
+                "http.statusCode": error_attributes.get("http.statusCode"),
+                "error.message": error_attributes.get("error.message"),
+                "error.code": error_attributes.get("error.code"),
+            }
+            if is_embedding:
+                notice_error_attributes.update({"embedding_id": str(uuid.uuid4())})
+            else:
+                notice_error_attributes.update({"completion_id": str(uuid.uuid4())})
+
+            ft.notice_error(
+                attributes=notice_error_attributes,
+            )
+
+            ft.__exit__(*sys.exc_info())
+            error_attributes["duration"] = ft.duration * 1000
+
+            if operation == "embedding":
+                handle_embedding_event(transaction, error_attributes)
+            else:
+                handle_chat_completion_event(transaction, error_attributes)
+        except Exception:
+            _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+
+        raise
+
+    if not response:
+        ft.__exit__(None, None, None)
+        return response
+    response_headers = response.get("ResponseMetadata", {}).get("HTTPHeaders") or {}
+    bedrock_attrs = {
+        "request_id": response_headers.get("x-amzn-requestid"),
+        "model": model,
+        "span_id": span_id,
+        "trace_id": trace_id,
+    }
+
+    try:
+        request_extractor(request_body, bedrock_attrs)
+    except json.decoder.JSONDecodeError:
+        pass
+    except Exception:
+        _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+
+    try:
+        # Read and replace response streaming bodies
+        response_body = await response["body"].read()
+        ft.__exit__(None, None, None)
+        bedrock_attrs["duration"] = ft.duration * 1000
+        response["body"] = StreamingBody(AsyncBytesIO(response_body), len(response_body))
+        # response_body = await response["body"].read()
+
+        # Run response extractor for non-streaming responses
+        try:
+            response_extractor(response_body, bedrock_attrs)
+        except Exception:
+            _logger.warning(RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+
+        if operation == "embedding":
+            handle_embedding_event(transaction, bedrock_attrs)
+        else:
+            handle_chat_completion_event(transaction, bedrock_attrs)
+
+    except Exception:
+        _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+
+    return response
+
+
 def instrument_aiobotocore_endpoint(module):
     wrap_function_wrapper(module, "AioEndpoint.make_request", wrap_endpoint_make_request)
+
+
+def instrument_aiobotocore_client(module):
+    if hasattr(module, "AioBaseClient"):
+        wrap_function_wrapper(module, "AioBaseClient._make_api_call", wrap_client__make_api_call)

--- a/newrelic/hooks/external_aiobotocore.py
+++ b/newrelic/hooks/external_aiobotocore.py
@@ -11,39 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import logging
-import aiohttp
-import aiofiles
 import traceback
 import sys
 from aiobotocore.response import StreamingBody
-import uuid
 from io import BytesIO
 
-from newrelic.api.transaction import current_transaction
-from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.external_trace import ExternalTrace
 from newrelic.common.object_wrapper import wrap_function_wrapper
-from newrelic.api.time_trace import current_trace, get_trace_linking_metadata
 from newrelic.hooks.external_botocore import (
-    bedrock_error_attributes,
-    handle_embedding_event,
     handle_bedrock_exception,
     run_bedrock_response_extractor,
     run_bedrock_request_extractor,
-    EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE,
     RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE,
-    RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE,
-    handle_chat_completion_event,
-    REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE,
-    MODEL_EXTRACTORS,
-    UNSUPPORTED_MODEL_WARNING_SENT,
 )
 
 _logger = logging.getLogger(__name__)
 
 
+# Class from https://github.com/aio-libs/aiobotocore/blob/master/tests/test_response.py
 class AsyncBytesIO(BytesIO):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -684,7 +684,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
         instance._nr_settings = settings
 
         # Add a bedrock flag to instance so we can determine when make_api_call instrumentation is hit from non-Bedrock paths and bypass it if so
-        instance._is_bedrock = True
+        instance._nr_is_bedrock = True
 
         try:
             # For aioboto3 clients, this will call make_api_call instrumentation in external_aiobotocore

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -141,9 +141,9 @@ def extract_firehose_agent_attrs(instance, *args, **kwargs):
                 region = instance._client_config.region_name
             if account_id and region:
                 agent_attrs["cloud.platform"] = "aws_kinesis_delivery_streams"
-                agent_attrs["cloud.resource_id"] = (
-                    f"arn:aws:firehose:{region}:{account_id}:deliverystream/{stream_name}"
-                )
+                agent_attrs[
+                    "cloud.resource_id"
+                ] = f"arn:aws:firehose:{region}:{account_id}:deliverystream/{stream_name}"
     except Exception as e:
         _logger.debug("Failed to capture AWS Kinesis Delivery Stream (Firehose) info.", exc_info=True)
     return agent_attrs
@@ -547,7 +547,9 @@ MODEL_EXTRACTORS = [  # Order is important here, avoiding dictionaries
 ]
 
 
-def handle_bedrock_exception(exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction):
+def handle_bedrock_exception(
+    exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction
+):
     try:
         bedrock_attrs = {
             "model": model,
@@ -678,6 +680,8 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
         instance._nr_stream_extractor = stream_extractor
         instance._nr_txn = transaction
         instance._nr_ft = ft
+        instance._nr_response_streaming = response_streaming
+        instance._nr_settings = settings
 
         # Add a bedrock flag to instance so we can determine when make_api_call instrumentation is hit from non-Bedrock paths and bypass it if so
         instance._is_bedrock = True
@@ -686,7 +690,9 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
             # For aioboto3 clients, this will call make_api_call instrumentation in external_aiobotocore
             response = wrapped(*args, **kwargs)
         except Exception as exc:
-            handle_bedrock_exception(exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction)
+            handle_bedrock_exception(
+                exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction
+            )
 
         if not response or response_streaming and not settings.ai_monitoring.streaming.enabled:
             ft.__exit__(None, None, None)
@@ -775,6 +781,42 @@ class GeneratorProxy(ObjectProxy):
 
     def close(self):
         return super(GeneratorProxy, self).close()
+
+
+class AsyncEventStreamWrapper(ObjectProxy):
+    def __aiter__(self):
+        g = AsyncGeneratorProxy(self.__wrapped__.__aiter__())
+        g._nr_ft = getattr(self, "_nr_ft", None)
+        g._nr_bedrock_attrs = getattr(self, "_nr_bedrock_attrs", {})
+        g._nr_model_extractor = getattr(self, "_nr_model_extractor", NULL_EXTRACTOR)
+        return g
+
+
+class AsyncGeneratorProxy(ObjectProxy):
+    def __init__(self, wrapped):
+        super(AsyncGeneratorProxy, self).__init__(wrapped)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        transaction = current_transaction()
+        if not transaction:
+            return await self.__wrapped__.__anext__()
+        return_val = None
+        try:
+            return_val = await self.__wrapped__.__anext__()
+            record_stream_chunk(self, return_val, transaction)
+        except StopAsyncIteration as e:
+            record_events_on_stop_iteration(self, transaction)
+            raise
+        except Exception as exc:
+            record_error(self, transaction, exc)
+            raise
+        return return_val
+
+    async def aclose(self):
+        return await super(AsyncGeneratorProxy, self).aclose()
 
 
 def record_stream_chunk(self, return_val, transaction):

--- a/tests/external_aiobotocore/conftest.py
+++ b/tests/external_aiobotocore/conftest.py
@@ -17,6 +17,7 @@ import logging
 import socket
 import threading
 
+import pytest
 import moto.server
 import werkzeug.serving
 from testing_support.fixture.event_loop import (  # noqa: F401, pylint: disable=W0611
@@ -26,6 +27,14 @@ from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
+
+from newrelic.common.package_version_utils import (
+    get_package_version,
+    get_package_version_tuple,
+)
+from external_botocore._mock_external_bedrock_server import MockExternalBedrockServer, extract_shortened_prompt
+
+BOTOCORE_VERSION = get_package_version("botocore")
 
 PORT = 4443
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"
@@ -150,3 +159,37 @@ class MotoService:
             self._server.shutdown()
 
         self._thread.join()
+
+
+# Bedrock Fixtures
+@pytest.fixture(scope="session")
+def bedrock_server(loop):
+    """
+    This fixture will create a mocked backend for testing purposes.
+    """
+    import aiobotocore
+
+    from newrelic.core.config import _environ_as_bool
+
+    if get_package_version_tuple("botocore") < (1, 31, 57):
+        pytest.skip(reason="Bedrock Runtime not available.")
+
+    if _environ_as_bool("NEW_RELIC_TESTING_RECORD_BEDROCK_RESPONSES", False):
+        raise NotImplementedError("To record test responses, use botocore instead.")
+
+    # Use mocked Bedrock backend and prerecorded responses
+    with MockExternalBedrockServer() as server:
+        session = aiobotocore.session.get_session()
+        client = loop.run_until_complete(
+            session.create_client(
+                "bedrock-runtime",
+                "us-east-1",
+                endpoint_url=f"http://localhost:{server.port}",
+                aws_access_key_id="NOT-A-REAL-SECRET",
+                aws_secret_access_key="NOT-A-REAL-SECRET",
+            ).__aenter__()
+        )
+
+        yield client
+
+        loop.run_until_complete(client.__aexit__(None, None, None))

--- a/tests/external_aiobotocore/conftest.py
+++ b/tests/external_aiobotocore/conftest.py
@@ -49,6 +49,8 @@ _default_settings = {
     "transaction_tracer.stack_trace_threshold": 0.0,
     "debug.log_data_collector_payloads": True,
     "debug.record_transaction_failure": True,
+    "custom_insights_events.max_attribute_value": 4096,
+    "ai_monitoring.enabled": True,
 }
 collector_agent_registration = collector_agent_registration_fixture(
     app_name="Python Agent Test (external_aiobotocore)",

--- a/tests/external_aiobotocore/conftest.py
+++ b/tests/external_aiobotocore/conftest.py
@@ -32,7 +32,7 @@ from newrelic.common.package_version_utils import (
     get_package_version,
     get_package_version_tuple,
 )
-from external_botocore._mock_external_bedrock_server import MockExternalBedrockServer, extract_shortened_prompt
+from external_botocore._mock_external_bedrock_server import MockExternalBedrockServer
 
 BOTOCORE_VERSION = get_package_version("botocore")
 

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -1,0 +1,975 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from io import BytesIO
+
+import boto3
+import botocore.errorfactory
+import botocore.eventstream
+import botocore.exceptions
+import pytest
+from external_botocore._test_bedrock_chat_completion import (
+    chat_completion_expected_events,
+    chat_completion_expected_malformed_request_body_events,
+    chat_completion_expected_malformed_response_body_events,
+    chat_completion_expected_malformed_response_streaming_body_events,
+    chat_completion_expected_malformed_response_streaming_chunk_events,
+    chat_completion_expected_streaming_error_events,
+    chat_completion_invalid_access_key_error_events,
+    chat_completion_invalid_model_error_events,
+    chat_completion_payload_templates,
+    chat_completion_streaming_expected_events,
+)
+from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from testing_support.fixtures import (
+    override_llm_token_callback_settings,
+    reset_core_stats_engine,
+    validate_attributes,
+)
+from testing_support.ml_testing_utils import (  # noqa: F401
+    add_token_count_to_events,
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    disabled_ai_monitoring_streaming_settings,
+    events_sans_content,
+    events_sans_llm_metadata,
+    events_with_context_attrs,
+    llm_token_count_callback,
+    set_trace_info,
+)
+from testing_support.validators.validate_custom_event import validate_custom_event_count
+from testing_support.validators.validate_custom_events import validate_custom_events
+from testing_support.validators.validate_error_trace_attributes import (
+    validate_error_trace_attributes,
+)
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+from newrelic.api.background_task import background_task
+from newrelic.api.llm_custom_attributes import WithLlmCustomAttributes
+from newrelic.api.transaction import add_custom_attribute
+from newrelic.common.object_names import callable_name
+from newrelic.hooks.external_botocore import MODEL_EXTRACTORS
+
+
+@pytest.fixture(scope="session", params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
+def response_streaming(request):
+    return request.param
+
+
+@pytest.fixture(scope="session", params=[False, True], ids=["RequestStandard", "RequestStreaming"])
+def request_streaming(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "amazon.titan-text-express-v1",
+        "ai21.j2-mid-v1",
+        "anthropic.claude-instant-v1",
+        "cohere.command-text-v14",
+        "meta.llama2-13b-chat-v1",
+        "mistral.mistral-7b-instruct-v0:2",
+    ],
+)
+def model_id(request, response_streaming):
+    model = request.param
+    if response_streaming and model == "ai21.j2-mid-v1":
+        pytest.skip(reason="Streaming not supported.")
+
+    return model
+
+
+@pytest.fixture(scope="module")
+def exercise_model(loop, bedrock_server, model_id, request_streaming, response_streaming):
+    payload_template = chat_completion_payload_templates[model_id]
+
+    def _exercise_model(prompt, temperature=0.7, max_tokens=100):
+        async def coro():
+            body = (payload_template % (prompt, temperature, max_tokens)).encode("utf-8")
+            if request_streaming:
+                body = BytesIO(body)
+
+            response = await bedrock_server.invoke_model(
+                body=body,
+                modelId=model_id,
+                accept="application/json",
+                contentType="application/json",
+            )
+            response_body = json.loads(response.get("body").read())
+            assert response_body
+
+            return response_body
+        return loop.run_until_complete(coro())
+
+    def _exercise_streaming_model(prompt, temperature=0.7, max_tokens=100):
+        async def coro():
+            body = (payload_template % (prompt, temperature, max_tokens)).encode("utf-8")
+            if request_streaming:
+                body = BytesIO(body)
+
+            response = await bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model_id,
+                accept="application/json",
+                contentType="application/json",
+            )
+            body = response.get("body")
+            for resp in body:
+                assert resp
+        return loop.run_until_complete(coro())
+
+    if response_streaming:
+        return _exercise_streaming_model
+    else:
+        return _exercise_model
+
+
+@pytest.fixture(scope="module")
+def expected_events(model_id, response_streaming):
+    if response_streaming:
+        return chat_completion_streaming_expected_events[model_id]
+    else:
+        return chat_completion_expected_events[model_id]
+
+
+@pytest.fixture(scope="module")
+def expected_metrics(response_streaming):
+    if response_streaming:
+        return [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
+    else:
+        return [("Llm/completion/Bedrock/invoke_model", 1)]
+
+
+@pytest.fixture(scope="module")
+def expected_invalid_access_key_error_events(model_id):
+    return chat_completion_invalid_access_key_error_events[model_id]
+
+
+_test_bedrock_chat_completion_prompt = "What is 212 degrees Fahrenheit converted to Celsius?"
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_in_txn_with_llm_metadata(
+    set_trace_info, exercise_model, expected_events, expected_metrics
+):
+    @validate_custom_events(events_with_context_attrs(expected_events))
+    # One summary event, one user message, and one response message from the assistant
+    @validate_custom_event_count(count=3)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_in_txn_with_llm_metadata",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_chat_completion_in_txn_with_llm_metadata")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        with WithLlmCustomAttributes({"context": "attr"}):
+            exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@disabled_ai_monitoring_record_content_settings
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_no_content(set_trace_info, exercise_model, expected_events, expected_metrics):
+    @validate_custom_events(events_sans_content(expected_events))
+    # One summary event, one user message, and one response message from the assistant
+    @validate_custom_event_count(count=3)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_no_content",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_chat_completion_no_content")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+def test_bedrock_chat_completion_with_token_count(set_trace_info, exercise_model, expected_events, expected_metrics):
+    @validate_custom_events(add_token_count_to_events(expected_events))
+    # One summary event, one user message, and one response message from the assistant
+    @validate_custom_event_count(count=3)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_with_token_count",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_chat_completion_with_token_count")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_no_llm_metadata(set_trace_info, exercise_model, expected_events, expected_metrics):
+    @validate_custom_events(events_sans_llm_metadata(expected_events))
+    # One summary event, one user message, and one response message from the assistant
+    @validate_custom_event_count(count=3)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_in_txn_no_llm_metadata",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion_in_txn_no_llm_metadata")
+    def _test():
+        set_trace_info()
+        exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+def test_bedrock_chat_completion_outside_txn(exercise_model):
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+
+@disabled_ai_monitoring_settings
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+@background_task(name="test_bedrock_chat_completion_disabled_ai_monitoring_setting")
+def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
+    set_trace_info()
+    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_streaming_settings
+def test_bedrock_chat_completion_streaming_disabled(
+    bedrock_server,
+):
+    """Streaming is disabled, but the rest of the AI settings are enabled. Custom events should not be collected."""
+
+    @validate_custom_event_count(count=0)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % (_test_bedrock_chat_completion_prompt, 0.7, 100)).encode(
+            "utf-8"
+        )
+
+        response = bedrock_server.invoke_model_with_response_stream(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+        list(response["body"])  # Iterate
+
+    _test()
+
+
+_client_error = botocore.exceptions.ClientError
+_client_error_name = callable_name(_client_error)
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_invalid_model(
+    bedrock_server, set_trace_info, response_streaming, expected_metrics
+):
+    @validate_custom_events(events_with_context_attrs(chat_completion_invalid_model_error_events))
+    @validate_error_trace_attributes(
+        "botocore.errorfactory:ValidationException",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 400,
+                "error.message": "The provided model identifier is invalid.",
+                "error.code": "ValidationException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_error_invalid_model",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion_error_invalid_model")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        with pytest.raises(_client_error):
+            with WithLlmCustomAttributes({"context": "attr"}):
+                if response_streaming:
+                    stream = bedrock_server.invoke_model_with_response_stream(
+                        body=b"{}",
+                        modelId="does-not-exist",
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+                    for _ in stream:
+                        pass
+                else:
+                    bedrock_server.invoke_model(
+                        body=b"{}",
+                        modelId="does-not-exist",
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_incorrect_access_key(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+    expected_metrics,
+):
+    """
+    A request is made to the server with invalid credentials. botocore will reach out to the server and receive an
+    UnrecognizedClientException as a response. Information from the request will be parsed and reported in customer
+    events. The error response can also be parsed, and will be included as attributes on the recorded exception.
+    """
+
+    @validate_custom_events(expected_invalid_access_key_error_events)
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token", temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+def test_bedrock_chat_completion_error_incorrect_access_key_no_content(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+    expected_metrics,
+):
+    """
+    Duplicate of test_bedrock_chat_completion_error_incorrect_access_key, but with content recording disabled.
+
+    See the original test for a description of the error case.
+    """
+
+    @validate_custom_events(events_sans_content(expected_invalid_access_key_error_events))
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token", temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+def test_bedrock_chat_completion_error_incorrect_access_key_with_token(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+    expected_metrics,
+):
+    @validate_custom_events(add_token_count_to_events(expected_invalid_access_key_error_events))
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):  # not sure where this exception actually comes from
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token", temperature=0.7, max_tokens=100)
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_malformed_request_body(
+    bedrock_server,
+    set_trace_info,
+    response_streaming,
+    expected_metrics,
+):
+    """
+    A request was made to the server, but the request body contains invalid JSON. The library will accept the invalid
+    payload, and still send a request. Our instrumentation will be unable to read it. As a result, no request
+    information will be recorded in custom events. This includes the initial prompt message event, which cannot be read
+    so it cannot be captured. The server will then respond with a ValidationException response immediately due to the
+    bad request. The response can still be parsed, so error information from the response will be recorded as normal.
+    """
+
+    @validate_custom_events(chat_completion_expected_malformed_request_body_events)
+    @validate_custom_event_count(count=1)
+    @validate_error_trace_attributes(
+        "botocore.errorfactory:ValidationException",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 400,
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        model = "amazon.titan-text-express-v1"
+        body = "{ Malformed Request Body".encode("utf-8")
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        with pytest.raises(_client_error):
+            if response_streaming:
+                bedrock_server.invoke_model_with_response_stream(
+                    body=body,
+                    modelId=model,
+                    accept="application/json",
+                    contentType="application/json",
+                )
+            else:
+                bedrock_server.invoke_model(
+                    body=body,
+                    modelId=model,
+                    accept="application/json",
+                    contentType="application/json",
+                )
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_malformed_response_body(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    After a non-streaming request was made to the server, the server responded with a response body that contains
+    invalid JSON. Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing
+    exceptions will be raised. Instrumentation will attempt to parse the invalid body, and should not raise an
+    exception when it fails to do so. As a result, recorded events will not contain the streamed response data but will contain the request data.
+    """
+
+    @validate_custom_events(chat_completion_expected_malformed_response_body_events)
+    @validate_custom_event_count(count=2)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % ("Malformed Body", 0.7, 100)).encode("utf-8")
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        response = bedrock_server.invoke_model(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+        assert response
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_malformed_response_streaming_body(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    A chunk in the stream returned by the server is valid, but contains a body with JSON that cannot be parsed.
+    Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing exceptions will
+    be raised. Instrumentation will attempt to parse the invalid body, and should not raise an exception when it fails
+    to do so. The result should be all streamed response data missing from the recorded events, but request and summary
+    events are recorded as normal.
+    """
+
+    @validate_custom_events(chat_completion_expected_malformed_response_streaming_body_events)
+    @validate_custom_event_count(count=2)
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Body", 0.7, 100)).encode("utf-8")
+
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        response = bedrock_server.invoke_model_with_response_stream(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+
+        chunks = list(response["body"])
+        assert chunks, "No response chunks returned"
+        for chunk in chunks:
+            with pytest.raises(json.decoder.JSONDecodeError):
+                json.loads(chunk["chunk"]["bytes"])
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    A chunk in the stream returned by the server is missing the prelude which causes an InvalidHeadersLength exception
+    to be raised during parsing of the chunk. Since the streamed chunk is not able to be parsed, the response
+    attribute on the raised exception is not present. This means all streamed response data will be missing from the
+    recorded events.
+    """
+
+    @validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
+    @validate_custom_event_count(count=2)
+    @validate_error_trace_attributes(
+        "botocore.eventstream:ChecksumMismatch",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "llm.conversation_id": "my-awesome-id",
+            },
+        },
+        forgone_params={
+            "agent": (),
+            "intrinsic": (),
+            "user": ("http.statusCode", "error.message", "error.code"),
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
+        with pytest.raises(botocore.eventstream.ChecksumMismatch):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+            response = "".join(chunk for chunk in response["body"])
+            assert response
+
+    _test()
+
+
+_event_stream_error = botocore.exceptions.EventStreamError
+_event_stream_error_name = "botocore.exceptions:EventStreamError"
+
+
+@reset_core_stats_engine()
+def test_bedrock_chat_completion_error_streaming_exception(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    During a streaming call, the streamed chunk's headers indicate an error. These headers are not HTTP headers, but
+    headers embedded in the binary format of the response from the server. The streamed chunk's response body is not
+    required to contain any information regarding the exception, the headers are sufficient to cause botocore's
+    parser to raise an actual exception based on the error code. The response attribute on the raised exception will
+    contain the error information. This means error data will be reported for the response, but all response message
+    data will be missing from the recorded events since the server returned an error instead of message data inside
+    the streamed response.
+    """
+
+    @validate_custom_events(chat_completion_expected_streaming_error_events)
+    @validate_custom_event_count(count=2)
+    @validate_error_trace_attributes(
+        _event_stream_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+        forgone_params={
+            "agent": (),
+            "intrinsic": (),
+            "user": ("http.statusCode"),
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+            list(response["body"])  # Iterate
+
+    _test()
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+def test_bedrock_chat_completion_error_streaming_exception_no_content(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with content recording disabled.
+
+    See the original test for a description of the error case.
+    """
+
+    @validate_custom_events(events_sans_content(chat_completion_expected_streaming_error_events))
+    @validate_custom_event_count(count=2)
+    @validate_error_trace_attributes(
+        _event_stream_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+        forgone_params={
+            "agent": (),
+            "intrinsic": (),
+            "user": ("http.statusCode"),
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+            list(response["body"])  # Iterate
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+def test_bedrock_chat_completion_error_streaming_exception_with_token_count(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with token callback being set.
+
+    See the original test for a description of the error case.
+    """
+
+    @validate_custom_events(add_token_count_to_events(chat_completion_expected_streaming_error_events))
+    @validate_custom_event_count(count=2)
+    @validate_error_trace_attributes(
+        _event_stream_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+        forgone_params={
+            "agent": (),
+            "intrinsic": (),
+            "user": ("http.statusCode"),
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+            list(response["body"])  # Iterate
+
+    _test()
+
+
+def test_bedrock_chat_completion_functions_marked_as_wrapped_for_sdk_compatibility(bedrock_server):
+    assert bedrock_server._nr_wrapped
+
+
+def test_chat_models_instrumented():
+    import aiobotocore
+
+    SUPPORTED_MODELS = [model for model, _, _, _ in MODEL_EXTRACTORS if "embed" not in model]
+
+    _id = os.environ.get("AWS_ACCESS_KEY_ID")
+    key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not _id or not key:
+        pytest.skip(reason="Credentials not available.")
+
+    session = aiobotocore.session.get_session()
+    client = loop.run_until_complete(
+        session.create_client(
+            "bedrock",
+            "us-east-1",
+        ).__aenter__()
+    )
+
+    try:
+        response = loop.run_until_complete(client.list_foundation_models(byOutputModality="TEXT"))
+        models = [model["modelId"] for model in response["modelSummaries"]]
+        not_supported = []
+        for model in models:
+            is_supported = any([model.startswith(supported_model) for supported_model in SUPPORTED_MODELS])
+            if not is_supported:
+                not_supported.append(model)
+
+        assert not not_supported, f"The following unsupported models were found: {not_supported}"
+    finally:
+        loop.run_until_complete(client.__aexit__(None, None, None))

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -15,7 +15,6 @@ import json
 import os
 from io import BytesIO
 
-import boto3
 import botocore.errorfactory
 import botocore.eventstream
 import botocore.exceptions

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -166,15 +166,6 @@ _test_bedrock_chat_completion_prompt = "What is 212 degrees Fahrenheit converted
 
 
 @reset_core_stats_engine()
-@disabled_ai_monitoring_settings
-@validate_custom_event_count(count=0)
-@background_task(name="test_bedrock_chat_completion_disabled_ai_monitoring_setting")
-def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
-    set_trace_info()
-    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
-
-
-@reset_core_stats_engine()
 def test_bedrock_chat_completion_in_txn_with_llm_metadata(
     set_trace_info, exercise_model, expected_events, expected_metrics
 ):
@@ -279,6 +270,15 @@ def test_bedrock_chat_completion_no_llm_metadata(set_trace_info, exercise_model,
     _test()
 
 
+@disabled_ai_monitoring_settings
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+@background_task(name="test_bedrock_chat_completion_disabled_ai_monitoring_setting")
+def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
+    set_trace_info()
+    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+
+
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
 def test_bedrock_chat_completion_outside_txn(exercise_model):
@@ -327,7 +327,7 @@ _client_error = botocore.exceptions.ClientError
 _client_error_name = callable_name(_client_error)
 
 
-def invalid_model_invoke_model(loop, bedrock_server, response_streaming):
+def invoke_model_invalid_model(loop, bedrock_server, response_streaming):
     async def _coro():
         with pytest.raises(_client_error):
             with WithLlmCustomAttributes({"context": "attr"}):
@@ -387,7 +387,7 @@ def test_bedrock_chat_completion_error_invalid_model(loop, bedrock_server, set_t
         add_custom_attribute("llm.foo", "bar")
         add_custom_attribute("non_llm_attr", "python-agent")
 
-        invalid_model_invoke_model(loop, bedrock_server, response_streaming)
+        invoke_model_invalid_model(loop, bedrock_server, response_streaming)
 
     _test()
 
@@ -544,7 +544,7 @@ def test_bedrock_chat_completion_error_incorrect_access_key_with_token(
     _test()
 
 
-def malformed_request_body_invoke_model(loop, bedrock_server, response_streaming):
+def invoke_model_malformed_request_body(loop, bedrock_server, response_streaming):
     async def _coro():
         with pytest.raises(_client_error):
             if response_streaming:
@@ -614,7 +614,7 @@ def test_bedrock_chat_completion_error_malformed_request_body(
         add_custom_attribute("llm.foo", "bar")
         add_custom_attribute("non_llm_attr", "python-agent")
 
-        malformed_request_body_invoke_model(loop, bedrock_server, response_streaming)
+        invoke_model_malformed_request_body(loop, bedrock_server, response_streaming)
 
     _test()
 

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -64,8 +64,7 @@ from newrelic.common.object_names import callable_name
 from newrelic.hooks.external_botocore import MODEL_EXTRACTORS
 
 
-# @pytest.fixture(scope="session", params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
-@pytest.fixture(scope="session", params=[True], ids=["ResponseStandard"])
+@pytest.fixture(scope="session", params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
 def response_streaming(request):
     return request.param
 
@@ -78,10 +77,10 @@ def request_streaming(request):
 @pytest.fixture(
     scope="module",
     params=[
+        "cohere.command-text-v14",
         "amazon.titan-text-express-v1",
         "ai21.j2-mid-v1",
         "anthropic.claude-instant-v1",
-        "cohere.command-text-v14",
         "meta.llama2-13b-chat-v1",
         "mistral.mistral-7b-instruct-v0:2",
     ],
@@ -131,31 +130,31 @@ def exercise_model(loop, bedrock_server, model_id, request_streaming, response_s
                 contentType="application/json",
             )
             body = response.get("body")
-            for resp in body:
+            async for resp in body:
                 assert resp
 
         return loop.run_until_complete(coro())
 
-    # if response_streaming:
-    #     return _exercise_streaming_model
-    # else:
-    return _exercise_model
+    if response_streaming:
+        return _exercise_streaming_model
+    else:
+        return _exercise_model
 
 
 @pytest.fixture(scope="module")
 def expected_events(model_id, response_streaming):
-    # if response_streaming:
-    #     return chat_completion_streaming_expected_events[model_id]
-    # else:
-    return chat_completion_expected_events[model_id]
+    if response_streaming:
+        return chat_completion_streaming_expected_events[model_id]
+    else:
+        return chat_completion_expected_events[model_id]
 
 
 @pytest.fixture(scope="module")
 def expected_metrics(response_streaming):
-    # if response_streaming:
-    #     return [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
-    # else:
-    return [("Llm/completion/Bedrock/invoke_model", 1)]
+    if response_streaming:
+        return [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
+    else:
+        return [("Llm/completion/Bedrock/invoke_model", 1)]
 
 
 @pytest.fixture(scope="module")
@@ -164,6 +163,15 @@ def expected_invalid_access_key_error_events(model_id):
 
 
 _test_bedrock_chat_completion_prompt = "What is 212 degrees Fahrenheit converted to Celsius?"
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_settings
+@validate_custom_event_count(count=0)
+@background_task(name="test_bedrock_chat_completion_disabled_ai_monitoring_setting")
+def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
+    set_trace_info()
+    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
 
 
 @reset_core_stats_engine()
@@ -278,107 +286,110 @@ def test_bedrock_chat_completion_outside_txn(exercise_model):
     exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
 
 
-@disabled_ai_monitoring_settings
 @reset_core_stats_engine()
 @validate_custom_event_count(count=0)
-@background_task(name="test_bedrock_chat_completion_disabled_ai_monitoring_setting")
-def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
-    set_trace_info()
-    exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+@disabled_ai_monitoring_streaming_settings
+def test_bedrock_chat_completion_streaming_disabled(
+    loop,
+    bedrock_server,
+):
+    """Streaming is disabled, but the rest of the AI settings are enabled. Custom events should not be collected."""
 
+    async def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % (_test_bedrock_chat_completion_prompt, 0.7, 100)).encode(
+            "utf-8"
+        )
+        response = await bedrock_server.invoke_model_with_response_stream(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+        body = response.get("body")
+        async for resp in body:
+            assert resp
 
-# @reset_core_stats_engine()
-# @disabled_ai_monitoring_streaming_settings
-# def test_bedrock_chat_completion_streaming_disabled(
-#     bedrock_server,
-# ):
-#     """Streaming is disabled, but the rest of the AI settings are enabled. Custom events should not be collected."""
-#
-#     @validate_custom_event_count(count=0)
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         model = "amazon.titan-text-express-v1"
-#         body = (chat_completion_payload_templates[model] % (_test_bedrock_chat_completion_prompt, 0.7, 100)).encode(
-#             "utf-8"
-#         )
-#
-#         response = bedrock_server.invoke_model_with_response_stream(
-#             body=body,
-#             modelId=model,
-#             accept="application/json",
-#             contentType="application/json",
-#         )
-#         list(response["body"])  # Iterate
-#
-#     _test()
+    loop.run_until_complete(_test())
 
 
 _client_error = botocore.exceptions.ClientError
 _client_error_name = callable_name(_client_error)
 
 
-@reset_core_stats_engine()
-@validate_custom_events(events_with_context_attrs(chat_completion_invalid_model_error_events))
-@validate_error_trace_attributes(
-    "botocore.errorfactory:ValidationException",
-    exact_attrs={
-        "agent": {},
-        "intrinsic": {},
-        "user": {
-            "http.statusCode": 400,
-            "error.message": "The provided model identifier is invalid.",
-            "error.code": "ValidationException",
+def invalid_model_invoke_model(loop, bedrock_server, response_streaming):
+    async def _coro():
+        with pytest.raises(_client_error):
+            with WithLlmCustomAttributes({"context": "attr"}):
+                if response_streaming:
+                    stream = await bedrock_server.invoke_model_with_response_stream(
+                        body=b"{}",
+                        modelId="does-not-exist",
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+                    for _ in stream:
+                        pass
+                else:
+                    await bedrock_server.invoke_model(
+                        body=b"{}",
+                        modelId="does-not-exist",
+                        accept="application/json",
+                        contentType="application/json",
+                    )
+
+    loop.run_until_complete(_coro())
+
+
+def test_bedrock_chat_completion_error_invalid_model(loop, bedrock_server, set_trace_info, response_streaming):
+    if response_streaming:
+        expected_metrics = [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
+    else:
+        expected_metrics = [("Llm/completion/Bedrock/invoke_model", 1)]
+
+    @reset_core_stats_engine()
+    @validate_custom_events(events_with_context_attrs(chat_completion_invalid_model_error_events))
+    @validate_error_trace_attributes(
+        "botocore.errorfactory:ValidationException",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 400,
+                "error.message": "The provided model identifier is invalid.",
+                "error.code": "ValidationException",
+            },
         },
-    },
-)
-@validate_transaction_metrics(
-    name="test_bedrock_chat_completion_error_invalid_model",
-    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-    custom_metrics=[
-        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-    ],
-    background_task=True,
-)
-@background_task(name="test_bedrock_chat_completion_error_invalid_model")
-def test_bedrock_chat_completion_error_invalid_model(
-    loop, bedrock_server, set_trace_info, response_streaming, expected_metrics
-):
-    async def _test():
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion_error_invalid_model",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion_error_invalid_model")
+    def _test():
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
         add_custom_attribute("llm.foo", "bar")
         add_custom_attribute("non_llm_attr", "python-agent")
 
-        with pytest.raises(_client_error):
-            with WithLlmCustomAttributes({"context": "attr"}):
-                # if response_streaming:
-                #     stream = bedrock_server.invoke_model_with_response_stream(
-                #         body=b"{}",
-                #         modelId="does-not-exist",
-                #         accept="application/json",
-                #         contentType="application/json",
-                #     )
-                #     for _ in stream:
-                #         pass
-                # else:
-                await bedrock_server.invoke_model(
-                    body=b"{}",
-                    modelId="does-not-exist",
-                    accept="application/json",
-                    contentType="application/json",
-                )
+        invalid_model_invoke_model(loop, bedrock_server, response_streaming)
 
-    loop.run_until_complete(_test())
+    _test()
 
 
 @reset_core_stats_engine()
@@ -533,37 +544,32 @@ def test_bedrock_chat_completion_error_incorrect_access_key_with_token(
     _test()
 
 
-@reset_core_stats_engine()
-@validate_custom_events(chat_completion_expected_malformed_request_body_events)
-@validate_custom_event_count(count=1)
-@validate_error_trace_attributes(
-    "botocore.errorfactory:ValidationException",
-    exact_attrs={
-        "agent": {},
-        "intrinsic": {},
-        "user": {
-            "http.statusCode": 400,
-            "error.message": "Malformed input request, please reformat your input and try again.",
-            "error.code": "ValidationException",
-        },
-    },
-)
-@validate_transaction_metrics(
-    name="test_bedrock_chat_completion",
-    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-    custom_metrics=[
-        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-    ],
-    background_task=True,
-)
-@background_task(name="test_bedrock_chat_completion")
+def malformed_request_body_invoke_model(loop, bedrock_server, response_streaming):
+    async def _coro():
+        with pytest.raises(_client_error):
+            if response_streaming:
+                await bedrock_server.invoke_model_with_response_stream(
+                    body="{ Malformed Request Body".encode("utf-8"),
+                    modelId="amazon.titan-text-express-v1",
+                    accept="application/json",
+                    contentType="application/json",
+                )
+            else:
+                await bedrock_server.invoke_model(
+                    body="{ Malformed Request Body".encode("utf-8"),
+                    modelId="amazon.titan-text-express-v1",
+                    accept="application/json",
+                    contentType="application/json",
+                )
+
+    loop.run_until_complete(_coro())
+
+
 def test_bedrock_chat_completion_error_malformed_request_body(
     loop,
     bedrock_server,
     set_trace_info,
     response_streaming,
-    expected_metrics,
 ):
     """
     A request was made to the server, but the request body contains invalid JSON. The library will accept the invalid
@@ -572,32 +578,45 @@ def test_bedrock_chat_completion_error_malformed_request_body(
     so it cannot be captured. The server will then respond with a ValidationException response immediately due to the
     bad request. The response can still be parsed, so error information from the response will be recorded as normal.
     """
+    if response_streaming:
+        expected_metrics = [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
+    else:
+        expected_metrics = [("Llm/completion/Bedrock/invoke_model", 1)]
 
-    async def _test():
-        model = "amazon.titan-text-express-v1"
-        body = "{ Malformed Request Body".encode("utf-8")
+    @reset_core_stats_engine()
+    @validate_custom_events(chat_completion_expected_malformed_request_body_events)
+    @validate_custom_event_count(count=1)
+    @validate_error_trace_attributes(
+        "botocore.errorfactory:ValidationException",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 400,
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_chat_completion",
+        scoped_metrics=expected_metrics,
+        rollup_metrics=expected_metrics,
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_chat_completion")
+    def _test():
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
         add_custom_attribute("llm.foo", "bar")
         add_custom_attribute("non_llm_attr", "python-agent")
 
-        with pytest.raises(_client_error):
-            # if response_streaming:
-            #     bedrock_server.invoke_model_with_response_stream(
-            #         body=body,
-            #         modelId=model,
-            #         accept="application/json",
-            #         contentType="application/json",
-            #     )
-            # else:
-            await bedrock_server.invoke_model(
-                body=body,
-                modelId=model,
-                accept="application/json",
-                contentType="application/json",
-            )
+        malformed_request_body_invoke_model(loop, bedrock_server, response_streaming)
 
-    loop.run_until_complete(_test())
+    _test()
 
 
 @reset_core_stats_engine()
@@ -644,304 +663,318 @@ def test_bedrock_chat_completion_error_malformed_response_body(
     loop.run_until_complete(_test())
 
 
-# @reset_core_stats_engine()
-# def test_bedrock_chat_completion_error_malformed_response_streaming_body(
-#     bedrock_server,
-#     set_trace_info,
-# ):
-#     """
-#     A chunk in the stream returned by the server is valid, but contains a body with JSON that cannot be parsed.
-#     Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing exceptions will
-#     be raised. Instrumentation will attempt to parse the invalid body, and should not raise an exception when it fails
-#     to do so. The result should be all streamed response data missing from the recorded events, but request and summary
-#     events are recorded as normal.
-#     """
-#
-#     @validate_custom_events(chat_completion_expected_malformed_response_streaming_body_events)
-#     @validate_custom_event_count(count=2)
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         model = "amazon.titan-text-express-v1"
-#         body = (chat_completion_payload_templates[model] % ("Malformed Streaming Body", 0.7, 100)).encode("utf-8")
-#
-#         set_trace_info()
-#         add_custom_attribute("llm.conversation_id", "my-awesome-id")
-#         add_custom_attribute("llm.foo", "bar")
-#         add_custom_attribute("non_llm_attr", "python-agent")
-#
-#         response = bedrock_server.invoke_model_with_response_stream(
-#             body=body,
-#             modelId=model,
-#             accept="application/json",
-#             contentType="application/json",
-#         )
-#
-#         chunks = list(response["body"])
-#         assert chunks, "No response chunks returned"
-#         for chunk in chunks:
-#             with pytest.raises(json.decoder.JSONDecodeError):
-#                 json.loads(chunk["chunk"]["bytes"])
-#
-#     _test()
-#
-#
-# @reset_core_stats_engine()
-# def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
-#     bedrock_server,
-#     set_trace_info,
-# ):
-#     """
-#     A chunk in the stream returned by the server is missing the prelude which causes an InvalidHeadersLength exception
-#     to be raised during parsing of the chunk. Since the streamed chunk is not able to be parsed, the response
-#     attribute on the raised exception is not present. This means all streamed response data will be missing from the
-#     recorded events.
-#     """
-#
-#     @validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
-#     @validate_custom_event_count(count=2)
-#     @validate_error_trace_attributes(
-#         "botocore.eventstream:ChecksumMismatch",
-#         exact_attrs={
-#             "agent": {},
-#             "intrinsic": {},
-#             "user": {
-#                 "llm.conversation_id": "my-awesome-id",
-#             },
-#         },
-#         forgone_params={
-#             "agent": (),
-#             "intrinsic": (),
-#             "user": ("http.statusCode", "error.message", "error.code"),
-#         },
-#     )
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         model = "amazon.titan-text-express-v1"
-#         body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
-#         with pytest.raises(botocore.eventstream.ChecksumMismatch):
-#             set_trace_info()
-#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
-#             add_custom_attribute("llm.foo", "bar")
-#             add_custom_attribute("non_llm_attr", "python-agent")
-#
-#             response = bedrock_server.invoke_model_with_response_stream(
-#                 body=body,
-#                 modelId=model,
-#                 accept="application/json",
-#                 contentType="application/json",
-#             )
-#             response = "".join(chunk for chunk in response["body"])
-#             assert response
-#
-#     _test()
-#
-#
-# _event_stream_error = botocore.exceptions.EventStreamError
-# _event_stream_error_name = "botocore.exceptions:EventStreamError"
-#
-#
-# @reset_core_stats_engine()
-# def test_bedrock_chat_completion_error_streaming_exception(
-#     bedrock_server,
-#     set_trace_info,
-# ):
-#     """
-#     During a streaming call, the streamed chunk's headers indicate an error. These headers are not HTTP headers, but
-#     headers embedded in the binary format of the response from the server. The streamed chunk's response body is not
-#     required to contain any information regarding the exception, the headers are sufficient to cause botocore's
-#     parser to raise an actual exception based on the error code. The response attribute on the raised exception will
-#     contain the error information. This means error data will be reported for the response, but all response message
-#     data will be missing from the recorded events since the server returned an error instead of message data inside
-#     the streamed response.
-#     """
-#
-#     @validate_custom_events(chat_completion_expected_streaming_error_events)
-#     @validate_custom_event_count(count=2)
-#     @validate_error_trace_attributes(
-#         _event_stream_error_name,
-#         exact_attrs={
-#             "agent": {},
-#             "intrinsic": {},
-#             "user": {
-#                 "error.message": "Malformed input request, please reformat your input and try again.",
-#                 "error.code": "ValidationException",
-#             },
-#         },
-#         forgone_params={
-#             "agent": (),
-#             "intrinsic": (),
-#             "user": ("http.statusCode"),
-#         },
-#     )
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         with pytest.raises(_event_stream_error):
-#             model = "amazon.titan-text-express-v1"
-#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-#
-#             set_trace_info()
-#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
-#             add_custom_attribute("llm.foo", "bar")
-#             add_custom_attribute("non_llm_attr", "python-agent")
-#
-#             response = bedrock_server.invoke_model_with_response_stream(
-#                 body=body,
-#                 modelId=model,
-#                 accept="application/json",
-#                 contentType="application/json",
-#             )
-#             list(response["body"])  # Iterate
-#
-#     _test()
-#
-#
-# @reset_core_stats_engine()
-# @disabled_ai_monitoring_record_content_settings
-# def test_bedrock_chat_completion_error_streaming_exception_no_content(
-#     bedrock_server,
-#     set_trace_info,
-# ):
-#     """
-#     Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with content recording disabled.
-#
-#     See the original test for a description of the error case.
-#     """
-#
-#     @validate_custom_events(events_sans_content(chat_completion_expected_streaming_error_events))
-#     @validate_custom_event_count(count=2)
-#     @validate_error_trace_attributes(
-#         _event_stream_error_name,
-#         exact_attrs={
-#             "agent": {},
-#             "intrinsic": {},
-#             "user": {
-#                 "error.message": "Malformed input request, please reformat your input and try again.",
-#                 "error.code": "ValidationException",
-#             },
-#         },
-#         forgone_params={
-#             "agent": (),
-#             "intrinsic": (),
-#             "user": ("http.statusCode"),
-#         },
-#     )
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         with pytest.raises(_event_stream_error):
-#             model = "amazon.titan-text-express-v1"
-#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-#
-#             set_trace_info()
-#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
-#             add_custom_attribute("llm.foo", "bar")
-#             add_custom_attribute("non_llm_attr", "python-agent")
-#
-#             response = bedrock_server.invoke_model_with_response_stream(
-#                 body=body,
-#                 modelId=model,
-#                 accept="application/json",
-#                 contentType="application/json",
-#             )
-#             list(response["body"])  # Iterate
-#
-#     _test()
-#
-#
-# @reset_core_stats_engine()
-# @override_llm_token_callback_settings(llm_token_count_callback)
-# def test_bedrock_chat_completion_error_streaming_exception_with_token_count(
-#     bedrock_server,
-#     set_trace_info,
-# ):
-#     """
-#     Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with token callback being set.
-#
-#     See the original test for a description of the error case.
-#     """
-#
-#     @validate_custom_events(add_token_count_to_events(chat_completion_expected_streaming_error_events))
-#     @validate_custom_event_count(count=2)
-#     @validate_error_trace_attributes(
-#         _event_stream_error_name,
-#         exact_attrs={
-#             "agent": {},
-#             "intrinsic": {},
-#             "user": {
-#                 "error.message": "Malformed input request, please reformat your input and try again.",
-#                 "error.code": "ValidationException",
-#             },
-#         },
-#         forgone_params={
-#             "agent": (),
-#             "intrinsic": (),
-#             "user": ("http.statusCode"),
-#         },
-#     )
-#     @validate_transaction_metrics(
-#         name="test_bedrock_chat_completion",
-#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-#         custom_metrics=[
-#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-#         ],
-#         background_task=True,
-#     )
-#     @background_task(name="test_bedrock_chat_completion")
-#     def _test():
-#         with pytest.raises(_event_stream_error):
-#             model = "amazon.titan-text-express-v1"
-#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-#
-#             set_trace_info()
-#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
-#             add_custom_attribute("llm.foo", "bar")
-#             add_custom_attribute("non_llm_attr", "python-agent")
-#
-#             response = bedrock_server.invoke_model_with_response_stream(
-#                 body=body,
-#                 modelId=model,
-#                 accept="application/json",
-#                 contentType="application/json",
-#             )
-#             list(response["body"])  # Iterate
-#
-#     _test()
+@reset_core_stats_engine()
+@validate_custom_events(chat_completion_expected_malformed_response_streaming_body_events)
+@validate_custom_event_count(count=2)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+def test_bedrock_chat_completion_error_malformed_response_streaming_body(
+    loop,
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    A chunk in the stream returned by the server is valid, but contains a body with JSON that cannot be parsed.
+    Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing exceptions will
+    be raised. Instrumentation will attempt to parse the invalid body, and should not raise an exception when it fails
+    to do so. The result should be all streamed response data missing from the recorded events, but request and summary
+    events are recorded as normal.
+    """
+
+    async def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Body", 0.7, 100)).encode("utf-8")
+
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        response = await bedrock_server.invoke_model_with_response_stream(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+
+        async for chunk in response.get("body"):
+            with pytest.raises(json.decoder.JSONDecodeError):
+                json.loads(chunk["chunk"]["bytes"])
+
+    loop.run_until_complete(_test())
+
+
+@reset_core_stats_engine()
+@validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
+@validate_custom_event_count(count=2)
+@validate_error_trace_attributes(
+    "botocore.eventstream:ChecksumMismatch",
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "llm.conversation_id": "my-awesome-id",
+        },
+    },
+    forgone_params={
+        "agent": (),
+        "intrinsic": (),
+        "user": ("http.statusCode", "error.message", "error.code"),
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
+    loop,
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    A chunk in the stream returned by the server is missing the prelude which causes an InvalidHeadersLength exception
+    to be raised during parsing of the chunk. Since the streamed chunk is not able to be parsed, the response
+    attribute on the raised exception is not present. This means all streamed response data will be missing from the
+    recorded events.
+    """
+
+    async def _test():
+        model = "amazon.titan-text-express-v1"
+        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
+        with pytest.raises(botocore.eventstream.ChecksumMismatch):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = await bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+
+            body = response.get("body")
+            async for resp in body:
+                assert resp
+
+    loop.run_until_complete(_test())
+
+
+_event_stream_error = botocore.exceptions.EventStreamError
+_event_stream_error_name = "botocore.exceptions:EventStreamError"
+
+
+@reset_core_stats_engine()
+@validate_custom_events(chat_completion_expected_streaming_error_events)
+@validate_custom_event_count(count=2)
+@validate_error_trace_attributes(
+    _event_stream_error_name,
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "error.message": "Malformed input request, please reformat your input and try again.",
+            "error.code": "ValidationException",
+        },
+    },
+    forgone_params={
+        "agent": (),
+        "intrinsic": (),
+        "user": ("http.statusCode"),
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+def test_bedrock_chat_completion_error_streaming_exception(
+    loop,
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    During a streaming call, the streamed chunk's headers indicate an error. These headers are not HTTP headers, but
+    headers embedded in the binary format of the response from the server. The streamed chunk's response body is not
+    required to contain any information regarding the exception, the headers are sufficient to cause botocore's
+    parser to raise an actual exception based on the error code. The response attribute on the raised exception will
+    contain the error information. This means error data will be reported for the response, but all response message
+    data will be missing from the recorded events since the server returned an error instead of message data inside
+    the streamed response.
+    """
+
+    async def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = await bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+
+            body = response.get("body")
+            async for resp in body:
+                assert resp
+
+    loop.run_until_complete(_test())
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+@validate_custom_events(events_sans_content(chat_completion_expected_streaming_error_events))
+@validate_custom_event_count(count=2)
+@validate_error_trace_attributes(
+    _event_stream_error_name,
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "error.message": "Malformed input request, please reformat your input and try again.",
+            "error.code": "ValidationException",
+        },
+    },
+    forgone_params={
+        "agent": (),
+        "intrinsic": (),
+        "user": ("http.statusCode"),
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+def test_bedrock_chat_completion_error_streaming_exception_no_content(
+    loop,
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with content recording disabled.
+
+    See the original test for a description of the error case.
+    """
+
+    async def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = await bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+
+            body = response.get("body")
+            async for resp in body:
+                assert resp
+
+    loop.run_until_complete(_test())
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+@validate_custom_events(add_token_count_to_events(chat_completion_expected_streaming_error_events))
+@validate_custom_event_count(count=2)
+@validate_error_trace_attributes(
+    _event_stream_error_name,
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "error.message": "Malformed input request, please reformat your input and try again.",
+            "error.code": "ValidationException",
+        },
+    },
+    forgone_params={
+        "agent": (),
+        "intrinsic": (),
+        "user": ("http.statusCode"),
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
+def test_bedrock_chat_completion_error_streaming_exception_with_token_count(
+    loop,
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with token callback being set.
+
+    See the original test for a description of the error case.
+    """
+
+    async def _test():
+        with pytest.raises(_event_stream_error):
+            model = "amazon.titan-text-express-v1"
+            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            response = await bedrock_server.invoke_model_with_response_stream(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+
+            body = response.get("body")
+            async for resp in body:
+                assert resp
+
+    loop.run_until_complete(_test())
 
 
 def test_bedrock_chat_completion_functions_marked_as_wrapped_for_sdk_compatibility(bedrock_server):

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -65,7 +65,8 @@ from newrelic.common.object_names import callable_name
 from newrelic.hooks.external_botocore import MODEL_EXTRACTORS
 
 
-@pytest.fixture(scope="session", params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
+# @pytest.fixture(scope="session", params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
+@pytest.fixture(scope="session", params=[True], ids=["ResponseStandard"])
 def response_streaming(request):
     return request.param
 
@@ -110,10 +111,12 @@ def exercise_model(loop, bedrock_server, model_id, request_streaming, response_s
                 accept="application/json",
                 contentType="application/json",
             )
-            response_body = json.loads(response.get("body").read())
+            body = await response["body"].read()
+            response_body = json.loads(body)
             assert response_body
 
             return response_body
+
         return loop.run_until_complete(coro())
 
     def _exercise_streaming_model(prompt, temperature=0.7, max_tokens=100):
@@ -131,28 +134,29 @@ def exercise_model(loop, bedrock_server, model_id, request_streaming, response_s
             body = response.get("body")
             for resp in body:
                 assert resp
+
         return loop.run_until_complete(coro())
 
-    if response_streaming:
-        return _exercise_streaming_model
-    else:
-        return _exercise_model
+    # if response_streaming:
+    #     return _exercise_streaming_model
+    # else:
+    return _exercise_model
 
 
 @pytest.fixture(scope="module")
 def expected_events(model_id, response_streaming):
-    if response_streaming:
-        return chat_completion_streaming_expected_events[model_id]
-    else:
-        return chat_completion_expected_events[model_id]
+    # if response_streaming:
+    #     return chat_completion_streaming_expected_events[model_id]
+    # else:
+    return chat_completion_expected_events[model_id]
 
 
 @pytest.fixture(scope="module")
 def expected_metrics(response_streaming):
-    if response_streaming:
-        return [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
-    else:
-        return [("Llm/completion/Bedrock/invoke_model", 1)]
+    # if response_streaming:
+    #     return [("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)]
+    # else:
+    return [("Llm/completion/Bedrock/invoke_model", 1)]
 
 
 @pytest.fixture(scope="module")
@@ -284,39 +288,39 @@ def test_bedrock_chat_completion_disabled_ai_monitoring_settings(set_trace_info,
     exercise_model(prompt=_test_bedrock_chat_completion_prompt, temperature=0.7, max_tokens=100)
 
 
-@reset_core_stats_engine()
-@disabled_ai_monitoring_streaming_settings
-def test_bedrock_chat_completion_streaming_disabled(
-    bedrock_server,
-):
-    """Streaming is disabled, but the rest of the AI settings are enabled. Custom events should not be collected."""
-
-    @validate_custom_event_count(count=0)
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        model = "amazon.titan-text-express-v1"
-        body = (chat_completion_payload_templates[model] % (_test_bedrock_chat_completion_prompt, 0.7, 100)).encode(
-            "utf-8"
-        )
-
-        response = bedrock_server.invoke_model_with_response_stream(
-            body=body,
-            modelId=model,
-            accept="application/json",
-            contentType="application/json",
-        )
-        list(response["body"])  # Iterate
-
-    _test()
+# @reset_core_stats_engine()
+# @disabled_ai_monitoring_streaming_settings
+# def test_bedrock_chat_completion_streaming_disabled(
+#     bedrock_server,
+# ):
+#     """Streaming is disabled, but the rest of the AI settings are enabled. Custom events should not be collected."""
+#
+#     @validate_custom_event_count(count=0)
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         model = "amazon.titan-text-express-v1"
+#         body = (chat_completion_payload_templates[model] % (_test_bedrock_chat_completion_prompt, 0.7, 100)).encode(
+#             "utf-8"
+#         )
+#
+#         response = bedrock_server.invoke_model_with_response_stream(
+#             body=body,
+#             modelId=model,
+#             accept="application/json",
+#             contentType="application/json",
+#         )
+#         list(response["body"])  # Iterate
+#
+#     _test()
 
 
 _client_error = botocore.exceptions.ClientError
@@ -324,33 +328,33 @@ _client_error_name = callable_name(_client_error)
 
 
 @reset_core_stats_engine()
-def test_bedrock_chat_completion_error_invalid_model(
-    bedrock_server, set_trace_info, response_streaming, expected_metrics
-):
-    @validate_custom_events(events_with_context_attrs(chat_completion_invalid_model_error_events))
-    @validate_error_trace_attributes(
-        "botocore.errorfactory:ValidationException",
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "http.statusCode": 400,
-                "error.message": "The provided model identifier is invalid.",
-                "error.code": "ValidationException",
-            },
+@validate_custom_events(events_with_context_attrs(chat_completion_invalid_model_error_events))
+@validate_error_trace_attributes(
+    "botocore.errorfactory:ValidationException",
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "http.statusCode": 400,
+            "error.message": "The provided model identifier is invalid.",
+            "error.code": "ValidationException",
         },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion_error_invalid_model",
-        scoped_metrics=expected_metrics,
-        rollup_metrics=expected_metrics,
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion_error_invalid_model")
-    def _test():
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion_error_invalid_model",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion_error_invalid_model")
+def test_bedrock_chat_completion_error_invalid_model(
+    loop, bedrock_server, set_trace_info, response_streaming, expected_metrics
+):
+    async def _test():
         set_trace_info()
         add_custom_attribute("llm.conversation_id", "my-awesome-id")
         add_custom_attribute("llm.foo", "bar")
@@ -358,24 +362,24 @@ def test_bedrock_chat_completion_error_invalid_model(
 
         with pytest.raises(_client_error):
             with WithLlmCustomAttributes({"context": "attr"}):
-                if response_streaming:
-                    stream = bedrock_server.invoke_model_with_response_stream(
-                        body=b"{}",
-                        modelId="does-not-exist",
-                        accept="application/json",
-                        contentType="application/json",
-                    )
-                    for _ in stream:
-                        pass
-                else:
-                    bedrock_server.invoke_model(
-                        body=b"{}",
-                        modelId="does-not-exist",
-                        accept="application/json",
-                        contentType="application/json",
-                    )
+                # if response_streaming:
+                #     stream = bedrock_server.invoke_model_with_response_stream(
+                #         body=b"{}",
+                #         modelId="does-not-exist",
+                #         accept="application/json",
+                #         contentType="application/json",
+                #     )
+                #     for _ in stream:
+                #         pass
+                # else:
+                await bedrock_server.invoke_model(
+                    body=b"{}",
+                    modelId="does-not-exist",
+                    accept="application/json",
+                    contentType="application/json",
+                )
 
-    _test()
+    loop.run_until_complete(_test())
 
 
 @reset_core_stats_engine()
@@ -531,7 +535,32 @@ def test_bedrock_chat_completion_error_incorrect_access_key_with_token(
 
 
 @reset_core_stats_engine()
+@validate_custom_events(chat_completion_expected_malformed_request_body_events)
+@validate_custom_event_count(count=1)
+@validate_error_trace_attributes(
+    "botocore.errorfactory:ValidationException",
+    exact_attrs={
+        "agent": {},
+        "intrinsic": {},
+        "user": {
+            "http.statusCode": 400,
+            "error.message": "Malformed input request, please reformat your input and try again.",
+            "error.code": "ValidationException",
+        },
+    },
+)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
 def test_bedrock_chat_completion_error_malformed_request_body(
+    loop,
     bedrock_server,
     set_trace_info,
     response_streaming,
@@ -545,31 +574,7 @@ def test_bedrock_chat_completion_error_malformed_request_body(
     bad request. The response can still be parsed, so error information from the response will be recorded as normal.
     """
 
-    @validate_custom_events(chat_completion_expected_malformed_request_body_events)
-    @validate_custom_event_count(count=1)
-    @validate_error_trace_attributes(
-        "botocore.errorfactory:ValidationException",
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "http.statusCode": 400,
-                "error.message": "Malformed input request, please reformat your input and try again.",
-                "error.code": "ValidationException",
-            },
-        },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=expected_metrics,
-        rollup_metrics=expected_metrics,
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
+    async def _test():
         model = "amazon.titan-text-express-v1"
         body = "{ Malformed Request Body".encode("utf-8")
         set_trace_info()
@@ -578,26 +583,39 @@ def test_bedrock_chat_completion_error_malformed_request_body(
         add_custom_attribute("non_llm_attr", "python-agent")
 
         with pytest.raises(_client_error):
-            if response_streaming:
-                bedrock_server.invoke_model_with_response_stream(
-                    body=body,
-                    modelId=model,
-                    accept="application/json",
-                    contentType="application/json",
-                )
-            else:
-                bedrock_server.invoke_model(
-                    body=body,
-                    modelId=model,
-                    accept="application/json",
-                    contentType="application/json",
-                )
+            # if response_streaming:
+            #     bedrock_server.invoke_model_with_response_stream(
+            #         body=body,
+            #         modelId=model,
+            #         accept="application/json",
+            #         contentType="application/json",
+            #     )
+            # else:
+            await bedrock_server.invoke_model(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
 
-    _test()
+    loop.run_until_complete(_test())
 
 
 @reset_core_stats_engine()
+@validate_custom_events(chat_completion_expected_malformed_response_body_events)
+@validate_custom_event_count(count=2)
+@validate_transaction_metrics(
+    name="test_bedrock_chat_completion",
+    scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
+    custom_metrics=[
+        (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+    ],
+    background_task=True,
+)
+@background_task(name="test_bedrock_chat_completion")
 def test_bedrock_chat_completion_error_malformed_response_body(
+    loop,
     bedrock_server,
     set_trace_info,
 ):
@@ -608,19 +626,7 @@ def test_bedrock_chat_completion_error_malformed_response_body(
     exception when it fails to do so. As a result, recorded events will not contain the streamed response data but will contain the request data.
     """
 
-    @validate_custom_events(chat_completion_expected_malformed_response_body_events)
-    @validate_custom_event_count(count=2)
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
+    async def _test():
         model = "amazon.titan-text-express-v1"
         body = (chat_completion_payload_templates[model] % ("Malformed Body", 0.7, 100)).encode("utf-8")
         set_trace_info()
@@ -628,7 +634,7 @@ def test_bedrock_chat_completion_error_malformed_response_body(
         add_custom_attribute("llm.foo", "bar")
         add_custom_attribute("non_llm_attr", "python-agent")
 
-        response = bedrock_server.invoke_model(
+        response = await bedrock_server.invoke_model(
             body=body,
             modelId=model,
             accept="application/json",
@@ -636,307 +642,307 @@ def test_bedrock_chat_completion_error_malformed_response_body(
         )
         assert response
 
-    _test()
+    loop.run_until_complete(_test())
 
 
-@reset_core_stats_engine()
-def test_bedrock_chat_completion_error_malformed_response_streaming_body(
-    bedrock_server,
-    set_trace_info,
-):
-    """
-    A chunk in the stream returned by the server is valid, but contains a body with JSON that cannot be parsed.
-    Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing exceptions will
-    be raised. Instrumentation will attempt to parse the invalid body, and should not raise an exception when it fails
-    to do so. The result should be all streamed response data missing from the recorded events, but request and summary
-    events are recorded as normal.
-    """
-
-    @validate_custom_events(chat_completion_expected_malformed_response_streaming_body_events)
-    @validate_custom_event_count(count=2)
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        model = "amazon.titan-text-express-v1"
-        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Body", 0.7, 100)).encode("utf-8")
-
-        set_trace_info()
-        add_custom_attribute("llm.conversation_id", "my-awesome-id")
-        add_custom_attribute("llm.foo", "bar")
-        add_custom_attribute("non_llm_attr", "python-agent")
-
-        response = bedrock_server.invoke_model_with_response_stream(
-            body=body,
-            modelId=model,
-            accept="application/json",
-            contentType="application/json",
-        )
-
-        chunks = list(response["body"])
-        assert chunks, "No response chunks returned"
-        for chunk in chunks:
-            with pytest.raises(json.decoder.JSONDecodeError):
-                json.loads(chunk["chunk"]["bytes"])
-
-    _test()
-
-
-@reset_core_stats_engine()
-def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
-    bedrock_server,
-    set_trace_info,
-):
-    """
-    A chunk in the stream returned by the server is missing the prelude which causes an InvalidHeadersLength exception
-    to be raised during parsing of the chunk. Since the streamed chunk is not able to be parsed, the response
-    attribute on the raised exception is not present. This means all streamed response data will be missing from the
-    recorded events.
-    """
-
-    @validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
-    @validate_custom_event_count(count=2)
-    @validate_error_trace_attributes(
-        "botocore.eventstream:ChecksumMismatch",
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "llm.conversation_id": "my-awesome-id",
-            },
-        },
-        forgone_params={
-            "agent": (),
-            "intrinsic": (),
-            "user": ("http.statusCode", "error.message", "error.code"),
-        },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        model = "amazon.titan-text-express-v1"
-        body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
-        with pytest.raises(botocore.eventstream.ChecksumMismatch):
-            set_trace_info()
-            add_custom_attribute("llm.conversation_id", "my-awesome-id")
-            add_custom_attribute("llm.foo", "bar")
-            add_custom_attribute("non_llm_attr", "python-agent")
-
-            response = bedrock_server.invoke_model_with_response_stream(
-                body=body,
-                modelId=model,
-                accept="application/json",
-                contentType="application/json",
-            )
-            response = "".join(chunk for chunk in response["body"])
-            assert response
-
-    _test()
-
-
-_event_stream_error = botocore.exceptions.EventStreamError
-_event_stream_error_name = "botocore.exceptions:EventStreamError"
-
-
-@reset_core_stats_engine()
-def test_bedrock_chat_completion_error_streaming_exception(
-    bedrock_server,
-    set_trace_info,
-):
-    """
-    During a streaming call, the streamed chunk's headers indicate an error. These headers are not HTTP headers, but
-    headers embedded in the binary format of the response from the server. The streamed chunk's response body is not
-    required to contain any information regarding the exception, the headers are sufficient to cause botocore's
-    parser to raise an actual exception based on the error code. The response attribute on the raised exception will
-    contain the error information. This means error data will be reported for the response, but all response message
-    data will be missing from the recorded events since the server returned an error instead of message data inside
-    the streamed response.
-    """
-
-    @validate_custom_events(chat_completion_expected_streaming_error_events)
-    @validate_custom_event_count(count=2)
-    @validate_error_trace_attributes(
-        _event_stream_error_name,
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "error.message": "Malformed input request, please reformat your input and try again.",
-                "error.code": "ValidationException",
-            },
-        },
-        forgone_params={
-            "agent": (),
-            "intrinsic": (),
-            "user": ("http.statusCode"),
-        },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        with pytest.raises(_event_stream_error):
-            model = "amazon.titan-text-express-v1"
-            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-
-            set_trace_info()
-            add_custom_attribute("llm.conversation_id", "my-awesome-id")
-            add_custom_attribute("llm.foo", "bar")
-            add_custom_attribute("non_llm_attr", "python-agent")
-
-            response = bedrock_server.invoke_model_with_response_stream(
-                body=body,
-                modelId=model,
-                accept="application/json",
-                contentType="application/json",
-            )
-            list(response["body"])  # Iterate
-
-    _test()
-
-
-@reset_core_stats_engine()
-@disabled_ai_monitoring_record_content_settings
-def test_bedrock_chat_completion_error_streaming_exception_no_content(
-    bedrock_server,
-    set_trace_info,
-):
-    """
-    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with content recording disabled.
-
-    See the original test for a description of the error case.
-    """
-
-    @validate_custom_events(events_sans_content(chat_completion_expected_streaming_error_events))
-    @validate_custom_event_count(count=2)
-    @validate_error_trace_attributes(
-        _event_stream_error_name,
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "error.message": "Malformed input request, please reformat your input and try again.",
-                "error.code": "ValidationException",
-            },
-        },
-        forgone_params={
-            "agent": (),
-            "intrinsic": (),
-            "user": ("http.statusCode"),
-        },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        with pytest.raises(_event_stream_error):
-            model = "amazon.titan-text-express-v1"
-            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-
-            set_trace_info()
-            add_custom_attribute("llm.conversation_id", "my-awesome-id")
-            add_custom_attribute("llm.foo", "bar")
-            add_custom_attribute("non_llm_attr", "python-agent")
-
-            response = bedrock_server.invoke_model_with_response_stream(
-                body=body,
-                modelId=model,
-                accept="application/json",
-                contentType="application/json",
-            )
-            list(response["body"])  # Iterate
-
-    _test()
-
-
-@reset_core_stats_engine()
-@override_llm_token_callback_settings(llm_token_count_callback)
-def test_bedrock_chat_completion_error_streaming_exception_with_token_count(
-    bedrock_server,
-    set_trace_info,
-):
-    """
-    Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with token callback being set.
-
-    See the original test for a description of the error case.
-    """
-
-    @validate_custom_events(add_token_count_to_events(chat_completion_expected_streaming_error_events))
-    @validate_custom_event_count(count=2)
-    @validate_error_trace_attributes(
-        _event_stream_error_name,
-        exact_attrs={
-            "agent": {},
-            "intrinsic": {},
-            "user": {
-                "error.message": "Malformed input request, please reformat your input and try again.",
-                "error.code": "ValidationException",
-            },
-        },
-        forgone_params={
-            "agent": (),
-            "intrinsic": (),
-            "user": ("http.statusCode"),
-        },
-    )
-    @validate_transaction_metrics(
-        name="test_bedrock_chat_completion",
-        scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
-        custom_metrics=[
-            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
-        ],
-        background_task=True,
-    )
-    @background_task(name="test_bedrock_chat_completion")
-    def _test():
-        with pytest.raises(_event_stream_error):
-            model = "amazon.titan-text-express-v1"
-            body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
-
-            set_trace_info()
-            add_custom_attribute("llm.conversation_id", "my-awesome-id")
-            add_custom_attribute("llm.foo", "bar")
-            add_custom_attribute("non_llm_attr", "python-agent")
-
-            response = bedrock_server.invoke_model_with_response_stream(
-                body=body,
-                modelId=model,
-                accept="application/json",
-                contentType="application/json",
-            )
-            list(response["body"])  # Iterate
-
-    _test()
+# @reset_core_stats_engine()
+# def test_bedrock_chat_completion_error_malformed_response_streaming_body(
+#     bedrock_server,
+#     set_trace_info,
+# ):
+#     """
+#     A chunk in the stream returned by the server is valid, but contains a body with JSON that cannot be parsed.
+#     Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing exceptions will
+#     be raised. Instrumentation will attempt to parse the invalid body, and should not raise an exception when it fails
+#     to do so. The result should be all streamed response data missing from the recorded events, but request and summary
+#     events are recorded as normal.
+#     """
+#
+#     @validate_custom_events(chat_completion_expected_malformed_response_streaming_body_events)
+#     @validate_custom_event_count(count=2)
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         model = "amazon.titan-text-express-v1"
+#         body = (chat_completion_payload_templates[model] % ("Malformed Streaming Body", 0.7, 100)).encode("utf-8")
+#
+#         set_trace_info()
+#         add_custom_attribute("llm.conversation_id", "my-awesome-id")
+#         add_custom_attribute("llm.foo", "bar")
+#         add_custom_attribute("non_llm_attr", "python-agent")
+#
+#         response = bedrock_server.invoke_model_with_response_stream(
+#             body=body,
+#             modelId=model,
+#             accept="application/json",
+#             contentType="application/json",
+#         )
+#
+#         chunks = list(response["body"])
+#         assert chunks, "No response chunks returned"
+#         for chunk in chunks:
+#             with pytest.raises(json.decoder.JSONDecodeError):
+#                 json.loads(chunk["chunk"]["bytes"])
+#
+#     _test()
+#
+#
+# @reset_core_stats_engine()
+# def test_bedrock_chat_completion_error_malformed_response_streaming_chunk(
+#     bedrock_server,
+#     set_trace_info,
+# ):
+#     """
+#     A chunk in the stream returned by the server is missing the prelude which causes an InvalidHeadersLength exception
+#     to be raised during parsing of the chunk. Since the streamed chunk is not able to be parsed, the response
+#     attribute on the raised exception is not present. This means all streamed response data will be missing from the
+#     recorded events.
+#     """
+#
+#     @validate_custom_events(chat_completion_expected_malformed_response_streaming_chunk_events)
+#     @validate_custom_event_count(count=2)
+#     @validate_error_trace_attributes(
+#         "botocore.eventstream:ChecksumMismatch",
+#         exact_attrs={
+#             "agent": {},
+#             "intrinsic": {},
+#             "user": {
+#                 "llm.conversation_id": "my-awesome-id",
+#             },
+#         },
+#         forgone_params={
+#             "agent": (),
+#             "intrinsic": (),
+#             "user": ("http.statusCode", "error.message", "error.code"),
+#         },
+#     )
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         model = "amazon.titan-text-express-v1"
+#         body = (chat_completion_payload_templates[model] % ("Malformed Streaming Chunk", 0.7, 100)).encode("utf-8")
+#         with pytest.raises(botocore.eventstream.ChecksumMismatch):
+#             set_trace_info()
+#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
+#             add_custom_attribute("llm.foo", "bar")
+#             add_custom_attribute("non_llm_attr", "python-agent")
+#
+#             response = bedrock_server.invoke_model_with_response_stream(
+#                 body=body,
+#                 modelId=model,
+#                 accept="application/json",
+#                 contentType="application/json",
+#             )
+#             response = "".join(chunk for chunk in response["body"])
+#             assert response
+#
+#     _test()
+#
+#
+# _event_stream_error = botocore.exceptions.EventStreamError
+# _event_stream_error_name = "botocore.exceptions:EventStreamError"
+#
+#
+# @reset_core_stats_engine()
+# def test_bedrock_chat_completion_error_streaming_exception(
+#     bedrock_server,
+#     set_trace_info,
+# ):
+#     """
+#     During a streaming call, the streamed chunk's headers indicate an error. These headers are not HTTP headers, but
+#     headers embedded in the binary format of the response from the server. The streamed chunk's response body is not
+#     required to contain any information regarding the exception, the headers are sufficient to cause botocore's
+#     parser to raise an actual exception based on the error code. The response attribute on the raised exception will
+#     contain the error information. This means error data will be reported for the response, but all response message
+#     data will be missing from the recorded events since the server returned an error instead of message data inside
+#     the streamed response.
+#     """
+#
+#     @validate_custom_events(chat_completion_expected_streaming_error_events)
+#     @validate_custom_event_count(count=2)
+#     @validate_error_trace_attributes(
+#         _event_stream_error_name,
+#         exact_attrs={
+#             "agent": {},
+#             "intrinsic": {},
+#             "user": {
+#                 "error.message": "Malformed input request, please reformat your input and try again.",
+#                 "error.code": "ValidationException",
+#             },
+#         },
+#         forgone_params={
+#             "agent": (),
+#             "intrinsic": (),
+#             "user": ("http.statusCode"),
+#         },
+#     )
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         with pytest.raises(_event_stream_error):
+#             model = "amazon.titan-text-express-v1"
+#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+#
+#             set_trace_info()
+#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
+#             add_custom_attribute("llm.foo", "bar")
+#             add_custom_attribute("non_llm_attr", "python-agent")
+#
+#             response = bedrock_server.invoke_model_with_response_stream(
+#                 body=body,
+#                 modelId=model,
+#                 accept="application/json",
+#                 contentType="application/json",
+#             )
+#             list(response["body"])  # Iterate
+#
+#     _test()
+#
+#
+# @reset_core_stats_engine()
+# @disabled_ai_monitoring_record_content_settings
+# def test_bedrock_chat_completion_error_streaming_exception_no_content(
+#     bedrock_server,
+#     set_trace_info,
+# ):
+#     """
+#     Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with content recording disabled.
+#
+#     See the original test for a description of the error case.
+#     """
+#
+#     @validate_custom_events(events_sans_content(chat_completion_expected_streaming_error_events))
+#     @validate_custom_event_count(count=2)
+#     @validate_error_trace_attributes(
+#         _event_stream_error_name,
+#         exact_attrs={
+#             "agent": {},
+#             "intrinsic": {},
+#             "user": {
+#                 "error.message": "Malformed input request, please reformat your input and try again.",
+#                 "error.code": "ValidationException",
+#             },
+#         },
+#         forgone_params={
+#             "agent": (),
+#             "intrinsic": (),
+#             "user": ("http.statusCode"),
+#         },
+#     )
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         with pytest.raises(_event_stream_error):
+#             model = "amazon.titan-text-express-v1"
+#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+#
+#             set_trace_info()
+#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
+#             add_custom_attribute("llm.foo", "bar")
+#             add_custom_attribute("non_llm_attr", "python-agent")
+#
+#             response = bedrock_server.invoke_model_with_response_stream(
+#                 body=body,
+#                 modelId=model,
+#                 accept="application/json",
+#                 contentType="application/json",
+#             )
+#             list(response["body"])  # Iterate
+#
+#     _test()
+#
+#
+# @reset_core_stats_engine()
+# @override_llm_token_callback_settings(llm_token_count_callback)
+# def test_bedrock_chat_completion_error_streaming_exception_with_token_count(
+#     bedrock_server,
+#     set_trace_info,
+# ):
+#     """
+#     Duplicate of test_bedrock_chat_completion_error_streaming_exception, but with token callback being set.
+#
+#     See the original test for a description of the error case.
+#     """
+#
+#     @validate_custom_events(add_token_count_to_events(chat_completion_expected_streaming_error_events))
+#     @validate_custom_event_count(count=2)
+#     @validate_error_trace_attributes(
+#         _event_stream_error_name,
+#         exact_attrs={
+#             "agent": {},
+#             "intrinsic": {},
+#             "user": {
+#                 "error.message": "Malformed input request, please reformat your input and try again.",
+#                 "error.code": "ValidationException",
+#             },
+#         },
+#         forgone_params={
+#             "agent": (),
+#             "intrinsic": (),
+#             "user": ("http.statusCode"),
+#         },
+#     )
+#     @validate_transaction_metrics(
+#         name="test_bedrock_chat_completion",
+#         scoped_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         rollup_metrics=[("Llm/completion/Bedrock/invoke_model_with_response_stream", 1)],
+#         custom_metrics=[
+#             (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+#         ],
+#         background_task=True,
+#     )
+#     @background_task(name="test_bedrock_chat_completion")
+#     def _test():
+#         with pytest.raises(_event_stream_error):
+#             model = "amazon.titan-text-express-v1"
+#             body = (chat_completion_payload_templates[model] % ("Streaming Exception", 0.7, 100)).encode("utf-8")
+#
+#             set_trace_info()
+#             add_custom_attribute("llm.conversation_id", "my-awesome-id")
+#             add_custom_attribute("llm.foo", "bar")
+#             add_custom_attribute("non_llm_attr", "python-agent")
+#
+#             response = bedrock_server.invoke_model_with_response_stream(
+#                 body=body,
+#                 modelId=model,
+#                 accept="application/json",
+#                 contentType="application/json",
+#             )
+#             list(response["body"])  # Iterate
+#
+#     _test()
 
 
 def test_bedrock_chat_completion_functions_marked_as_wrapped_for_sdk_compatibility(bedrock_server):

--- a/tests/external_aiobotocore/test_bedrock_embeddings.py
+++ b/tests/external_aiobotocore/test_bedrock_embeddings.py
@@ -1,0 +1,495 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from io import BytesIO
+
+import botocore.exceptions
+import pytest
+from external_botocore._test_bedrock_embeddings import (
+    embedding_expected_events,
+    embedding_expected_malformed_request_body_events,
+    embedding_expected_malformed_response_body_events,
+    embedding_invalid_access_key_error_events,
+    embedding_payload_templates,
+)
+from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from testing_support.fixtures import (
+    override_llm_token_callback_settings,
+    reset_core_stats_engine,
+    validate_attributes,
+)
+from testing_support.ml_testing_utils import (  # noqa: F401
+    add_token_count_to_events,
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+    events_sans_content,
+    events_sans_llm_metadata,
+    llm_token_count_callback,
+    set_trace_info,
+)
+from testing_support.validators.validate_custom_event import validate_custom_event_count
+from testing_support.validators.validate_custom_events import validate_custom_events
+from testing_support.validators.validate_error_trace_attributes import (
+    validate_error_trace_attributes,
+)
+from testing_support.validators.validate_transaction_metrics import (
+    validate_transaction_metrics,
+)
+
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import add_custom_attribute
+from newrelic.common.object_names import callable_name
+from newrelic.hooks.external_botocore import MODEL_EXTRACTORS
+
+
+@pytest.fixture(scope="session", params=[False, True], ids=["RequestStandard", "RequestStreaming"])
+def request_streaming(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "amazon.titan-embed-text-v1",
+        "amazon.titan-embed-g1-text-02",
+        "cohere.embed-english-v3",
+    ],
+)
+def model_id(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def exercise_model(loop, bedrock_server, model_id, request_streaming):
+    payload_template = embedding_payload_templates[model_id]
+
+    def _exercise_model(prompt):
+        async def coro():
+            body = (payload_template % prompt).encode("utf-8")
+            if request_streaming:
+                body = BytesIO(body)
+
+            response = await bedrock_server.invoke_model(
+                body=body,
+                modelId=model_id,
+                accept="application/json",
+                contentType="application/json",
+            )
+            response_body = json.loads(response.get("body").read())
+            assert response_body
+
+            return response_body
+        return loop.run_until_complete(coro())
+
+    return _exercise_model
+
+
+@pytest.fixture(scope="module")
+def expected_events(model_id):
+    return embedding_expected_events[model_id]
+
+
+@pytest.fixture(scope="module")
+def expected_invalid_access_key_error_events(model_id):
+    return embedding_invalid_access_key_error_events[model_id]
+
+
+_test_bedrock_embedding_prompt = "This is an embedding test."
+
+
+@reset_core_stats_engine()
+def test_bedrock_embedding_with_llm_metadata(set_trace_info, exercise_model, expected_events):
+    @validate_custom_events(expected_events)
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        exercise_model(prompt=_test_bedrock_embedding_prompt)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+def test_bedrock_embedding_no_content(set_trace_info, exercise_model, model_id):
+    @validate_custom_events(events_sans_content(embedding_expected_events[model_id]))
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+        exercise_model(prompt=_test_bedrock_embedding_prompt)
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_embedding_no_llm_metadata(set_trace_info, exercise_model, expected_events):
+    @validate_custom_events(events_sans_llm_metadata(expected_events))
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding_no_llm_metadata",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding_no_llm_metadata")
+    def _test():
+        set_trace_info()
+        exercise_model(prompt=_test_bedrock_embedding_prompt)
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+def test_bedrock_embedding_with_token_count(set_trace_info, exercise_model, expected_events):
+    @validate_custom_events(add_token_count_to_events(expected_events))
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @validate_attributes("agent", ["llm"])
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+
+        exercise_model(prompt="This is an embedding test.")
+
+    _test()
+
+
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+def test_bedrock_embedding_outside_txn(exercise_model):
+    add_custom_attribute("llm.conversation_id", "my-awesome-id")
+    exercise_model(prompt=_test_bedrock_embedding_prompt)
+
+
+@disabled_ai_monitoring_settings
+@reset_core_stats_engine()
+@validate_custom_event_count(count=0)
+@background_task(name="test_bedrock_embedding_disabled_ai_monitoring_setting")
+def test_bedrock_embedding_disabled_ai_monitoring_settings(set_trace_info, exercise_model):
+    set_trace_info()
+    exercise_model(prompt=_test_bedrock_embedding_prompt)
+
+
+_client_error = botocore.exceptions.ClientError
+_client_error_name = callable_name(_client_error)
+
+
+@reset_core_stats_engine()
+def test_bedrock_embedding_error_incorrect_access_key(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+):
+    """
+    A request is made to the server with invalid credentials. botocore will reach out to the server and receive an
+    UnrecognizedClientException as a response. Information from the request will be parsed and reported in customer
+    events. The error response can also be parsed, and will be included as attributes on the recorded exception.
+    """
+
+    @validate_custom_events(expected_invalid_access_key_error_events)
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token")
+
+    _test()
+
+
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+def test_bedrock_embedding_error_incorrect_access_key_no_content(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+):
+    @validate_custom_events(events_sans_content(expected_invalid_access_key_error_events))
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token")
+
+    _test()
+
+
+@reset_core_stats_engine()
+@override_llm_token_callback_settings(llm_token_count_callback)
+def test_bedrock_embedding_error_incorrect_access_key_with_token_count(
+    monkeypatch,
+    bedrock_server,
+    exercise_model,
+    set_trace_info,
+    expected_invalid_access_key_error_events,
+):
+    @validate_custom_events(add_token_count_to_events(expected_invalid_access_key_error_events))
+    @validate_error_trace_attributes(
+        _client_error_name,
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 403,
+                "error.message": "The security token included in the request is invalid.",
+                "error.code": "UnrecognizedClientException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        monkeypatch.setattr(bedrock_server._request_signer._credentials, "access_key", "INVALID-ACCESS-KEY")
+
+        with pytest.raises(_client_error):  # not sure where this exception actually comes from
+            set_trace_info()
+            add_custom_attribute("llm.conversation_id", "my-awesome-id")
+            add_custom_attribute("llm.foo", "bar")
+            add_custom_attribute("non_llm_attr", "python-agent")
+
+            exercise_model(prompt="Invalid Token")
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_embedding_error_malformed_request_body(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    A request was made to the server, but the request body contains invalid JSON. The library will accept the invalid
+    payload, and still send a request. Our instrumentation will be unable to read it. As a result, no request
+    information will be recorded in custom events. This includes the initial prompt message event, which cannot be read
+    so it cannot be captured. The server will then respond with a ValidationException response immediately due to the
+    bad request. The response can still be parsed, so error information from the response will be recorded as normal.
+    """
+
+    @validate_custom_events(embedding_expected_malformed_request_body_events)
+    @validate_custom_event_count(count=1)
+    @validate_error_trace_attributes(
+        "botocore.errorfactory:ValidationException",
+        exact_attrs={
+            "agent": {},
+            "intrinsic": {},
+            "user": {
+                "http.statusCode": 400,
+                "error.message": "Malformed input request, please reformat your input and try again.",
+                "error.code": "ValidationException",
+            },
+        },
+    )
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        model = "amazon.titan-embed-g1-text-02"
+        body = "{ Malformed Request Body".encode("utf-8")
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        with pytest.raises(_client_error):
+            bedrock_server.invoke_model(
+                body=body,
+                modelId=model,
+                accept="application/json",
+                contentType="application/json",
+            )
+
+    _test()
+
+
+@reset_core_stats_engine()
+def test_bedrock_embedding_error_malformed_response_body(
+    bedrock_server,
+    set_trace_info,
+):
+    """
+    After a non-streaming request was made to the server, the server responded with a response body that contains
+    invalid JSON. Since the JSON body is not parsed by botocore and just returned to the user as bytes, no parsing
+    exceptions will be raised. Instrumentation will attempt to parse the invalid body, and should not raise an
+    exception when it fails to do so. As a result, recorded events will not contain the streamed response data but will contain the request data.
+    """
+
+    @validate_custom_events(embedding_expected_malformed_response_body_events)
+    @validate_custom_event_count(count=1)
+    @validate_transaction_metrics(
+        name="test_bedrock_embedding",
+        scoped_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        rollup_metrics=[("Llm/embedding/Bedrock/invoke_model", 1)],
+        custom_metrics=[
+            (f"Supportability/Python/ML/Bedrock/{BOTOCORE_VERSION}", 1),
+        ],
+        background_task=True,
+    )
+    @background_task(name="test_bedrock_embedding")
+    def _test():
+        model = "amazon.titan-embed-g1-text-02"
+        body = (embedding_payload_templates[model] % "Malformed Body").encode("utf-8")
+        set_trace_info()
+        add_custom_attribute("llm.conversation_id", "my-awesome-id")
+        add_custom_attribute("llm.foo", "bar")
+        add_custom_attribute("non_llm_attr", "python-agent")
+
+        response = bedrock_server.invoke_model(
+            body=body,
+            modelId=model,
+            accept="application/json",
+            contentType="application/json",
+        )
+        assert response
+
+    _test()
+
+
+def test_embedding_models_instrumented():
+    import aiobotocore
+
+    SUPPORTED_MODELS = [model for model, _, _, _ in MODEL_EXTRACTORS if "embed" in model]
+
+    _id = os.environ.get("AWS_ACCESS_KEY_ID")
+    key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not _id or not key:
+        pytest.skip(reason="Credentials not available.")
+
+    session = aiobotocore.session.get_session()
+    client = loop.run_until_complete(
+        session.create_client(
+            "bedrock",
+            "us-east-1",
+        ).__aenter__()
+    )
+
+    try:
+        response = client.list_foundation_models(byOutputModality="EMBEDDING")
+        models = [model["modelId"] for model in response["modelSummaries"]]
+        not_supported = []
+        for model in models:
+            is_supported = any([model.startswith(supported_model) for supported_model in SUPPORTED_MODELS])
+            if not is_supported:
+                not_supported.append(model)
+
+        assert not not_supported, f"The following unsupported models were found: {not_supported}"
+    finally:
+        loop.run_until_complete(client.__aexit__(None, None, None))

--- a/tests/external_botocore/_mock_external_bedrock_server.py
+++ b/tests/external_botocore/_mock_external_bedrock_server.py
@@ -15,7 +15,7 @@
 import json
 import re
 
-from ._mock_bedrock_encoding_utils import encode_streaming_payload
+from external_botocore._mock_bedrock_encoding_utils import encode_streaming_payload
 from testing_support.mock_external_http_server import MockExternalHTTPServer
 
 # This defines an external server test apps can make requests to instead of

--- a/tests/external_botocore/_mock_external_bedrock_server.py
+++ b/tests/external_botocore/_mock_external_bedrock_server.py
@@ -15,7 +15,7 @@
 import json
 import re
 
-from _mock_bedrock_encoding_utils import encode_streaming_payload
+from ._mock_bedrock_encoding_utils import encode_streaming_payload
 from testing_support.mock_external_http_server import MockExternalHTTPServer
 
 # This defines an external server test apps can make requests to instead of

--- a/tox.ini
+++ b/tox.ini
@@ -294,6 +294,7 @@ deps =
     external_aiobotocore-aiobotocorelatest: flask-cors
     external_aiobotocore-aiobotocorelatest: moto[all]
     external_aiobotocore-aiobotocorelatest: aiohttp
+    external_aiobotocore-aiobotocorelatest: aiofiles
     external_botocore-botocorelatest: botocore
     external_botocore-botocorelatest: boto3
     external_botocore-botocorelatest-langchain: langchain


### PR DESCRIPTION
This PR adds instrumentation and tests to support `invoke_model_with_response_stream` in async Bedrock. 
