### PR TITLE
Ruff Linting

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -35,7 +35,7 @@ jobs:
         id: ml
         # You can override Mega-Linter flavor used to have faster performances
         # More info at https://oxsecurity.github.io/megalinter/flavors/
-        uses: oxsecurity/megalinter/flavors/python@a7a0163b6c8ff7474a283d99a706e27483ddd80f # 7.10.0
+        uses: oxsecurity/megalinter/flavors/python@ec124f7998718d79379a3c5b39f5359952baf21d # 8.4.2
         env:
           # All available variables are described in documentation
           # https://oxsecurity.github.io/megalinter/configuration/

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,14 +1,14 @@
 ---
-# Mega-Linter GitHub Action configuration file
-# More info at https://oxsecurity.github.io/megalinter
-name: Mega-Linter
+# MegaLinter GitHub Action configuration file
+# More info at https://megalinter.io
+name: MegaLinter
 
 on:
   # Trigger mega-linter at every push. Action will also be visible from Pull Requests to main
   # push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
   pull_request:
 
-env: # Comment env block if you do not want to apply fixes
+env: # Comment env block if you don't want to apply fixes
   # Apply linter fixes configuration
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
   APPLY_FIXES_EVENT: pull_request # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
@@ -19,58 +19,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Mega-Linter
+  megalinter:
+    name: MegaLinter
     runs-on: ubuntu-22.04
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push, comment issues & post new PR
+      # Remove the ones you do not need
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
 
-      # Mega-Linter
-      - name: Mega-Linter
+      # MegaLinter
+      - name: MegaLinter
         id: ml
-        # You can override Mega-Linter flavor used to have faster performances
-        # More info at https://oxsecurity.github.io/megalinter/flavors/
+        # You can override MegaLinter flavor used to have faster performances
+        # More info at https://megalinter.io/flavors/
         uses: oxsecurity/megalinter/flavors/python@ec124f7998718d79379a3c5b39f5359952baf21d # 8.4.2
         env:
           # All available variables are described in documentation
-          # https://oxsecurity.github.io/megalinter/configuration/
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Set 'true' if you always want to lint all sources
-          DEFAULT_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}
+          # https://megalinter.io/configuration/
+          VALIDATE_ALL_CODEBASE: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ADD YOUR CUSTOM ENV VARIABLES HERE TO OVERRIDE VALUES OF .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-          PYTHON_RUFF_ARGUMENTS: '--config=''output-format="github"'''
-          PYTHON_RUFF_FORMAT_ARGUMENTS: '--config=''output-format="github"'''
+          # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
+          PYTHON_RUFF_ARGUMENTS: --config pyproject.toml --config 'output-format="github"'
+          PYTHON_RUFF_FORMAT_ARGUMENTS: --config pyproject.toml --config 'output-format="github"'
 
-      # Upload Mega-Linter artifacts
+      # Upload MegaLinter artifacts
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # 4.3.1
+        if: success() || failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
-          name: Mega-Linter reports
+          name: MegaLinter reports
           path: |
             megalinter-reports
             mega-linter.log
-
-      # Create pull request if applicable (for now works only on PR from same repository, not from forks)
-      - name: Create Pull Request with applied fixes
-        id: cpr
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@c55203cfde3e5c11a452d352b4393e68b85b4533 # 6.0.3
-        with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          commit-message: "[Mega-Linter] Apply linters automatic fixes"
-          title: "[Mega-Linter] Apply linters automatic fixes"
-          labels: bot
-      - name: Create PR output
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        run: |
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
 
       # Push new commit if applicable (for now works only on PR from same repository, not from forks)
       - name: Prepare commit
@@ -78,7 +66,9 @@ jobs:
         run: sudo chown -Rc $UID .git/
       - name: Commit and push applied linter fixes
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # 5.0.1
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # 5.1.0
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
-          commit_message: "[Mega-Linter] Apply linters fixes"
+          commit_message: "[MegaLinter] Apply linters fixes"
+          commit_user_name: newrelic-python-agent-team
+          commit_user_email: 137356142+newrelic-python-agent-team@users.noreply.github.com

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -6,7 +6,7 @@ DEFAULT_BRANCH: main # Usually master or main
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
 PRINT_ALPACA: false
-VALIDATE_ALL_CODEBASE: false # only lint new and edited files
+VALIDATE_ALL_CODEBASE: true
 IGNORE_GITIGNORED_FILES: true
 FILTER_REGEX_EXCLUDE: "(.*/?packages/.*)" # Ignore packages directories
 
@@ -23,4 +23,6 @@ ENABLE_LINTERS: # If you use ENABLE_LINTERS variable, all other linters will be 
   - YAML_YAMLLINT
 
 PYTHON_RUFF_CONFIG_FILE: pyproject.toml
+PYTHON_RUFF_CLI_LINT_MODE: project
 PYTHON_RUFF_FORMAT_CONFIG_FILE: pyproject.toml
+PYTHON_RUFF_FORMAT_CLI_LINT_MODE: project

--- a/newrelic/admin/__init__.py
+++ b/newrelic/admin/__init__.py
@@ -125,7 +125,7 @@ def load_external_plugins():
         if sys.version_info >= (3, 10):
             from importlib.metadata import entry_points
         # Introduced in Python 3.8
-        elif sys.version_info >= (3, 8) and sys.version_info <= (3, 9):
+        elif sys.version_info >= (3, 8) and sys.version_info < (3, 9):
             from importlib_metadata import entry_points
         # Removed in Python 3.12
         else:

--- a/newrelic/admin/__init__.py
+++ b/newrelic/admin/__init__.py
@@ -53,7 +53,7 @@ def usage(name):
 
 
 @command("help", "[command]", hidden=True)
-def help(args):
+def help_(args):
     if not args:
         print("Usage: newrelic-admin command [options]")
         print()

--- a/newrelic/admin/local_config.py
+++ b/newrelic/admin/local_config.py
@@ -22,9 +22,9 @@ from newrelic.admin import command, usage
 from <config_file>.""",
 )
 def local_config(args):
+    import logging
     import os
     import sys
-    import logging
 
     if len(args) == 0:
         usage("local-config")

--- a/newrelic/admin/network_config.py
+++ b/newrelic/admin/network_config.py
@@ -22,9 +22,9 @@ from newrelic.admin import command, usage
 from <config_file>.""",
 )
 def network_config(args):
+    import logging
     import os
     import sys
-    import logging
 
     if len(args) == 0:
         usage("network-config")

--- a/newrelic/admin/run_python.py
+++ b/newrelic/admin/run_python.py
@@ -61,7 +61,8 @@ def run_python(args):
         if name.startswith("NEW_RELIC_") or name.startswith("PYTHON"):
             log_message("%s = %r", name, os.environ.get(name))
 
-    from newrelic import version, __file__ as root_directory
+    from newrelic import __file__ as root_directory
+    from newrelic import version
 
     root_directory = os.path.dirname(root_directory)
     boot_directory = os.path.join(root_directory, "bootstrap")

--- a/newrelic/admin/server_config.py
+++ b/newrelic/admin/server_config.py
@@ -24,9 +24,9 @@ side configuration. The application name as specified in the agent
 configuration file is used.""",
 )
 def server_config(args):
+    import logging
     import os
     import sys
-    import logging
     import time
 
     if len(args) == 0:

--- a/newrelic/api/cat_header_mixin.py
+++ b/newrelic/api/cat_header_mixin.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from newrelic.common.encoding_utils import (
-    obfuscate,
-    deobfuscate,
-    json_encode,
-    json_decode,
-    base64_encode,
     base64_decode,
+    base64_encode,
+    deobfuscate,
+    json_decode,
+    json_encode,
+    obfuscate,
 )
 
 

--- a/newrelic/api/generator_trace.py
+++ b/newrelic/api/generator_trace.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import functools
-import types
 import sys
+import types
 
-from newrelic.api.time_trace import current_trace
 from newrelic.api.function_trace import FunctionTrace
-from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
+from newrelic.api.time_trace import current_trace
 from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 
 
 def GeneratorTraceWrapper(wrapped, name=None, group=None, label=None, params=None):

--- a/newrelic/api/html_insertion.py
+++ b/newrelic/api/html_insertion.py
@@ -16,7 +16,7 @@ import re
 
 _head_re = re.compile(b"<head[^>]*>", re.IGNORECASE)
 
-_xua_meta_re = re.compile(b"""<\\s*meta[^>]+http-equiv\\s*=\\s*['"]""" b"""x-ua-compatible['"][^>]*>""", re.IGNORECASE)
+_xua_meta_re = re.compile(b"""<\\s*meta[^>]+http-equiv\\s*=\\s*['"]x-ua-compatible['"][^>]*>""", re.IGNORECASE)
 
 _charset_meta_re = re.compile(b"""<\\s*meta[^>]+charset\\s*=[^>]*>""", re.IGNORECASE)
 

--- a/newrelic/api/import_hook.py
+++ b/newrelic/api/import_hook.py
@@ -57,7 +57,7 @@ _ok_modules = (
 _uninstrumented_modules = set()
 
 
-def register_import_hook(name, callable):  # pylint: disable=redefined-builtin
+def register_import_hook(name, callable):  # noqa: A002
     hooks = _import_hooks.get(name, None)
 
     if name not in _import_hooks or hooks is None:

--- a/newrelic/api/import_hook.py
+++ b/newrelic/api/import_hook.py
@@ -14,9 +14,7 @@
 
 import logging
 import sys
-
 from importlib.util import find_spec
-
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/api/in_function.py
+++ b/newrelic/api/in_function.py
@@ -14,4 +14,4 @@
 
 # Use of these from this module will be deprecated.
 
-from newrelic.common.object_wrapper import in_function, InFunctionWrapper, wrap_in_function
+from newrelic.common.object_wrapper import InFunctionWrapper, in_function, wrap_in_function

--- a/newrelic/api/lambda_handler.py
+++ b/newrelic/api/lambda_handler.py
@@ -14,13 +14,13 @@
 
 import functools
 import warnings
-from newrelic.common.object_wrapper import FunctionWrapper
+
+from newrelic.api.application import application_instance
 from newrelic.api.transaction import current_transaction
 from newrelic.api.web_transaction import WebTransaction
-from newrelic.api.application import application_instance
+from newrelic.common.object_wrapper import FunctionWrapper
 from newrelic.core.attribute import truncate
 from newrelic.core.config import global_settings
-
 
 COLD_START_RECORDED = False
 MEGABYTE_IN_BYTES = 2**20

--- a/newrelic/api/ml_model.py
+++ b/newrelic/api/ml_model.py
@@ -116,7 +116,8 @@ def set_llm_token_count_callback(callback, application=None):
 
         if not isinstance(token_count_val, int) or token_count_val < 0:
             _logger.warning(
-                f"llm_token_count_callback returned an invalid value of {token_count_val}. This value must be a positive integer and will not be recorded for the token_count."
+                "llm_token_count_callback returned an invalid value of %s. This value must be a positive integer and will not be recorded for the token_count.",
+                token_count_val,
             )
             return None
 

--- a/newrelic/api/object_wrapper.py
+++ b/newrelic/api/object_wrapper.py
@@ -17,7 +17,6 @@ import sys
 # These have been moved. They are retained here until all references to
 # them are moved at which point will mark as deprecated to ensure users
 # weren't using them directly.
-
 from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import ObjectWrapper, wrap_object
 

--- a/newrelic/api/out_function.py
+++ b/newrelic/api/out_function.py
@@ -14,4 +14,4 @@
 
 # Use of these from this module will be deprecated.
 
-from newrelic.common.object_wrapper import out_function, OutFunctionWrapper, wrap_out_function
+from newrelic.common.object_wrapper import OutFunctionWrapper, out_function, wrap_out_function

--- a/newrelic/api/post_function.py
+++ b/newrelic/api/post_function.py
@@ -14,4 +14,4 @@
 
 # Use of these from this module will be deprecated.
 
-from newrelic.common.object_wrapper import post_function, PostFunctionWrapper, wrap_post_function
+from newrelic.common.object_wrapper import PostFunctionWrapper, post_function, wrap_post_function

--- a/newrelic/api/pre_function.py
+++ b/newrelic/api/pre_function.py
@@ -14,4 +14,4 @@
 
 # Use of these from this module will be deprecated.
 
-from newrelic.common.object_wrapper import pre_function, PreFunctionWrapper, wrap_pre_function
+from newrelic.common.object_wrapper import PreFunctionWrapper, pre_function, wrap_pre_function

--- a/newrelic/api/profile_trace.py
+++ b/newrelic/api/profile_trace.py
@@ -70,7 +70,7 @@ class ProfileTrace:
             except Exception:
                 pass
 
-            for name, obj in frame.f_globals.items():
+            for obj in frame.f_globals.values():
                 try:
                     if obj.__dict__[func_name].func_code is co:
                         return obj.__dict__[func_name]

--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -211,7 +211,9 @@ class TimeTrace:
                 node.add_attrs(self._add_agent_attribute)
             except Exception as exc:
                 _logger.debug(
-                    f"Failed to extract source code context from callable {source}. Report this issue to newrelic support. Exception: {exc}"
+                    "Failed to extract source code context from callable %s. Report this issue to newrelic support. Exception: %s",
+                    source,
+                    exc,
                 )
 
     def _observe_exception(self, exc_info=None, ignore=None, expected=None, status_code=None):

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -1871,7 +1871,7 @@ def capture_request_params(flag=True):
     transaction = current_transaction()
     if transaction and transaction.settings:
         if transaction.settings.high_security:
-            _logger.warn("Cannot modify capture_params in High Security Mode.")
+            _logger.warning("Cannot modify capture_params in High Security Mode.")
         else:
             transaction.capture_params = flag
 

--- a/newrelic/api/transaction_name.py
+++ b/newrelic/api/transaction_name.py
@@ -15,8 +15,8 @@
 import functools
 
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import FunctionWrapper, wrap_object
 
 
 def TransactionNameWrapper(wrapped, name=None, group=None, priority=None):

--- a/newrelic/api/web_transaction.py
+++ b/newrelic/api/web_transaction.py
@@ -15,9 +15,8 @@
 import functools
 import logging
 import time
-import warnings
-
 import urllib.parse as urlparse
+import warnings
 
 from newrelic.api.application import Application, application_instance
 from newrelic.api.transaction import Transaction, current_transaction

--- a/newrelic/api/wsgi_application.py
+++ b/newrelic/api/wsgi_application.py
@@ -96,7 +96,7 @@ class _WSGIApplicationIterable:
 
 
 class _WSGIInputWrapper:
-    def __init__(self, transaction, input):
+    def __init__(self, transaction, input):  # noqa: A002
         self.__transaction = transaction
         self.__input = input
 

--- a/newrelic/common/async_proxy.py
+++ b/newrelic/common/async_proxy.py
@@ -15,7 +15,7 @@
 import logging
 import time
 
-from newrelic.common.coroutine import is_coroutine_callable, is_asyncio_coroutine, is_generator_function
+from newrelic.common.coroutine import is_asyncio_coroutine, is_coroutine_callable, is_generator_function
 from newrelic.common.object_wrapper import ObjectProxy
 from newrelic.core.trace_cache import trace_cache
 

--- a/newrelic/common/async_wrapper.py
+++ b/newrelic/common/async_wrapper.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import functools
+
 from newrelic.common.coroutine import (
-    is_coroutine_callable,
-    is_asyncio_coroutine,
-    is_generator_function,
     is_async_generator_function,
+    is_asyncio_coroutine,
+    is_coroutine_callable,
+    is_generator_function,
 )
 
 

--- a/newrelic/common/encoding_utils.py
+++ b/newrelic/common/encoding_utils.py
@@ -29,7 +29,6 @@ import types
 import zlib
 from collections import OrderedDict
 
-
 HEXDIGLC_RE = re.compile("^[0-9a-f]+$")
 DELIMITER_FORMAT_RE = re.compile("[ \t]*,[ \t]*")
 PARENT_TYPE = {"0": "App", "1": "Browser", "2": "Mobile"}

--- a/newrelic/common/log_file.py
+++ b/newrelic/common/log_file.py
@@ -76,7 +76,7 @@ def _initialize_file_logging(log_file, log_level):
     _agent_logger.setLevel(log_level)
 
     _agent_logger.debug("Initializing Python agent logging.")
-    _agent_logger.debug(f'Log file "{log_file}".')
+    _agent_logger.debug('Log file "%s".', log_file)
 
 
 def initialize_logging(log_file, log_level):
@@ -101,7 +101,7 @@ def initialize_logging(log_file, log_level):
             except Exception:
                 _initialize_stderr_logging(log_level)
 
-                _agent_logger.exception(f"Falling back to stderr logging as unable to create log file {log_file!r}.")
+                _agent_logger.exception("Falling back to stderr logging as unable to create log file %r.", log_file)
 
         _initialized = True
 

--- a/newrelic/common/object_names.py
+++ b/newrelic/common/object_names.py
@@ -15,11 +15,10 @@
 """This module implements functions for deriving the full name of an object."""
 
 import builtins
+import functools
+import inspect
 import sys
 import types
-import inspect
-import functools
-
 
 # Object model terminology for quick reference.
 #

--- a/newrelic/common/object_names.py
+++ b/newrelic/common/object_names.py
@@ -63,7 +63,7 @@ import functools
 #     instance to which a method is bound, or None
 
 
-def _module_name(object):
+def _module_name(object):  # noqa: A002
     mname = None
 
     # For the module name we first need to deal with the special
@@ -111,7 +111,7 @@ def _module_name(object):
     return mname
 
 
-def _object_context(object):
+def _object_context(object):  # noqa: A002
     if inspect.ismethod(object):
         # In Python 3, ismethod() returns True for bound methods. We
         # need to distinguish between class methods and instance methods.
@@ -247,7 +247,7 @@ def object_context(target):
     return details
 
 
-def callable_name(object, separator=":"):
+def callable_name(object, separator=":"):  # noqa: A002
     """Returns a string name identifying the supplied object. This will be
     of the form 'module:object_path'.
 

--- a/newrelic/common/system_info.py
+++ b/newrelic/common/system_info.py
@@ -213,7 +213,7 @@ def _linux_total_physical_memory(filename=None):
         parser = re.compile(r"^(?P<key>\S*):\s*(?P<value>\d*)\s*kB")
 
         with open(filename, "r") as fp:
-            for line in fp.readlines():
+            for line in fp.readlines():  # noqa: FURB129 # Read all lines at once
                 match = parser.match(line)
                 if not match:
                     continue

--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
 import re
 import socket
-import json
 import string
-import newrelic.packages.urllib3 as urllib3
 
+import newrelic.packages.urllib3 as urllib3
 from newrelic.common.agent_http import InsecureHttpClient
 from newrelic.common.encoding_utils import json_decode
 from newrelic.core.internal_metrics import internal_count_metric
-
 
 _logger = logging.getLogger(__name__)
 VALID_CHARS_RE = re.compile(r"[0-9a-zA-Z_ ./-]")

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -4017,7 +4017,7 @@ def _process_module_entry_points():
         if sys.version_info >= (3, 10):
             from importlib.metadata import entry_points
         # Introduced in Python 3.8
-        elif sys.version_info >= (3, 8) and sys.version_info <= (3, 9):
+        elif sys.version_info >= (3, 8) and sys.version_info < (3, 9):
             from importlib_metadata import entry_points
         # Removed in Python 3.12
         else:
@@ -4089,7 +4089,7 @@ def _setup_extensions():
         if sys.version_info >= (3, 10):
             from importlib.metadata import entry_points
         # Introduced in Python 3.8
-        elif sys.version_info >= (3, 8) and sys.version_info <= (3, 9):
+        elif sys.version_info >= (3, 8) and sys.version_info < (3, 9):
             from importlib_metadata import entry_points
         # Removed in Python 3.12
         else:

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -48,12 +48,6 @@ from newrelic.core.agent_control_health import (
     agent_control_healthcheck_loop,
 )
 from newrelic.core.config import Settings, apply_config_setting, default_host, fetch_config_setting
-from newrelic.core.agent_control_health import (
-    HealthStatus,
-    agent_control_health_instance,
-    agent_control_healthcheck_loop,
-)
-
 
 __all__ = ["initialize", "filter_app_factory"]
 

--- a/newrelic/console.py
+++ b/newrelic/console.py
@@ -61,11 +61,7 @@ def shell_command(wrapped):
         result = shlex.split(line)
 
         (options, args) = parser.parse_args(result)
-
-        kwargs = {}
-        for key, value in options.__dict__.items():
-            if value is not None:
-                kwargs[key] = value
+        kwargs = {key: value for key, value in options.__dict__.items() if value is not None}
 
         return wrapped(self, *args, **kwargs)
 

--- a/newrelic/console.py
+++ b/newrelic/console.py
@@ -28,15 +28,13 @@ import sys
 import threading
 import time
 import traceback
-
 from collections import OrderedDict
 from inspect import signature
 
-
 from newrelic.common.object_wrapper import ObjectProxy
 from newrelic.core.agent import agent_instance
-from newrelic.core.config import flatten_settings, global_settings
 from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance
+from newrelic.core.config import flatten_settings, global_settings
 from newrelic.core.trace_cache import trace_cache
 
 

--- a/newrelic/console.py
+++ b/newrelic/console.py
@@ -380,12 +380,12 @@ class ConsoleShell(cmd.Cmd):
             print("Sorry, the embedded Python interpreter is disabled.", file=self.stdout)
             return
 
-        locals = {}
+        locals_ = {}
 
-        locals["stdin"] = self.stdin
-        locals["stdout"] = self.stdout
+        locals_["stdin"] = self.stdin
+        locals_["stdout"] = self.stdout
 
-        console = EmbeddedConsole(locals)
+        console = EmbeddedConsole(locals_)
 
         console.stdin = self.stdin
         console.stdout = self.stdout
@@ -409,7 +409,7 @@ class ConsoleShell(cmd.Cmd):
         on greenlets, then only the thread stack of the currently
         executing coroutine will be displayed."""
 
-        all = []
+        all_ = []
         for threadId, stack in sys._current_frames().items():
             block = []
             block.append(f"# ThreadID: {threadId}")
@@ -421,9 +421,9 @@ class ConsoleShell(cmd.Cmd):
                 block.append(f"File: '{filename}', line {int(lineno)}, in {name}")
                 if line:
                     block.append(f"  {line.strip()}")
-            all.append("\n".join(block))
+            all_.append("\n".join(block))
 
-        print("\n\n".join(all), file=self.stdout)
+        print("\n\n".join(all_), file=self.stdout)
 
 
 class ConnectionManager:

--- a/newrelic/core/adaptive_sampler.py
+++ b/newrelic/core/adaptive_sampler.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import random
-import time
 import threading
+import time
 
 
 class AdaptiveSampler:

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -152,7 +152,7 @@ class Agent:
 
         initialize_logging(settings.log_file, settings.log_level)
 
-        _logger.info(f"New Relic Python Agent ({newrelic.version})")
+        _logger.info("New Relic Python Agent (%s)", newrelic.version)
 
         check_environment()
 
@@ -619,7 +619,7 @@ class Agent:
             try:
                 application.harvest(shutdown=False, flexible=True)
             except Exception:
-                _logger.exception(f"Failed to harvest data for {application.name}.")
+                _logger.exception("Failed to harvest data for %s.", application.name)
 
         self._flexible_harvest_duration = time.time() - self._last_flexible_harvest
 
@@ -643,7 +643,7 @@ class Agent:
             try:
                 application.harvest(shutdown, flexible=False)
             except Exception:
-                _logger.exception(f"Failed to harvest data for {application.name}.")
+                _logger.exception("Failed to harvest data for %s.", application.name)
 
         self._default_harvest_duration = time.time() - self._last_default_harvest
 

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -31,11 +31,11 @@ import newrelic
 import newrelic.core.application
 import newrelic.core.config
 from newrelic.common.log_file import initialize_logging
+from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance
 from newrelic.core.thread_utilization import thread_utilization_data_source
 from newrelic.samplers.cpu_usage import cpu_usage_data_source
 from newrelic.samplers.gc_data import garbage_collector_data_source
 from newrelic.samplers.memory_usage import memory_usage_data_source
-from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -125,11 +125,11 @@ class Agent:
     _registration_callables = {}
 
     @staticmethod
-    def run_on_startup(callable):  # pylint: disable=W0622
+    def run_on_startup(callable):  # noqa: A002
         Agent._startup_callables.append(callable)
 
     @staticmethod
-    def run_on_registration(application, callable):  # pylint: disable=W0622
+    def run_on_registration(application, callable):  # noqa: A002
         callables = Agent._registration_callables.setdefault(application, [])
         callables.append(callable)
 
@@ -711,8 +711,8 @@ class Agent:
 
             _logger.debug("Activating agent instance.")
 
-            for callable in self._startup_callables:
-                callable()
+            for callable_ in self._startup_callables:
+                callable_()
 
             _logger.debug("Start Python Agent main thread.")
 

--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -28,6 +28,7 @@ from newrelic.common.utilization import (
     KubernetesUtilization,
     PCFUtilization,
 )
+from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance
 from newrelic.core.attribute import truncate
 from newrelic.core.config import fetch_config_setting, finalize_application_settings, global_settings_dump
 from newrelic.core.internal_metrics import internal_count_metric
@@ -39,7 +40,6 @@ from newrelic.network.exceptions import (
     NetworkInterfaceException,
     RetryDataForRequest,
 )
-from newrelic.core.agent_control_health import HealthStatus, agent_control_health_instance
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -25,6 +25,11 @@ from functools import partial
 
 from newrelic.common.object_names import callable_name
 from newrelic.core.adaptive_sampler import AdaptiveSampler
+from newrelic.core.agent_control_health import (
+    HealthStatus,
+    agent_control_health_instance,
+    agent_control_healthcheck_loop,
+)
 from newrelic.core.config import global_settings
 from newrelic.core.custom_event import create_custom_event
 from newrelic.core.data_collector import create_session
@@ -42,11 +47,6 @@ from newrelic.network.exceptions import (
     RetryDataForRequest,
 )
 from newrelic.samplers.data_sampler import DataSampler
-from newrelic.core.agent_control_health import (
-    HealthStatus,
-    agent_control_healthcheck_loop,
-    agent_control_health_instance,
-)
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -255,17 +255,17 @@ def _truncate_bytes(s, maxsize):
 def check_name_length(name, max_length=MAX_ATTRIBUTE_LENGTH, encoding="utf-8"):
     trunc_name = truncate(name, max_length, encoding)
     if name != trunc_name:
-        raise NameTooLongException()
+        raise NameTooLongException
 
 
 def check_name_is_string(name):
     if not isinstance(name, (str, bytes)):
-        raise NameIsNotStringException()
+        raise NameIsNotStringException
 
 
 def check_max_int(value, max_int=MAX_64_BIT_INT):
     if isinstance(value, int) and value > max_int:
-        raise IntTooLargeException()
+        raise IntTooLargeException
 
 
 def process_user_attribute(name, value, max_length=MAX_ATTRIBUTE_LENGTH, ending=None):
@@ -372,7 +372,7 @@ def sanitize(value):
         try:
             value = str(value)
         except Exception:
-            raise CastingFailureException()
+            raise CastingFailureException
         else:
             _logger.debug("Attribute value is of type: %r. Casting %r to string: %s", type(original), original, value)
 

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -653,7 +653,7 @@ def default_otlp_host(host):
     otlp_host = HOST_MAP.get(host, None)
     if not otlp_host:
         default = HOST_MAP["collector.newrelic.com"]
-        _logger.warn(f"Unable to find corresponding OTLP host using default {default}")
+        _logger.warning("Unable to find corresponding OTLP host using default %s", default)
         otlp_host = default
     return otlp_host
 
@@ -1410,7 +1410,7 @@ def error_matches_rules(rules_prefix, exc_info, status_code=None, settings=None)
             # Coerce into integer
             status_code = int(status_code)
         except:
-            _logger.error(f"Failed to coerce status code into integer. status_code: {str(status_code)}")
+            _logger.error("Failed to coerce status code into integer. status_code: %s", str(status_code))
         else:
             if status_code in status_codes_rules:
                 return True

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -37,9 +37,7 @@ from newrelic.core.attribute_filter import AttributeFilter
 try:
     import grpc
 
-    from newrelic.core.infinite_tracing_pb2 import (  # pylint: disable=W0611,C0412  # noqa: F401
-        Span,
-    )
+    from newrelic.core.infinite_tracing_pb2 import Span  # pylint: disable=W0611,C0412  # noqa: F401
 except Exception:
     grpc = None
 

--- a/newrelic/core/custom_event.py
+++ b/newrelic/core/custom_event.py
@@ -40,7 +40,7 @@ class NameInvalidCharactersException(Exception):
 def check_event_type_valid_chars(name):
     regex = EVENT_TYPE_VALID_CHARS_REGEX
     if not regex.match(name):
-        raise NameInvalidCharactersException()
+        raise NameInvalidCharactersException
 
 
 def process_event_type(name):

--- a/newrelic/core/data_collector.py
+++ b/newrelic/core/data_collector.py
@@ -19,10 +19,9 @@ import logging
 from newrelic.common.agent_http import ApplicationModeClient, DeveloperModeClient, ServerlessModeClient
 from newrelic.core.agent_protocol import AgentProtocol, OtlpProtocol, ServerlessModeProtocol
 from newrelic.core.agent_streaming import StreamingRpc
+from newrelic.core.attribute import MAX_NUM_USER_ATTRIBUTES, process_user_attribute
 from newrelic.core.config import global_settings
 from newrelic.core.otlp_utils import encode_metric_data, encode_ml_event_data
-
-from newrelic.core.attribute import process_user_attribute, MAX_NUM_USER_ATTRIBUTES
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/database_utils.py
+++ b/newrelic/core/database_utils.py
@@ -702,11 +702,10 @@ def _explain_plan(connections, sql, database, connect_params, cursor_params, sql
         else:
             cursor.execute(query, **kwargs)
 
-        columns = []
-
         if cursor.description:
-            for column in cursor.description:
-                columns.append(column[0])
+            columns = [column[0] for column in cursor.description]
+        else:
+            columns = []
 
         rows = cursor.fetchall()
 

--- a/newrelic/core/database_utils.py
+++ b/newrelic/core/database_utils.py
@@ -824,7 +824,7 @@ class SQLStatement:
             except UnicodeError as e:
                 settings = global_settings()
                 if settings.debug.log_explain_plan_queries:
-                    _logger.debug(f"An error occurred while decoding sql statement: {e.reason}")
+                    _logger.debug("An error occurred while decoding sql statement: %s", e.reason)
 
                 self._operation = ""
                 self._target = ""

--- a/newrelic/core/database_utils.py
+++ b/newrelic/core/database_utils.py
@@ -21,9 +21,8 @@ import logging
 import re
 import weakref
 
-
-from newrelic.core.internal_metrics import internal_metric
 from newrelic.core.config import global_settings
+from newrelic.core.internal_metrics import internal_metric
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/core/datastore_node.py
+++ b/newrelic/core/datastore_node.py
@@ -15,10 +15,9 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
 from newrelic.common import system_info
-from newrelic.core.node_mixin import DatastoreNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import DatastoreNodeMixin
 
 _DatastoreNode = namedtuple(
     "_DatastoreNode",

--- a/newrelic/core/environment.py
+++ b/newrelic/core/environment.py
@@ -259,6 +259,6 @@ def _get_stdlib_builtin_module_names():
     elif python_version >= (3, 10):
         stdlibs = sys.stdlib_module_names
     else:
-        _logger.warn("Unsupported Python version. Unable to determine stdlibs.")
+        _logger.warning("Unsupported Python version. Unable to determine stdlibs.")
         return builtins
     return builtins | stdlibs

--- a/newrelic/core/external_node.py
+++ b/newrelic/core/external_node.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import urllib.parse as urlparse
-
 from collections import namedtuple
 
 import newrelic.core.attribute as attribute
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _ExternalNode = namedtuple(
     "_ExternalNode",

--- a/newrelic/core/function_node.py
+++ b/newrelic/core/function_node.py
@@ -15,10 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
-
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _FunctionNode = namedtuple(
     "_FunctionNode",

--- a/newrelic/core/graphql_node.py
+++ b/newrelic/core/graphql_node.py
@@ -15,10 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
 from newrelic.core.metric import TimeMetric
 from newrelic.core.node_mixin import GenericNodeMixin
-
 
 _GraphQLOperationNode = namedtuple(
     "_GraphQLNode",

--- a/newrelic/core/internal_metrics.py
+++ b/newrelic/core/internal_metrics.py
@@ -14,9 +14,10 @@
 
 import functools
 import sys
-import types
-import time
 import threading
+import time
+import types
+
 import newrelic.common.object_wrapper
 
 _context = threading.local()

--- a/newrelic/core/loop_node.py
+++ b/newrelic/core/loop_node.py
@@ -15,9 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _LoopNode = namedtuple("_LoopNode", ["fetch_name", "start_time", "end_time", "duration", "guid"])
 

--- a/newrelic/core/memcache_node.py
+++ b/newrelic/core/memcache_node.py
@@ -15,9 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _MemcacheNode = namedtuple(
     "_MemcacheNode",

--- a/newrelic/core/message_node.py
+++ b/newrelic/core/message_node.py
@@ -15,9 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _MessageNode = namedtuple(
     "_MessageNode",

--- a/newrelic/core/otlp_utils.py
+++ b/newrelic/core/otlp_utils.py
@@ -102,7 +102,7 @@ def create_key_value(key, value):
     # those are not valid custom attribute types according to our api spec,
     # we will not bother to support them here either.
     else:
-        _logger.warning(f"Unsupported attribute value type {key}: {value}.")
+        _logger.warning("Unsupported attribute value type %s: %s.", key, value)
 
 
 def create_key_values_from_iterable(iterable):

--- a/newrelic/core/profile_sessions.py
+++ b/newrelic/core/profile_sessions.py
@@ -26,7 +26,6 @@ from newrelic.common.encoding_utils import json_encode
 from newrelic.core.config import global_settings
 from newrelic.core.trace_cache import trace_cache
 
-
 _logger = logging.getLogger(__name__)
 
 AGENT_PACKAGE_DIRECTORY = os.path.dirname(newrelic.__file__) + os.sep

--- a/newrelic/core/solr_node.py
+++ b/newrelic/core/solr_node.py
@@ -15,9 +15,8 @@
 from collections import namedtuple
 
 import newrelic.core.trace_node
-
-from newrelic.core.node_mixin import GenericNodeMixin
 from newrelic.core.metric import TimeMetric
+from newrelic.core.node_mixin import GenericNodeMixin
 
 _SolrNode = namedtuple(
     "_SolrNode",

--- a/newrelic/core/stack_trace.py
+++ b/newrelic/core/stack_trace.py
@@ -18,8 +18,8 @@ etc.
 
 """
 
-import sys
 import itertools
+import sys
 
 from newrelic.core.config import global_settings
 

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -65,7 +65,7 @@ EVENT_HARVEST_METHODS = {
 }
 
 
-def c2t(count=0, total=0.0, min=0.0, max=0.0, sum_of_squares=0.0):
+def c2t(count=0, total=0.0, min=0.0, max=0.0, sum_of_squares=0.0):  # noqa: A002
     return (count, total, total, min, max, sum_of_squares)
 
 

--- a/newrelic/core/trace_cache.py
+++ b/newrelic/core/trace_cache.py
@@ -20,7 +20,6 @@ import sys
 import threading
 import traceback
 import weakref
-
 from collections.abc import MutableMapping
 
 try:

--- a/newrelic/extras/framework_django/templatetags/newrelic_tags.py
+++ b/newrelic/extras/framework_django/templatetags/newrelic_tags.py
@@ -14,7 +14,7 @@
 
 import django.template
 
-from newrelic.hooks.framework_django import newrelic_browser_timing_header, newrelic_browser_timing_footer
+from newrelic.hooks.framework_django import newrelic_browser_timing_footer, newrelic_browser_timing_header
 
 register = django.template.Library()
 

--- a/newrelic/hooks/adapter_cheroot.py
+++ b/newrelic/hooks/adapter_cheroot.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def instrument_cheroot_wsgiserver(module):

--- a/newrelic/hooks/adapter_cherrypy.py
+++ b/newrelic/hooks/adapter_cherrypy.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def instrument_cherrypy_wsgiserver(module):

--- a/newrelic/hooks/adapter_flup.py
+++ b/newrelic/hooks/adapter_flup.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def wrap_wsgi_application_entry_point(server, application, *args, **kwargs):

--- a/newrelic/hooks/adapter_gevent.py
+++ b/newrelic/hooks/adapter_gevent.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import wrap_in_function
 from newrelic.api.wsgi_application import WSGIApplicationWrapper
+from newrelic.common.object_wrapper import wrap_in_function
 
 
 def instrument_gevent_wsgi(module):

--- a/newrelic/hooks/adapter_gunicorn.py
+++ b/newrelic/hooks/adapter_gunicorn.py
@@ -15,8 +15,8 @@
 import sys
 
 from newrelic.api.wsgi_application import WSGIApplicationWrapper
+from newrelic.common.coroutine import is_asyncio_coroutine, is_coroutine_callable
 from newrelic.common.object_wrapper import wrap_out_function
-from newrelic.common.coroutine import is_coroutine_callable, is_asyncio_coroutine
 
 
 def is_coroutine(fn):

--- a/newrelic/hooks/adapter_meinheld.py
+++ b/newrelic/hooks/adapter_meinheld.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def instrument_meinheld_server(module):

--- a/newrelic/hooks/adapter_paste.py
+++ b/newrelic/hooks/adapter_paste.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def instrument_paste_httpserver(module):

--- a/newrelic/hooks/adapter_wsgiref.py
+++ b/newrelic/hooks/adapter_wsgiref.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.wsgi_application
 import newrelic.api.in_function
+import newrelic.api.wsgi_application
 
 
 def instrument_wsgiref_simple_server(module):

--- a/newrelic/hooks/application_celery.py
+++ b/newrelic/hooks/application_celery.py
@@ -28,7 +28,7 @@ from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.message_trace import MessageTrace
 from newrelic.api.pre_function import wrap_pre_function
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_wrapper import FunctionWrapper, wrap_function_wrapper, _NRBoundFunctionWrapper
+from newrelic.common.object_wrapper import FunctionWrapper, _NRBoundFunctionWrapper, wrap_function_wrapper
 from newrelic.core.agent import shutdown_agent
 
 UNKNOWN_TASK_NAME = "<Unknown Task>"

--- a/newrelic/hooks/application_gearman.py
+++ b/newrelic/hooks/application_gearman.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 from newrelic.api.application import application_instance as default_application
-from newrelic.common.object_wrapper import wrap_function_wrapper, FunctionWrapper
 from newrelic.api.background_task import BackgroundTask
-from newrelic.api.function_trace import FunctionTrace, wrap_function_trace
-from newrelic.api.transaction import current_transaction
-from newrelic.api.time_trace import current_trace
-from newrelic.common.object_names import callable_name
 from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.function_trace import FunctionTrace, wrap_function_trace
+from newrelic.api.time_trace import current_trace
+from newrelic.api.transaction import current_transaction
+from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import FunctionWrapper, wrap_function_wrapper
 
 # Following wrappers are specifically for a gearman client.
 

--- a/newrelic/hooks/component_djangorestframework.py
+++ b/newrelic/hooks/component_djangorestframework.py
@@ -14,10 +14,10 @@
 
 import sys
 
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
-from newrelic.api.transaction import current_transaction
 from newrelic.api.function_trace import FunctionTrace
+from newrelic.api.transaction import current_transaction
 from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 
 
 def _nr_wrapper_APIView_dispatch_(wrapped, instance, args, kwargs):

--- a/newrelic/hooks/component_piston.py
+++ b/newrelic/hooks/component_piston.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 
-import newrelic.api.transaction
 import newrelic.api.function_trace
+import newrelic.api.in_function
+import newrelic.api.transaction
 import newrelic.common.object_wrapper
 from newrelic.common.object_names import callable_name
-import newrelic.api.in_function
 
 
 class MethodWrapper:

--- a/newrelic/hooks/component_tastypie.py
+++ b/newrelic/hooks/component_tastypie.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from newrelic.api.function_trace import FunctionTraceWrapper
-from newrelic.common.object_names import callable_name
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
-from newrelic.api.transaction import current_transaction
 from newrelic.api.time_trace import notice_error
+from newrelic.api.transaction import current_transaction
+from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 
 
 def _nr_wrap_handle_exception(wrapped, instance, args, kwargs):

--- a/newrelic/hooks/coroutines_asyncio.py
+++ b/newrelic/hooks/coroutines_asyncio.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import wrap_out_function, wrap_function_wrapper
+from newrelic.common.object_wrapper import wrap_function_wrapper, wrap_out_function
 from newrelic.core.trace_cache import trace_cache
 
 

--- a/newrelic/hooks/database_cx_oracle.py
+++ b/newrelic/hooks/database_cx_oracle.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 from newrelic.api.database_trace import register_database_client
-from newrelic.common.object_wrapper import wrap_object, ObjectProxy
-
+from newrelic.common.object_wrapper import ObjectProxy, wrap_object
 from newrelic.hooks.database_dbapi2 import ConnectionFactory
 
 

--- a/newrelic/hooks/database_ibm_db_dbi.py
+++ b/newrelic/hooks/database_ibm_db_dbi.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import wrap_object
 from newrelic.api.database_trace import register_database_client
-
+from newrelic.common.object_wrapper import wrap_object
 from newrelic.hooks.database_dbapi2 import ConnectionFactory
 
 

--- a/newrelic/hooks/database_mysql.py
+++ b/newrelic/hooks/database_mysql.py
@@ -14,7 +14,6 @@
 
 from newrelic.api.database_trace import register_database_client
 from newrelic.common.object_wrapper import wrap_object
-
 from newrelic.hooks.database_dbapi2 import ConnectionFactory
 
 

--- a/newrelic/hooks/database_postgresql.py
+++ b/newrelic/hooks/database_postgresql.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import wrap_object
 from newrelic.api.database_trace import register_database_client
-
+from newrelic.common.object_wrapper import wrap_object
 from newrelic.hooks.database_psycopg2 import instance_info
 
 

--- a/newrelic/hooks/database_psycopg.py
+++ b/newrelic/hooks/database_psycopg.py
@@ -14,8 +14,7 @@
 
 import inspect
 import os
-
-from urllib.parse import unquote, parse_qsl
+from urllib.parse import parse_qsl, unquote
 
 from newrelic.api.database_trace import DatabaseTrace, register_database_client
 from newrelic.api.function_trace import FunctionTrace
@@ -28,7 +27,6 @@ from newrelic.hooks.database_dbapi2 import CursorWrapper as DBAPI2CursorWrapper
 from newrelic.hooks.database_dbapi2_async import AsyncConnectionFactory as DBAPI2AsyncConnectionFactory
 from newrelic.hooks.database_dbapi2_async import AsyncConnectionWrapper as DBAPI2AsyncConnectionWrapper
 from newrelic.hooks.database_dbapi2_async import AsyncCursorWrapper as DBAPI2AsyncCursorWrapper
-
 from newrelic.packages.urllib3 import util as ul3_util
 
 # These functions return True if a non-default connection or cursor class is

--- a/newrelic/hooks/database_psycopg2.py
+++ b/newrelic/hooks/database_psycopg2.py
@@ -14,8 +14,7 @@
 
 import inspect
 import os
-
-from urllib.parse import unquote, parse_qsl
+from urllib.parse import parse_qsl, unquote
 
 from newrelic.api.database_trace import DatabaseTrace, register_database_client
 from newrelic.api.function_trace import FunctionTrace
@@ -26,7 +25,6 @@ from newrelic.hooks.database_dbapi2 import DEFAULT
 from newrelic.hooks.database_dbapi2 import ConnectionFactory as DBAPI2ConnectionFactory
 from newrelic.hooks.database_dbapi2 import ConnectionWrapper as DBAPI2ConnectionWrapper
 from newrelic.hooks.database_dbapi2 import CursorWrapper as DBAPI2CursorWrapper
-
 from newrelic.packages.urllib3 import util as ul3_util
 
 

--- a/newrelic/hooks/database_psycopg2cffi.py
+++ b/newrelic/hooks/database_psycopg2cffi.py
@@ -14,8 +14,7 @@
 
 from newrelic.api.database_trace import register_database_client
 from newrelic.common.object_wrapper import wrap_object
-
-from newrelic.hooks.database_psycopg2 import instance_info, instrument_psycopg2_extensions, ConnectionFactory
+from newrelic.hooks.database_psycopg2 import ConnectionFactory, instance_info, instrument_psycopg2_extensions
 
 
 def instrument_psycopg2cffi(module):

--- a/newrelic/hooks/database_psycopg2ct.py
+++ b/newrelic/hooks/database_psycopg2ct.py
@@ -14,7 +14,6 @@
 
 from newrelic.api.database_trace import register_database_client
 from newrelic.common.object_wrapper import wrap_object
-
 from newrelic.hooks.database_dbapi2 import ConnectionFactory
 from newrelic.hooks.database_psycopg2 import instance_info, instrument_psycopg2_extensions
 

--- a/newrelic/hooks/database_pymssql.py
+++ b/newrelic/hooks/database_pymssql.py
@@ -16,11 +16,8 @@ from newrelic.api.database_trace import register_database_client
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import wrap_object
-
-from newrelic.hooks.database_dbapi2 import (
-    ConnectionWrapper as DBAPI2ConnectionWrapper,
-    ConnectionFactory as DBAPI2ConnectionFactory,
-)
+from newrelic.hooks.database_dbapi2 import ConnectionFactory as DBAPI2ConnectionFactory
+from newrelic.hooks.database_dbapi2 import ConnectionWrapper as DBAPI2ConnectionWrapper
 
 
 class ConnectionWrapper(DBAPI2ConnectionWrapper):

--- a/newrelic/hooks/database_pymysql.py
+++ b/newrelic/hooks/database_pymysql.py
@@ -14,13 +14,9 @@
 
 from newrelic.api.database_trace import register_database_client
 from newrelic.common.object_wrapper import wrap_object
-
-from newrelic.hooks.database_mysqldb import (
-    ConnectionFactory as MySqlDBConnectionFactory,
-    ConnectionWrapper as MySqlDBConnectionWrapper,
-)
-
 from newrelic.hooks.database_dbapi2 import CursorWrapper as DBAPI2CursorWrapper
+from newrelic.hooks.database_mysqldb import ConnectionFactory as MySqlDBConnectionFactory
+from newrelic.hooks.database_mysqldb import ConnectionWrapper as MySqlDBConnectionWrapper
 
 
 class CursorWrapper(DBAPI2CursorWrapper):

--- a/newrelic/hooks/database_pyodbc.py
+++ b/newrelic/hooks/database_pyodbc.py
@@ -14,7 +14,6 @@
 
 from newrelic.api.database_trace import register_database_client
 from newrelic.common.object_wrapper import wrap_object
-
 from newrelic.hooks.database_dbapi2 import ConnectionFactory
 
 

--- a/newrelic/hooks/database_sqlite.py
+++ b/newrelic/hooks/database_sqlite.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.database_trace import register_database_client, DatabaseTrace
+from newrelic.api.database_trace import DatabaseTrace, register_database_client
 from newrelic.api.function_trace import FunctionTrace, FunctionTraceWrapper
 from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import wrap_object
-
-from newrelic.hooks.database_dbapi2 import (
-    CursorWrapper as DBAPI2CursorWrapper,
-    ConnectionWrapper as DBAPI2ConnectionWrapper,
-    ConnectionFactory as DBAPI2ConnectionFactory,
-)
+from newrelic.hooks.database_dbapi2 import ConnectionFactory as DBAPI2ConnectionFactory
+from newrelic.hooks.database_dbapi2 import ConnectionWrapper as DBAPI2ConnectionWrapper
+from newrelic.hooks.database_dbapi2 import CursorWrapper as DBAPI2CursorWrapper
 
 DEFAULT = object()
 

--- a/newrelic/hooks/datastore_firestore.py
+++ b/newrelic/hooks/datastore_firestore.py
@@ -14,7 +14,7 @@
 
 from newrelic.api.datastore_trace import wrap_datastore_trace
 from newrelic.api.function_trace import wrap_function_trace
-from newrelic.common.async_wrapper import generator_wrapper, async_generator_wrapper
+from newrelic.common.async_wrapper import async_generator_wrapper, generator_wrapper
 
 
 def _conn_str_to_host(getter):

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -600,7 +600,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
                 except json.decoder.JSONDecodeError:
                     pass
                 except Exception:
-                    _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+                    _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
                 error_attributes = bedrock_error_attributes(exc, bedrock_attrs)
                 notice_error_attributes = {
@@ -624,7 +624,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
                 else:
                     handle_chat_completion_event(transaction, error_attributes)
             except Exception:
-                _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+                _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
             raise
 
@@ -653,7 +653,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
         except json.decoder.JSONDecodeError:
             pass
         except Exception:
-            _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(REQUEST_EXTACTOR_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
         try:
             if response_streaming:
@@ -675,7 +675,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
             try:
                 response_extractor(response_body, bedrock_attrs)
             except Exception:
-                _logger.warning(RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+                _logger.warning(RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
             if operation == "embedding":
                 handle_embedding_event(transaction, bedrock_attrs)
@@ -683,7 +683,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
                 handle_chat_completion_event(transaction, bedrock_attrs)
 
         except Exception:
-            _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
         return response
 
@@ -738,7 +738,7 @@ def record_stream_chunk(self, return_val, transaction):
             if _type == "content_block_stop":
                 record_events_on_stop_iteration(self, transaction)
         except Exception:
-            _logger.warning(RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(RESPONSE_EXTRACTOR_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def record_events_on_stop_iteration(self, transaction):
@@ -754,7 +754,7 @@ def record_events_on_stop_iteration(self, transaction):
             bedrock_attrs["duration"] = self._nr_ft.duration * 1000
             handle_chat_completion_event(transaction, bedrock_attrs)
         except Exception:
-            _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(RESPONSE_PROCESSING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
         # Clear cached data as this can be very large.
         self._nr_bedrock_attrs.clear()
@@ -788,7 +788,7 @@ def record_error(self, transaction, exc):
             # Clear cached data as this can be very large.
             error_attributes.clear()
         except Exception:
-            _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def handle_embedding_event(transaction, bedrock_attrs):

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -804,7 +804,7 @@ def handle_embedding_event(transaction, bedrock_attrs):
     trace_id = bedrock_attrs.get("trace_id", None)
     request_id = bedrock_attrs.get("request_id", None)
     model = bedrock_attrs.get("model", None)
-    input = bedrock_attrs.get("input")
+    input_ = bedrock_attrs.get("input")
 
     embedding_dict = {
         "vendor": "bedrock",
@@ -813,7 +813,7 @@ def handle_embedding_event(transaction, bedrock_attrs):
         "span_id": span_id,
         "trace_id": trace_id,
         "token_count": (
-            settings.ai_monitoring.llm_token_count_callback(model, input)
+            settings.ai_monitoring.llm_token_count_callback(model, input_)
             if settings.ai_monitoring.llm_token_count_callback
             else None
         ),
@@ -826,7 +826,7 @@ def handle_embedding_event(transaction, bedrock_attrs):
     embedding_dict.update(llm_metadata_dict)
 
     if settings.ai_monitoring.record_content.enabled:
-        embedding_dict["input"] = input
+        embedding_dict["input"] = input_
 
     embedding_dict = {k: v for k, v in embedding_dict.items() if v is not None}
     transaction.record_custom_event("LlmEmbedding", embedding_dict)

--- a/newrelic/hooks/external_feedparser.py
+++ b/newrelic/hooks/external_feedparser.py
@@ -15,11 +15,10 @@
 import sys
 import types
 
-
-import newrelic.api.transaction
-import newrelic.api.object_wrapper
-import newrelic.common.object_wrapper
 import newrelic.api.external_trace
+import newrelic.api.object_wrapper
+import newrelic.api.transaction
+import newrelic.common.object_wrapper
 
 
 class capture_external_trace:

--- a/newrelic/hooks/external_httplib.py
+++ b/newrelic/hooks/external_httplib.py
@@ -14,7 +14,6 @@
 
 import functools
 
-
 from newrelic.api.external_trace import ExternalTrace
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import wrap_function_wrapper

--- a/newrelic/hooks/external_s3transfer.py
+++ b/newrelic/hooks/external_s3transfer.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from newrelic.api.time_trace import current_trace
-from newrelic.common.signature import bind_args
 from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.common.signature import bind_args
 from newrelic.core.context import context_wrapper
 
 

--- a/newrelic/hooks/framework_django.py
+++ b/newrelic/hooks/framework_django.py
@@ -38,7 +38,6 @@ from newrelic.common.object_wrapper import (
 )
 from newrelic.config import extra_settings
 from newrelic.core.config import global_settings
-
 from newrelic.hooks.framework_django_py3 import (
     _nr_wrap_converted_middleware_async_,
     _nr_wrapper_BaseHandler_get_response_async_,

--- a/newrelic/hooks/framework_django_py3.py
+++ b/newrelic/hooks/framework_django_py3.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from newrelic.api.function_trace import FunctionTraceWrapper
 from newrelic.api.time_trace import notice_error
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import function_wrapper
-from newrelic.api.function_trace import FunctionTraceWrapper
 
 
 def _bind_get_response(request, *args, **kwargs):

--- a/newrelic/hooks/framework_falcon.py
+++ b/newrelic/hooks/framework_falcon.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import sys
-from newrelic.common.object_names import callable_name
-from newrelic.common.object_wrapper import wrap_function_wrapper, function_wrapper
-from newrelic.api.transaction import current_transaction
-from newrelic.api.time_trace import notice_error
-from newrelic.api.wsgi_application import wrap_wsgi_application
+
 from newrelic.api.function_trace import function_trace
+from newrelic.api.time_trace import notice_error
+from newrelic.api.transaction import current_transaction
+from newrelic.api.wsgi_application import wrap_wsgi_application
+from newrelic.common.object_names import callable_name
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 
 
 def _bind_handle_exception_v1(ex, req, resp, *args, **kwargs):

--- a/newrelic/hooks/framework_tornado.py
+++ b/newrelic/hooks/framework_tornado.py
@@ -13,21 +13,21 @@
 # limitations under the License.
 
 import functools
-import textwrap
 import inspect
 import sys
+import textwrap
 import time
-from newrelic.api.function_trace import function_trace
-from newrelic.api.transaction import current_transaction
-from newrelic.api.external_trace import ExternalTrace
-from newrelic.api.time_trace import notice_error, current_trace
-from newrelic.api.web_transaction import WebTransaction
+
 from newrelic.api.application import application_instance
-from newrelic.core.trace_cache import trace_cache
-from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.function_trace import function_trace
+from newrelic.api.time_trace import current_trace, notice_error
+from newrelic.api.transaction import current_transaction
+from newrelic.api.web_transaction import WebTransaction
 from newrelic.common.async_proxy import async_proxy
 from newrelic.common.object_names import callable_name
-
+from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
+from newrelic.core.trace_cache import trace_cache
 
 _VERSION = None
 _instrumented = set()

--- a/newrelic/hooks/framework_webpy.py
+++ b/newrelic/hooks/framework_webpy.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 
-import newrelic.api.transaction
 import newrelic.api.function_trace
 import newrelic.api.in_function
 import newrelic.api.out_function
 import newrelic.api.pre_function
-from newrelic.common.object_names import callable_name
-from newrelic.api.wsgi_application import WSGIApplicationWrapper
+import newrelic.api.transaction
 from newrelic.api.time_trace import notice_error
+from newrelic.api.wsgi_application import WSGIApplicationWrapper
+from newrelic.common.object_names import callable_name
 
 
 def transaction_name_delegate(*args, **kwargs):

--- a/newrelic/hooks/logger_logging.py
+++ b/newrelic/hooks/logger_logging.py
@@ -20,7 +20,6 @@ from newrelic.api.transaction import current_transaction, record_log_event
 from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 from newrelic.core.config import global_settings
 
-
 IGNORED_LOG_RECORD_KEYS = set(["message", "msg"])
 
 

--- a/newrelic/hooks/logger_loguru.py
+++ b/newrelic/hooks/logger_loguru.py
@@ -92,7 +92,7 @@ def wrap_log(wrapped, instance, args, kwargs):
             options[1] += 2
 
     except Exception as e:
-        _logger.debug(f"Exception in loguru handling: {str(e)}")
+        _logger.debug("Exception in loguru handling: %s", e)
         return wrapped(*args, **kwargs)
     else:
         return wrapped(**bound_args)

--- a/newrelic/hooks/logger_loguru.py
+++ b/newrelic/hooks/logger_loguru.py
@@ -138,7 +138,7 @@ def patch_loguru_logger(logger):
             logger.add(_nr_log_forwarder, format="{message}")
             logger._core._nr_instrumented = True
     elif not hasattr(logger, "_nr_instrumented"):  # pragma: no cover
-        for _, handler in logger._handlers.items():
+        for handler in logger._handlers.values():
             if handler._writer is _nr_log_forwarder:
                 logger._nr_instrumented = True
                 return

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -186,7 +186,7 @@ class NewRelicSerializerWrapper(ObjectProxy):
         self._nr_serializer_name = serializer_name
         self._nr_group_prefix = group_prefix
 
-    def serialize(self, topic, object):
+    def serialize(self, topic, object):  # noqa: A002
         wrapped = self.__wrapped__.serialize  # pylint: disable=W0622
         args = (topic, object)
         kwargs = {}

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -452,7 +452,7 @@ def _record_tool_success(
     try:
         result = str(response)
     except Exception:
-        _logger.debug(f"Failed to convert tool response into a string.\n{traceback.format_exception(*sys.exc_info())}")
+        _logger.debug("Failed to convert tool response into a string.\n%s", traceback.format_exception(*sys.exc_info()))
     if settings.ai_monitoring.record_content.enabled:
         full_tool_event_dict.update({"input": tool_input, "output": result})
     full_tool_event_dict.update(_get_llm_metadata(transaction))
@@ -707,7 +707,7 @@ def _create_successful_chain_run_events(
             output_message_list = [str(response)]
         except Exception as e:
             _logger.warning(
-                f"Unable to capture response inside langchain chain instrumentation. No response message event will be captured. Report this issue to New Relic Support.\n{traceback.format_exception(*sys.exc_info())}"
+                "Unable to capture response inside langchain chain instrumentation. No response message event will be captured. Report this issue to New Relic Support.\n%s", traceback.format_exception(*sys.exc_info())
             )
 
     # Make sure the builtin attributes take precedence over metadata attributes.

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -707,7 +707,8 @@ def _create_successful_chain_run_events(
             output_message_list = [str(response)]
         except Exception as e:
             _logger.warning(
-                "Unable to capture response inside langchain chain instrumentation. No response message event will be captured. Report this issue to New Relic Support.\n%s", traceback.format_exception(*sys.exc_info())
+                "Unable to capture response inside langchain chain instrumentation. No response message event will be captured. Report this issue to New Relic Support.\n%s",
+                traceback.format_exception(*sys.exc_info()),
             )
 
     # Make sure the builtin attributes take precedence over metadata attributes.

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -259,7 +259,7 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
     trace_id = linking_metadata.get("trace.id")
     try:
         response_headers = getattr(response, "_nr_response_headers", {})
-        input = kwargs.get("input")
+        input_ = kwargs.get("input")
 
         attribute_response = response
         # In v1, response objects are pydantic models so this function call converts the
@@ -287,7 +287,7 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
             "span_id": span_id,
             "trace_id": trace_id,
             "token_count": (
-                settings.ai_monitoring.llm_token_count_callback(response_model, input)
+                settings.ai_monitoring.llm_token_count_callback(response_model, input_)
                 if settings.ai_monitoring.llm_token_count_callback
                 else None
             ),
@@ -319,7 +319,7 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
             "ingest_source": "Python",
         }
         if settings.ai_monitoring.record_content.enabled:
-            full_embedding_response_dict["input"] = input
+            full_embedding_response_dict["input"] = input_
         full_embedding_response_dict.update(_get_llm_attributes(transaction))
         transaction.record_custom_event("LlmEmbedding", full_embedding_response_dict)
     except Exception:
@@ -331,7 +331,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
     span_id = linking_metadata.get("span.id")
     trace_id = linking_metadata.get("trace.id")
     model = kwargs.get("model") or kwargs.get("engine")
-    input = kwargs.get("input")
+    input_ = kwargs.get("input")
 
     exc_organization = None
     notice_error_attributes = {}
@@ -376,7 +376,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
             "span_id": span_id,
             "trace_id": trace_id,
             "token_count": (
-                settings.ai_monitoring.llm_token_count_callback(model, input)
+                settings.ai_monitoring.llm_token_count_callback(model, input_)
                 if settings.ai_monitoring.llm_token_count_callback
                 else None
             ),
@@ -388,7 +388,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
             "error": True,
         }
         if settings.ai_monitoring.record_content.enabled:
-            error_embedding_dict["input"] = input
+            error_embedding_dict["input"] = input_
         error_embedding_dict.update(_get_llm_attributes(transaction))
         transaction.record_custom_event("LlmEmbedding", error_embedding_dict)
     except Exception:

--- a/newrelic/hooks/mlmodel_openai.py
+++ b/newrelic/hooks/mlmodel_openai.py
@@ -323,7 +323,7 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
         full_embedding_response_dict.update(_get_llm_attributes(transaction))
         transaction.record_custom_event("LlmEmbedding", full_embedding_response_dict)
     except Exception:
-        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs, ft, exc):
@@ -361,7 +361,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
                 "embedding_id": embedding_id,
             }
     except Exception:
-        _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
     message = notice_error_attributes.pop("error.message", None)
     if message:
@@ -392,7 +392,7 @@ def _record_embedding_error(transaction, embedding_id, linking_metadata, kwargs,
         error_embedding_dict.update(_get_llm_attributes(transaction))
         transaction.record_custom_event("LlmEmbedding", error_embedding_dict)
     except Exception:
-        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 async def wrap_chat_completion_async(wrapped, instance, args, kwargs):
@@ -454,7 +454,7 @@ def _handle_completion_success(transaction, linking_metadata, completion_id, kwa
             return_val._nr_openai_attrs["model"] = kwargs.get("model") or kwargs.get("engine")
             return
         except Exception:
-            _logger.warning(STREAM_PARSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(STREAM_PARSING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
     try:
         # If response is not a stream generator, record the event data.
@@ -475,7 +475,7 @@ def _handle_completion_success(transaction, linking_metadata, completion_id, kwa
 
         _record_completion_success(transaction, linking_metadata, completion_id, kwargs, ft, response_headers, response)
     except Exception:
-        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def _record_completion_success(transaction, linking_metadata, completion_id, kwargs, ft, response_headers, response):
@@ -571,7 +571,7 @@ def _record_completion_success(transaction, linking_metadata, completion_id, kwa
             output_message_list,
         )
     except Exception:
-        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def _record_completion_error(transaction, linking_metadata, completion_id, kwargs, ft, exc):
@@ -605,7 +605,7 @@ def _record_completion_error(transaction, linking_metadata, completion_id, kwarg
                 "completion_id": completion_id,
             }
     except Exception:
-        _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
     # Override the default message if it is not empty.
     message = notice_error_attributes.pop("error.message", None)
     if message:
@@ -657,7 +657,7 @@ def _record_completion_error(transaction, linking_metadata, completion_id, kwarg
             output_message_list,
         )
     except Exception:
-        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+        _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def wrap_convert_to_openai_object(wrapped, instance, args, kwargs):
@@ -767,7 +767,7 @@ def _record_stream_chunk(self, return_val):
                     self._nr_openai_attrs["role"] = self._nr_openai_attrs.get("role") or delta.get("role")
                 self._nr_openai_attrs["finish_reason"] = choices[0].get("finish_reason")
         except Exception:
-            _logger.warning(STREAM_PARSING_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(STREAM_PARSING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
 
 def _record_events_on_stop_iteration(self, transaction):
@@ -787,7 +787,7 @@ def _record_events_on_stop_iteration(self, transaction):
                 transaction, linking_metadata, completion_id, openai_attrs, self._nr_ft, response_headers, None
             )
         except Exception:
-            _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE % traceback.format_exception(*sys.exc_info()))
+            _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
         finally:
             # Clear cached data as this can be very large.
             # Note this is also important for not reporting the events twice. In openai v1

--- a/newrelic/hooks/template_genshi.py
+++ b/newrelic/hooks/template_genshi.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import newrelic.api.function_trace
 import newrelic.api.transaction
 import newrelic.common.object_wrapper
-import newrelic.api.function_trace
 
 
 class stream_wrapper:

--- a/newrelic/samplers/cpu_usage.py
+++ b/newrelic/samplers/cpu_usage.py
@@ -19,9 +19,8 @@ usage.
 
 import os
 
-from newrelic.common.system_info import logical_processor_count
 from newrelic.common.stopwatch import start_timer
-
+from newrelic.common.system_info import logical_processor_count
 from newrelic.samplers.decorators import data_source_factory
 
 

--- a/newrelic/samplers/memory_usage.py
+++ b/newrelic/samplers/memory_usage.py
@@ -19,8 +19,8 @@ memory usage.
 
 import os
 
-from newrelic.core.config import global_settings
 from newrelic.common.system_info import physical_memory_used, total_physical_memory
+from newrelic.core.config import global_settings
 from newrelic.samplers.decorators import data_source_generator
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ select = [
     "EXE",  # flake8-executable
     # "FA",  # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat
-    # "ICN",  # flake8-import-conventions
+    "ICN",  # flake8-import-conventions
     "LOG",  # flake8-logging
     # "G",  # flake8-logging-format
     # "INP",  # flake8-no-pep420

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ select = [
     "ISC",  # flake8-implicit-str-concat
     "ICN",  # flake8-import-conventions
     "LOG",  # flake8-logging
-    # "G",  # flake8-logging-format
+    "G",  # flake8-logging-format
     # "INP",  # flake8-no-pep420
     "PYI",  # flake8-pyi
     # "PT",  # flake8-pytest-style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ select = [
     "LOG",  # flake8-logging
     # "G",  # flake8-logging-format
     # "INP",  # flake8-no-pep420
-    # "PYI",  # flake8-pyi
+    "PYI",  # flake8-pyi
     # "PT",  # flake8-pytest-style
     "Q",  # flake8-quotes
     # "RSE",  # flake8-raise
@@ -102,6 +102,7 @@ ignore = [
     "D203",  # incorrect-blank-line-before-class
     "D213",  # multi-line-summary-second-line
     "ARG001",  # unused-argument
+    "PYI024",  # collections-named-tuple (not currently using type annotations)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ select = [
     # "EM",  # flake8-errmsg
     "EXE",  # flake8-executable
     # "FA",  # flake8-future-annotations
-    # "ISC",  # flake8-implicit-str-concat
+    "ISC",  # flake8-implicit-str-concat
     # "ICN",  # flake8-import-conventions
     "LOG",  # flake8-logging
     # "G",  # flake8-logging-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,43 +18,45 @@ select = [
     # Enabled linters and rules
     # "F",  # Pyflakes
     # "E",  # pycodestyle
-    # "W",  # pycodestyle
+    "W",  # pycodestyle
     # "I",  # isort
     # "N",  # pep8-naming
     # "UP",  # pyupgrade
-    # "YTT",  # flake8-2020
+    "YTT",  # flake8-2020
     # "ASYNC",  # flake8-async
     # "S",  # flake8-bandit
     # "BLE",  # flake8-blind-except
     # "FBT",  # flake8-boolean-trap
     # "B",  # flake8-bugbear
     # "A",  # flake8-builtins
-    # "COM",  # flake8-commas
+    "COM",  # flake8-commas
     # "C4",  # flake8-comprehensions
-    # "T10",  # flake8-debugger
+    "DTZ",  # flake8-datetimez
+    "T10",  # flake8-debugger
     # "EM",  # flake8-errmsg
+    "EXE",  # flake8-executable
     # "FA",  # flake8-future-annotations
     # "ISC",  # flake8-implicit-str-concat
     # "ICN",  # flake8-import-conventions
-    # "LOG",  # flake8-logging
+    "LOG",  # flake8-logging
     # "G",  # flake8-logging-format
     # "INP",  # flake8-no-pep420
     # "PYI",  # flake8-pyi
     # "PT",  # flake8-pytest-style
-    # "Q",  # flake8-quotes
+    "Q",  # flake8-quotes
     # "RSE",  # flake8-raise
     # "RET",  # flake8-return
     # "SLF",  # flake8-self
-    # "SLOT",  # flake8-slots
+    "SLOT",  # flake8-slots
     # "SIM",  # flake8-simplify
-    # "TID",  # flake8-tidy-imports
-    # "INT",  # flake8-gettext
+    "TID",  # flake8-tidy-imports
+    "INT",  # flake8-gettext
     # "ARG",  # flake8-unused-arguments
     # "PTH",  # flake8-use-pathlib
     # "PGH",  # pygrep-hooks
     # "PL",  # Pylint
     # "TRY",  # tryceratops
-    # "FLY",  # flynt
+    "FLY",  # flynt
     # "PERF",  # Perflint
     # "FURB",  # refurb
     # "RUF",  # Ruff-specific rules
@@ -64,10 +66,7 @@ select = [
 # "ANN",  # flake8-annotations
 # "D",  # pydocstyle
 # "C90",  # mccabe
-# "CPY",  # flake8-copyright
-# "DTZ",  # flake8-datetimez
 # "DJ",  # flake8-django
-# "EXE",  # flake8-executable
 # "PIE",  # flake8-pie
 # "T20",  # flake8-print
 # "TC",  # flake8-type-checking
@@ -78,6 +77,9 @@ select = [
 # "NPY",  # NumPy-specific rules
 # "FAST",  # FastAPI
 # "AIR",  # Airflow
+
+# Preview linters (disabled)
+# "CPY",  # flake8-copyright
 # "DOC",  # pydoclint
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,17 @@ ignore = [
     # Additional disabled rules
     "D203",  # incorrect-blank-line-before-class
     "D213",  # multi-line-summary-second-line
+    "ARG001",  # unused-argument
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"conftest.py" = ["F401"]
+"tests/*" = [
+    # Disabled rules in tests
+    "F401",  # unused-import
+    "F811",  # redefined-while-unused (pytest fixtures trigger this)
+    "PLR2004",  # magic-value-comparison (comparing to constant values)
+    "S101",  # assert (acceptable in tests)
+]
 
 # Alternate linters and formatters
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ select = [
     "PYI",  # flake8-pyi
     # "PT",  # flake8-pytest-style
     "Q",  # flake8-quotes
-    # "RSE",  # flake8-raise
+    "RSE",  # flake8-raise
     # "RET",  # flake8-return
     # "SLF",  # flake8-self
     "SLOT",  # flake8-slots

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ select = [
     # "N",  # pep8-naming
     # "UP",  # pyupgrade
     "YTT",  # flake8-2020
-    # "ASYNC",  # flake8-async
+    "ASYNC",  # flake8-async
     # "S",  # flake8-bandit
     # "BLE",  # flake8-blind-except
     # "FBT",  # flake8-boolean-trap
@@ -109,6 +109,7 @@ ignore = [
     "F811",  # redefined-while-unused (pytest fixtures trigger this)
     "PLR2004",  # magic-value-comparison (comparing to constant values)
     "S101",  # assert (acceptable in tests)
+    "ASYNC251",  # blocking-sleep-in-async-function (acceptable in tests)
 ]
 
 # Alternate linters and formatters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,53 +16,53 @@ skip-magic-trailing-comma = true
 isort.split-on-trailing-comma=false
 select = [
     # Enabled linters and rules
-    "F",  # Pyflakes
-    "E",  # pycodestyle
-    "W",  # pycodestyle
-    "I",  # isort
-    "N",  # pep8-naming
-    "D",  # pydocstyle
-    "UP",  # pyupgrade
-    "YTT",  # flake8-2020
-    "ANN",  # flake8-annotations
-    "ASYNC",  # flake8-async
-    "S",  # flake8-bandit
-    "BLE",  # flake8-blind-except
-    "FBT",  # flake8-boolean-trap
-    "B",  # flake8-bugbear
-    "A",  # flake8-builtins
-    "COM",  # flake8-commas
-    "C4",  # flake8-comprehensions
-    "T10",  # flake8-debugger
-    "EM",  # flake8-errmsg
-    "FA",  # flake8-future-annotations
-    "ISC",  # flake8-implicit-str-concat
-    "ICN",  # flake8-import-conventions
-    "LOG",  # flake8-logging
-    "G",  # flake8-logging-format
-    "INP",  # flake8-no-pep420
-    "PYI",  # flake8-pyi
-    "PT",  # flake8-pytest-style
-    "Q",  # flake8-quotes
-    "RSE",  # flake8-raise
-    "RET",  # flake8-return
-    "SLF",  # flake8-self
-    "SLOT",  # flake8-slots
-    "SIM",  # flake8-simplify
-    "TID",  # flake8-tidy-imports
-    "INT",  # flake8-gettext
-    "ARG",  # flake8-unused-arguments
-    "PTH",  # flake8-use-pathlib
-    "PGH",  # pygrep-hooks
-    "PL",  # Pylint
-    "TRY",  # tryceratops
-    "FLY",  # flynt
-    "PERF",  # Perflint
-    "FURB",  # refurb
-    "RUF",  # Ruff-specific rules
+    # "F",  # Pyflakes
+    # "E",  # pycodestyle
+    # "W",  # pycodestyle
+    # "I",  # isort
+    # "N",  # pep8-naming
+    # "UP",  # pyupgrade
+    # "YTT",  # flake8-2020
+    # "ASYNC",  # flake8-async
+    # "S",  # flake8-bandit
+    # "BLE",  # flake8-blind-except
+    # "FBT",  # flake8-boolean-trap
+    # "B",  # flake8-bugbear
+    # "A",  # flake8-builtins
+    # "COM",  # flake8-commas
+    # "C4",  # flake8-comprehensions
+    # "T10",  # flake8-debugger
+    # "EM",  # flake8-errmsg
+    # "FA",  # flake8-future-annotations
+    # "ISC",  # flake8-implicit-str-concat
+    # "ICN",  # flake8-import-conventions
+    # "LOG",  # flake8-logging
+    # "G",  # flake8-logging-format
+    # "INP",  # flake8-no-pep420
+    # "PYI",  # flake8-pyi
+    # "PT",  # flake8-pytest-style
+    # "Q",  # flake8-quotes
+    # "RSE",  # flake8-raise
+    # "RET",  # flake8-return
+    # "SLF",  # flake8-self
+    # "SLOT",  # flake8-slots
+    # "SIM",  # flake8-simplify
+    # "TID",  # flake8-tidy-imports
+    # "INT",  # flake8-gettext
+    # "ARG",  # flake8-unused-arguments
+    # "PTH",  # flake8-use-pathlib
+    # "PGH",  # pygrep-hooks
+    # "PL",  # Pylint
+    # "TRY",  # tryceratops
+    # "FLY",  # flynt
+    # "PERF",  # Perflint
+    # "FURB",  # refurb
+    # "RUF",  # Ruff-specific rules
 ]
 
 # Disabled Linters
+# "ANN",  # flake8-annotations
+# "D",  # pydocstyle
 # "C90",  # mccabe
 # "CPY",  # flake8-copyright
 # "DTZ",  # flake8-datetimez

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ select = [
     "T10",  # flake8-debugger
     # "EM",  # flake8-errmsg
     "EXE",  # flake8-executable
-    # "FA",  # flake8-future-annotations
+    "FA",  # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat
     "ICN",  # flake8-import-conventions
     "LOG",  # flake8-logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ skip-magic-trailing-comma = true
 
 [tool.ruff.lint]
 isort.split-on-trailing-comma=false
+pep8-naming.extend-ignore-names = ["X", "y"]
+
 select = [
     # Enabled linters and rules
     # "F",  # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ select = [
     # "BLE",  # flake8-blind-except
     # "FBT",  # flake8-boolean-trap
     # "B",  # flake8-bugbear
-    # "A",  # flake8-builtins
+    "A",  # flake8-builtins
     "COM",  # flake8-commas
     # "C4",  # flake8-comprehensions
     "DTZ",  # flake8-datetimez

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ select = [
     # "TRY",  # tryceratops
     "FLY",  # flynt
     # "PERF",  # Perflint
-    # "FURB",  # refurb
+    "FURB",  # refurb
     # "RUF",  # Ruff-specific rules
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,14 @@ select = [
 # "DOC",  # pydoclint
 
 ignore = [
+    # Temporarily disabled rules
+    "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
+    "PERF203",  # try-except-in-loop (most of these are unavoidable)
+    # Permanently disabled rules
+    "D203",  # incorrect-blank-line-before-class
+    "D213",  # multi-line-summary-second-line
+    "ARG001",  # unused-argument
+    "PYI024",  # collections-named-tuple (not currently using type annotations)
     # Ruff recommended linter rules to disable when using formatter
     "W191",  # tab-indentation
     "E111",  # indentation-with-invalid-multiple
@@ -98,13 +106,6 @@ ignore = [
     "Q003",  # avoidable-escaped-quote
     "COM812",  # missing-trailing-comma
     "COM819",  # prohibited-trailing-comma
-    # Additional disabled rules
-    "D203",  # incorrect-blank-line-before-class
-    "D213",  # multi-line-summary-second-line
-    "ARG001",  # unused-argument
-    "PYI024",  # collections-named-tuple (not currently using type annotations)
-    "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
-    "PERF203",  # try-except-in-loop (most of these are unavoidable)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ select = [
     # "F",  # Pyflakes
     # "E",  # pycodestyle
     "W",  # pycodestyle
-    # "I",  # isort
+    "I",  # isort
     # "N",  # pep8-naming
     # "UP",  # pyupgrade
     "YTT",  # flake8-2020

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ select = [
     # "PL",  # Pylint
     # "TRY",  # tryceratops
     "FLY",  # flynt
-    # "PERF",  # Perflint
+    "PERF",  # Perflint
     "FURB",  # refurb
     # "RUF",  # Ruff-specific rules
 ]
@@ -104,6 +104,7 @@ ignore = [
     "ARG001",  # unused-argument
     "PYI024",  # collections-named-tuple (not currently using type annotations)
     "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
+    "PERF203",  # try-except-in-loop (most of these are unavoidable)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ select = [
     "INT",  # flake8-gettext
     # "ARG",  # flake8-unused-arguments
     # "PTH",  # flake8-use-pathlib
-    # "PGH",  # pygrep-hooks
+    "PGH",  # pygrep-hooks
     # "PL",  # Pylint
     # "TRY",  # tryceratops
     "FLY",  # flynt
@@ -103,6 +103,7 @@ ignore = [
     "D213",  # multi-line-summary-second-line
     "ARG001",  # unused-argument
     "PYI024",  # collections-named-tuple (not currently using type annotations)
+    "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
-from distutils.command.build_ext import build_ext  # noqa
-from distutils.core import Extension  # noqa
-from distutils.errors import (  # noqa
+from distutils.command.build_ext import build_ext
+from distutils.core import Extension
+from distutils.errors import (
     CCompilerError,
     DistutilsExecError,
     DistutilsPlatformError,

--- a/tests/adapter_asgiref/conftest.py
+++ b/tests/adapter_asgiref/conftest.py
@@ -11,13 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_asgiref/conftest.py
+++ b/tests/adapter_asgiref/conftest.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_cheroot/conftest.py
+++ b/tests/adapter_cheroot/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_cheroot/conftest.py
+++ b/tests/adapter_cheroot/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_cheroot/test_wsgi.py
+++ b/tests/adapter_cheroot/test_wsgi.py
@@ -15,8 +15,9 @@
 import socket
 
 import cheroot.wsgi
-import newrelic.api.transaction
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+import newrelic.api.transaction
 
 
 def get_open_port():

--- a/tests/adapter_daphne/conftest.py
+++ b/tests/adapter_daphne/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_daphne/conftest.py
+++ b/tests/adapter_daphne/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_gevent/_application.py
+++ b/tests/adapter_gevent/_application.py
@@ -15,9 +15,8 @@
 import threading
 import time
 
-from testing_support.util import get_open_port
-
 from gevent import Timeout, sleep
+from testing_support.util import get_open_port
 
 
 def request_timeout_application(environ, start_response):

--- a/tests/adapter_gevent/conftest.py
+++ b/tests/adapter_gevent/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 import webtest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_gevent/conftest.py
+++ b/tests/adapter_gevent/conftest.py
@@ -14,10 +14,7 @@
 
 import pytest
 import webtest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_gunicorn/conftest.py
+++ b/tests/adapter_gunicorn/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_gunicorn/conftest.py
+++ b/tests/adapter_gunicorn/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_gunicorn/test_aiohttp_app_factory.py
+++ b/tests/adapter_gunicorn/test_aiohttp_app_factory.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import os
-import pytest
 import random
 import socket
 import time
+
+import pytest
 from testing_support.fixtures import TerminatingPopen
 from testing_support.util import get_open_port
-
 
 aiohttp = pytest.importorskip("aiohttp")
 from urllib.request import urlopen

--- a/tests/adapter_gunicorn/test_asgi_app.py
+++ b/tests/adapter_gunicorn/test_asgi_app.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import os
 import random
 import socket
 import time
+
+import pytest
 from testing_support.fixtures import TerminatingPopen
 from testing_support.util import get_open_port
 
-
 pytest.importorskip("asyncio")
 from urllib.request import urlopen
+
 from testing_support.util import get_open_port
 
 

--- a/tests/adapter_gunicorn/test_gaiohttp.py
+++ b/tests/adapter_gunicorn/test_gaiohttp.py
@@ -14,16 +14,17 @@
 
 import os
 import random
-import pytest
-import time
 import socket
+import time
+
+import pytest
 from testing_support.fixtures import TerminatingPopen
 from testing_support.util import get_open_port
-
 
 pytest.importorskip("aiohttp.wsgi")
 pytest.importorskip("gunicorn.workers.gaiohttp")
 from urllib.request import urlopen
+
 from testing_support.util import get_open_port
 
 

--- a/tests/adapter_hypercorn/conftest.py
+++ b/tests/adapter_hypercorn/conftest.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_hypercorn/conftest.py
+++ b/tests/adapter_hypercorn/conftest.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_uvicorn/conftest.py
+++ b/tests/adapter_uvicorn/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_uvicorn/conftest.py
+++ b/tests/adapter_uvicorn/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/adapter_uvicorn/test_uvicorn.py
+++ b/tests/adapter_uvicorn/test_uvicorn.py
@@ -25,9 +25,9 @@ from testing_support.fixtures import (
     raise_background_exceptions,
     wait_for_background_threads,
 )
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.sample_asgi_applications import AppWithCall, AppWithCallRaw, simple_app_v2_raw
+from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from uvicorn.config import Config
 from uvicorn.main import Server
 

--- a/tests/adapter_waitress/conftest.py
+++ b/tests/adapter_waitress/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 import webtest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/adapter_waitress/conftest.py
+++ b/tests/adapter_waitress/conftest.py
@@ -14,10 +14,7 @@
 
 import pytest
 import webtest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/agent_features/conftest.py
+++ b/tests/agent_features/conftest.py
@@ -12,17 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-from testing_support.fixtures import (
-    newrelic_caplog as caplog,
-)
-from testing_support.fixture.event_loop import (
-    event_loop,
-)
-
+from testing_support.fixture.event_loop import event_loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
+from testing_support.fixtures import newrelic_caplog as caplog
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/agent_features/conftest.py
+++ b/tests/agent_features/conftest.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     newrelic_caplog as caplog,
 )
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop,
 )
 

--- a/tests/agent_features/test_asgi_distributed_tracing.py
+++ b/tests/agent_features/test_asgi_distributed_tracing.py
@@ -60,7 +60,7 @@ parent_info = {
 @asgi_application()
 async def target_asgi_application(scope, receive, send):
     status = "200 OK"
-    type = "http.response.start"
+    type_ = "http.response.start"
     output = b"hello world"
     response_headers = [
         (b"content-type", b"text/html; charset=utf-8"),
@@ -81,7 +81,7 @@ async def target_asgi_application(scope, receive, send):
     assert txn.priority == 10.001
     assert txn.sampled
 
-    await send({"type": type, "status": status, "headers": response_headers})
+    await send({"type": type_, "status": status, "headers": response_headers})
 
     await send({"type": "http.response.body", "body": b"Hello World"})
 

--- a/tests/agent_features/test_asgi_w3c_trace_context.py
+++ b/tests/agent_features/test_asgi_w3c_trace_context.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 import pytest
-
-from newrelic.api.transaction import current_transaction
-from newrelic.api.external_trace import ExternalTrace
-from newrelic.api.asgi_application import asgi_application
-
 from testing_support.asgi_testing import AsgiTest
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_event_attributes import validate_transaction_event_attributes
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.asgi_application import asgi_application
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import current_transaction
 
 
 @asgi_application()

--- a/tests/agent_features/test_asgi_w3c_trace_context.py
+++ b/tests/agent_features/test_asgi_w3c_trace_context.py
@@ -28,7 +28,7 @@ from testing_support.validators.validate_transaction_event_attributes import val
 @asgi_application()
 async def target_asgi_application(scope, receive, send):
     status = "200 OK"
-    type = "http.response.start"
+    type_ = "http.response.start"
     txn = current_transaction()
     if txn._sampled is None:
         txn._sampled = True
@@ -40,7 +40,7 @@ async def target_asgi_application(scope, receive, send):
         encoded_val = value.encode("utf-8")
         response_headers.append((encoded_key, encoded_val))
 
-    await send({"type": type, "status": status, "headers": response_headers})
+    await send({"type": type_, "status": status, "headers": response_headers})
 
     await send({"type": "http.response.body", "body": b"Hello World"})
 

--- a/tests/agent_features/test_async_generator_trace.py
+++ b/tests/agent_features/test_async_generator_trace.py
@@ -16,4 +16,4 @@ import sys
 
 # Async Generators were introduced in Python 3.6, but some APIs weren't completely stable until Python 3.7.
 if sys.version_info >= (3, 7):
-    from _test_async_generator_trace import *  # NOQA
+    from _test_async_generator_trace import *

--- a/tests/agent_features/test_async_wrapper_detection.py
+++ b/tests/agent_features/test_async_wrapper_detection.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import functools
 import time
+
+import pytest
+from testing_support.fixtures import capture_transaction_metrics
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 from newrelic.api.database_trace import database_trace
@@ -25,11 +27,7 @@ from newrelic.api.function_trace import function_trace
 from newrelic.api.graphql_trace import graphql_operation_trace, graphql_resolver_trace
 from newrelic.api.memcache_trace import memcache_trace
 from newrelic.api.message_trace import message_trace
-
 from newrelic.common.async_wrapper import generator_wrapper
-
-from testing_support.fixtures import capture_transaction_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 trace_metric_cases = [
     (functools.partial(function_trace, name="simple_gen"), "Function/simple_gen"),

--- a/tests/agent_features/test_attribute.py
+++ b/tests/agent_features/test_attribute.py
@@ -498,7 +498,7 @@ def test_str_raises_type_error():
 
 class AttributeErrorString:
     def __str__(self):
-        raise AttributeError()
+        raise AttributeError
 
 
 def test_str_raises_attribute_error():

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -941,7 +941,7 @@ def test_enduser_id_attribute_api_valid_types(input_user_id, reported_user_id, h
         set_user_id(input_user_id)
 
         try:
-            raise ValueError()
+            raise ValueError
         except Exception:
             notice_error()
 
@@ -957,7 +957,7 @@ def test_enduser_id_attribute_api_invalid_types(input_user_id):
         set_user_id(input_user_id)
 
         try:
-            raise ValueError()
+            raise ValueError
         except Exception:
             notice_error()
 

--- a/tests/agent_features/test_cat.py
+++ b/tests/agent_features/test_cat.py
@@ -85,7 +85,7 @@ _override_settings = {"cross_application_tracing.enabled": True, "distributed_tr
 def test_cat_fips_compliance(monkeypatch, fips_enabled):
     # Set md5 to raise a ValueError to simulate FIPS compliance issues.
     def md5_crash(*args, **kwargs):
-        raise ValueError()
+        raise ValueError
 
     if fips_enabled:
         # monkeypatch.setattr("hashlib.md5", md5_crash)

--- a/tests/agent_features/test_code_level_metrics.py
+++ b/tests/agent_features/test_code_level_metrics.py
@@ -25,9 +25,11 @@ from _test_code_level_metrics import (
     ExerciseClassCallable,
     ExerciseTypeConstructor,
     ExerciseTypeConstructorCallable,
+    exercise_function,
+    exercise_lambda,
+    exercise_partial,
 )
 from _test_code_level_metrics import __file__ as FILE_PATH
-from _test_code_level_metrics import exercise_function, exercise_lambda, exercise_partial
 from testing_support.fixtures import dt_enabled, override_application_settings
 from testing_support.validators.validate_span_events import validate_span_events
 

--- a/tests/agent_features/test_coroutine_trace.py
+++ b/tests/agent_features/test_coroutine_trace.py
@@ -489,4 +489,4 @@ def test_trace_outlives_transaction(event_loop):
 
 
 if sys.version_info >= (3, 5):
-    from _test_async_coroutine_trace import *  # NOQA
+    from _test_async_coroutine_trace import *

--- a/tests/agent_features/test_coroutine_transaction.py
+++ b/tests/agent_features/test_coroutine_transaction.py
@@ -51,7 +51,7 @@ def coroutine_test(event_loop, transaction, nr_enabled=True, does_hang=False, ca
 
         try:
             if does_hang:
-                await loop.create_future()  # noqa
+                await loop.create_future()
             else:
                 await asyncio.sleep(0.0)
                 if nr_enabled and txn.enabled:

--- a/tests/agent_features/test_dead_transactions.py
+++ b/tests/agent_features/test_dead_transactions.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import gc
+
 import pytest
 
-from newrelic.api.background_task import BackgroundTask
 from newrelic.api.application import application_instance
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.api.background_task import BackgroundTask
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 @function_wrapper

--- a/tests/agent_features/test_exception_messages.py
+++ b/tests/agent_features/test_exception_messages.py
@@ -23,7 +23,6 @@ from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import background_task
 from newrelic.api.time_trace import notice_error
 
-
 UNICODE_MESSAGE = "I💜🐍"
 UNICODE_ENGLISH = "I love python"
 BYTES_ENGLISH = b"I love python"

--- a/tests/agent_features/test_function_trace.py
+++ b/tests/agent_features/test_function_trace.py
@@ -14,11 +14,11 @@
 
 import time
 
-from newrelic.api.background_task import background_task
-from newrelic.api.function_trace import FunctionTrace
-
 from testing_support.fixtures import validate_tt_parenting
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
+from newrelic.api.function_trace import FunctionTrace
 
 _test_function_trace_default_group_scoped_metrics = [("Function/FunctionTrace", 1)]
 

--- a/tests/agent_features/test_llm_token_count_callback.py
+++ b/tests/agent_features/test_llm_token_count_callback.py
@@ -53,7 +53,7 @@ def test_exception_in_user_callback():
     settings = application().settings
 
     def user_exc():
-        raise TypeError()
+        raise TypeError
 
     set_llm_token_count_callback(user_exc)
 

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -15,7 +15,6 @@
 import json
 import logging
 import sys
-
 from io import StringIO as Buffer
 from traceback import format_exception
 
@@ -25,7 +24,6 @@ from newrelic.agent import get_linking_metadata
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.log import NewRelicContextFormatter
-
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/agent_features/test_ml_events.py
+++ b/tests/agent_features/test_ml_events.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import time
-
 from importlib import reload
 
 import pytest
@@ -28,7 +27,6 @@ from newrelic.api.application import application_instance as application
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import record_ml_event
 from newrelic.core.config import global_settings
-
 
 _now = time.time()
 

--- a/tests/agent_features/test_notice_error.py
+++ b/tests/agent_features/test_notice_error.py
@@ -428,7 +428,7 @@ def test_application_error_event_limit():
 @background_task()
 def test_transaction_notice_error_params_not_a_dict():
     try:
-        raise RuntimeError()
+        raise RuntimeError
     except RuntimeError:
         notice_error(sys.exc_info(), attributes=[1, 2, 3])
 
@@ -437,6 +437,6 @@ def test_transaction_notice_error_params_not_a_dict():
 @validate_application_error_trace_count(num_errors=1)
 def test_application_notice_error_params_not_a_dict():
     try:
-        raise RuntimeError()
+        raise RuntimeError
     except RuntimeError:
         notice_error(sys.exc_info(), attributes=[1, 2, 3], application=application())

--- a/tests/agent_features/test_stack_trace.py
+++ b/tests/agent_features/test_stack_trace.py
@@ -15,13 +15,8 @@
 import sys
 
 from newrelic.core.config import global_settings
-from newrelic.core.stack_trace import (
-    exception_stack,
-    current_stack,
-    _format_stack_trace as _format_stack_trace_from_dicts,
-    _extract_stack,
-    _extract_tb,
-)
+from newrelic.core.stack_trace import _extract_stack, _extract_tb, current_stack, exception_stack
+from newrelic.core.stack_trace import _format_stack_trace as _format_stack_trace_from_dicts
 
 
 def _format_stack_trace_from_tuples(frames):

--- a/tests/agent_features/test_supportability_metrics.py
+++ b/tests/agent_features/test_supportability_metrics.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import subprocess
 import sys
 
-import newrelic.agent
-
-from newrelic.core.agent import agent_instance
-
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+import pytest
 from testing_support.validators.validate_metric_payload import validate_metric_payload
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
+import newrelic.agent
+from newrelic.core.agent import agent_instance
 
 _unscoped_metrics = [
     ("Supportability/api/FunctionTrace", 1),

--- a/tests/agent_features/test_transaction_name.py
+++ b/tests/agent_features/test_transaction_name.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.background_task import background_task
-from newrelic.api.transaction import set_transaction_name, set_background_task
-
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import set_background_task, set_transaction_name
 
 
 # test

--- a/tests/agent_features/test_w3c_trace_context.py
+++ b/tests/agent_features/test_w3c_trace_context.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 
 import json
-import webtest
-import pytest
 
-from newrelic.api.transaction import current_transaction
-from newrelic.api.external_trace import ExternalTrace
-from newrelic.api.wsgi_application import wsgi_application
+import pytest
+import webtest
 from testing_support.fixtures import override_application_settings
 from testing_support.validators.validate_span_events import validate_span_events
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_event_attributes import validate_transaction_event_attributes
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import current_transaction
+from newrelic.api.wsgi_application import wsgi_application
 
 
 @wsgi_application()

--- a/tests/agent_streaming/conftest.py
+++ b/tests/agent_streaming/conftest.py
@@ -15,7 +15,7 @@
 import threading
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/agent_streaming/conftest.py
+++ b/tests/agent_streaming/conftest.py
@@ -15,10 +15,7 @@
 import threading
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_grpc_server import MockExternalgRPCServer
 
 from newrelic.common.streaming_utils import StreamBuffer

--- a/tests/agent_streaming/test_span_events.py
+++ b/tests/agent_streaming/test_span_events.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from testing_support.fixtures import core_application_stats_engine, override_application_settings
+from testing_support.validators.validate_span_events import validate_span_events
+
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import current_transaction
-
-from testing_support.fixtures import override_application_settings, core_application_stats_engine
-from testing_support.validators.validate_span_events import validate_span_events
 
 
 @override_application_settings({"distributed_tracing.enabled": True})

--- a/tests/agent_streaming/test_stream_buffer.py
+++ b/tests/agent_streaming/test_stream_buffer.py
@@ -21,7 +21,7 @@ from newrelic.core.infinite_tracing_pb2 import Span, SpanBatch
 
 class StopIterationOnWait(CONDITION_CLS):
     def wait(self, *args, **kwargs):
-        raise StopIteration()
+        raise StopIteration
 
 
 @staticmethod

--- a/tests/agent_unittests/conftest.py
+++ b/tests/agent_unittests/conftest.py
@@ -18,11 +18,11 @@ import tempfile
 from importlib import reload
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     newrelic_caplog as caplog,
 )
 

--- a/tests/agent_unittests/conftest.py
+++ b/tests/agent_unittests/conftest.py
@@ -14,17 +14,11 @@
 
 import sys
 import tempfile
-
 from importlib import reload
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-from testing_support.fixtures import (
-    newrelic_caplog as caplog,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
+from testing_support.fixtures import newrelic_caplog as caplog
 
 from newrelic.core.agent import agent_instance
 

--- a/tests/agent_unittests/test_agent.py
+++ b/tests/agent_unittests/test_agent.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import pytest
+from testing_support.fixtures import override_generic_settings
+
 from newrelic.core.agent import Agent
 from newrelic.core.config import finalize_application_settings
-from testing_support.fixtures import override_generic_settings
 
 
 class FakeApplication:

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -18,6 +18,7 @@ import ssl
 import tempfile
 
 import pytest
+from testing_support.http_client_recorder import HttpClientRecorder
 
 from newrelic.common import certs, system_info
 from newrelic.common.agent_http import DeveloperModeClient
@@ -34,8 +35,6 @@ from newrelic.network.exceptions import (
     NetworkInterfaceException,
     RetryDataForRequest,
 )
-from testing_support.http_client_recorder import HttpClientRecorder
-
 
 # Global constants used in tests
 APP_NAME = "test_app"

--- a/tests/agent_unittests/test_check_environment.py
+++ b/tests/agent_unittests/test_check_environment.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tempfile
 import os
 import shutil
 import sys
+import tempfile
+
 import pytest
+
 import newrelic.core.agent as agent
 
 

--- a/tests/agent_unittests/test_environment.py
+++ b/tests/agent_unittests/test_environment.py
@@ -34,7 +34,7 @@ def module(version):
 
 def test_plugin_list():
     # Let's pretend we fired an import hook
-    import pytest  # noqa: F401
+    import pytest
 
     for name, version, _ in plugins():
         if name == "newrelic.hooks.newrelic":

--- a/tests/agent_unittests/test_full_uri_payloads.py
+++ b/tests/agent_unittests/test_full_uri_payloads.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import os
 import time
 
-
+import pytest
 from testing_support.fixtures import collector_agent_registration_fixture
-from newrelic.core.agent_protocol import AgentProtocol
+
 from newrelic.common.agent_http import HttpClient
-from newrelic.core.config import global_settings, _environ_as_bool
+from newrelic.core.agent_protocol import AgentProtocol
+from newrelic.core.config import _environ_as_bool, global_settings
 
 DEVELOPER_MODE = _environ_as_bool("NEW_RELIC_DEVELOPER_MODE", False) or "NEW_RELIC_LICENSE_KEY" not in os.environ
 SKIP_IF_DEVELOPER_MODE = pytest.mark.skipif(DEVELOPER_MODE, reason="Cannot connect to collector in developer mode")

--- a/tests/agent_unittests/test_harvest_loop.py
+++ b/tests/agent_unittests/test_harvest_loop.py
@@ -28,7 +28,7 @@ from newrelic.core.error_node import ErrorNode
 from newrelic.core.function_node import FunctionNode
 from newrelic.core.log_event_node import LogEventNode
 from newrelic.core.root_node import RootNode
-from newrelic.core.stats_engine import CustomMetrics, SampledDataSet, DimensionalMetrics
+from newrelic.core.stats_engine import CustomMetrics, DimensionalMetrics, SampledDataSet
 from newrelic.core.transaction_node import TransactionNode
 from newrelic.network.exceptions import RetryDataForRequest
 

--- a/tests/agent_unittests/test_import_hook.py
+++ b/tests/agent_unittests/test_import_hook.py
@@ -53,7 +53,7 @@ def test_import_hook_finder(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "input_,expected",
     [
         ("*", {"run", "A.run", "B.run"}),
         ("NotFound.*", set()),
@@ -65,9 +65,9 @@ def test_import_hook_finder(monkeypatch):
         ("*.RUN", set()),  # Check for case insensitivity issues
     ],
 )
-def test_module_function_globbing(input, expected):
+def test_module_function_globbing(input_, expected):
     """This asserts the behavior of filename style globbing on modules."""
     import _test_import_hook as module
 
-    result = set(_module_function_glob(module, input))
+    result = set(_module_function_glob(module, input_))
     assert result == expected, (result, expected)

--- a/tests/agent_unittests/test_import_hook.py
+++ b/tests/agent_unittests/test_import_hook.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.api.import_hook as import_hook
 import pytest
 
+import newrelic.api.import_hook as import_hook
 from newrelic.config import _module_function_glob
 
 

--- a/tests/agent_unittests/test_package_version_utils.py
+++ b/tests/agent_unittests/test_package_version_utils.py
@@ -127,7 +127,7 @@ def _getattr_deprecation_warning(attr):
         warnings.warn("Testing deprecation warnings.", DeprecationWarning)
         return "3.2.1"
     else:
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 def test_deprecation_warning_suppression(monkeypatch, recwarn):

--- a/tests/agent_unittests/test_serverless_mode_settings.py
+++ b/tests/agent_unittests/test_serverless_mode_settings.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import pytest
+from testing_support.validators.validate_serverless_payload import validate_serverless_payload
 
 from newrelic.api.application import register_application
 from newrelic.api.background_task import background_task
-from testing_support.validators.validate_serverless_payload import validate_serverless_payload
 
 INI_FILE_EMPTY = """
 [newrelic]

--- a/tests/agent_unittests/test_utilization_settings.py
+++ b/tests/agent_unittests/test_utilization_settings.py
@@ -14,7 +14,6 @@
 
 import os
 import tempfile
-
 from importlib import reload
 
 import pytest
@@ -35,7 +34,6 @@ from newrelic.core.config import (
     finalize_application_settings,
     global_settings,
 )
-
 
 INI_FILE_WITHOUT_UTIL_CONF = b"""
 [newrelic]

--- a/tests/application_celery/conftest.py
+++ b/tests/application_celery/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/application_celery/conftest.py
+++ b/tests/application_celery/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/application_celery/test_max_tasks_per_child.py
+++ b/tests/application_celery/test_max_tasks_per_child.py
@@ -34,7 +34,7 @@ def mock_agent_shutdown(wrapped, instance, args, kwargs):
 @validate_function_called("newrelic.core.agent", "Agent.shutdown_agent")
 def test_max_tasks_per_child():
     def on_exit(*args, **kwargs):
-        raise OnExit()
+        raise OnExit
 
     ctx = get_context()
     worker = Worker(ctx.SimpleQueue(), ctx.SimpleQueue(), None, maxtasks=1, on_exit=on_exit)

--- a/tests/application_celery/test_task_methods.py
+++ b/tests/application_celery/test_task_methods.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import celery
 import pytest
-
 from _target_application import add, tsum
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 from testing_support.validators.validate_transaction_count import validate_transaction_count
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-
-import celery
-
 
 FORGONE_TASK_METRICS = [("Function/_target_application.add", None), ("Function/_target_application.tsum", None)]
 

--- a/tests/application_celery/test_wrappers.py
+++ b/tests/application_celery/test_wrappers.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import celery
 from _target_application import add
 
-import celery
-
 from newrelic.common.object_wrapper import _NRBoundFunctionWrapper
-
 
 FORGONE_TASK_METRICS = [("Function/_target_application.add", None), ("Function/_target_application.tsum", None)]
 

--- a/tests/application_gearman/conftest.py
+++ b/tests/application_gearman/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/application_gearman/conftest.py
+++ b/tests/application_gearman/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/application_gearman/test_gearman.py
+++ b/tests/application_gearman/test_gearman.py
@@ -20,9 +20,9 @@ import os
 import threading
 
 import gearman
+from testing_support.db_settings import gearman_settings
 
 from newrelic.api.background_task import background_task
-from testing_support.db_settings import gearman_settings
 
 worker_thread = None
 worker_event = threading.Event()

--- a/tests/component_djangorestframework/conftest.py
+++ b/tests/component_djangorestframework/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/component_djangorestframework/conftest.py
+++ b/tests/component_djangorestframework/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/component_djangorestframework/settings.py
+++ b/tests/component_djangorestframework/settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import django
 
 BASE_DIR = os.path.dirname(__file__)

--- a/tests/component_djangorestframework/urls.py
+++ b/tests/component_djangorestframework/urls.py
@@ -28,7 +28,7 @@ from views import index
 
 
 class View(APIView):
-    def get(self, request, format=None):
+    def get(self, request, format=None):  # noqa: A002
         return Response([{"message": "restframework view response"}])
 
 
@@ -37,7 +37,7 @@ class Error(Exception):
 
 
 class ViewError(APIView):
-    def get(self, request, format=None):
+    def get(self, request, format=None):  # noqa: A002
         raise Error("xxx")
 
 

--- a/tests/component_djangorestframework/urls.py
+++ b/tests/component_djangorestframework/urls.py
@@ -22,8 +22,8 @@ except ImportError:
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-from rest_framework.views import APIView
 from rest_framework.settings import APISettings, api_settings
+from rest_framework.views import APIView
 from views import index
 
 

--- a/tests/component_flask_rest/_test_application.py
+++ b/tests/component_flask_rest/_test_application.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import webtest
-
 from flask import Flask
 from werkzeug.exceptions import HTTPException
 

--- a/tests/component_flask_rest/conftest.py
+++ b/tests/component_flask_rest/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/component_flask_rest/conftest.py
+++ b/tests/component_flask_rest/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/component_graphqlserver/_test_graphql.py
+++ b/tests/component_graphqlserver/_test_graphql.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flask import Flask
-from sanic import Sanic
 import json
-import webtest
 
-from testing_support.asgi_testing import AsgiTest
+import webtest
+from flask import Flask
 from framework_graphql._target_schema_sync import target_schema as schema
 from graphql_server.flask import GraphQLView as FlaskView
 from graphql_server.sanic import GraphQLView as SanicView
+from sanic import Sanic
+from testing_support.asgi_testing import AsgiTest
 
 # Sanic
 target_application = dict()

--- a/tests/component_graphqlserver/conftest.py
+++ b/tests/component_graphqlserver/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/component_graphqlserver/conftest.py
+++ b/tests/component_graphqlserver/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/component_graphqlserver/test_graphql.py
+++ b/tests/component_graphqlserver/test_graphql.py
@@ -43,12 +43,12 @@ def target_application(request):
     return framework, version, _test_graphql.target_application[framework]
 
 
-def example_middleware(next, root, info, **args):  # pylint: disable=W0622
+def example_middleware(next, root, info, **args):  # noqa: A002
     return_value = next(root, info, **args)
     return return_value
 
 
-def error_middleware(next, root, info, **args):  # pylint: disable=W0622
+def error_middleware(next, root, info, **args):  # noqa: A002
     raise RuntimeError("Runtime Error!")
 
 

--- a/tests/component_tastypie/api.py
+++ b/tests/component_tastypie/api.py
@@ -30,4 +30,4 @@ class SimpleResource(Resource):
         elif pk == "ZeroDivisionError":
             1 / 0
         else:
-            raise NotImplemented()
+            raise NotImplemented

--- a/tests/component_tastypie/api.py
+++ b/tests/component_tastypie/api.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from django.core.exceptions import ObjectDoesNotExist
-from tastypie.resources import Resource
 from tastypie.exceptions import NotFound
+from tastypie.resources import Resource
 
 
 class SimpleResource(Resource):

--- a/tests/component_tastypie/conftest.py
+++ b/tests/component_tastypie/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/component_tastypie/conftest.py
+++ b/tests/component_tastypie/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/component_tastypie/settings.py
+++ b/tests/component_tastypie/settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import django
 
 BASE_DIR = os.path.dirname(__file__)

--- a/tests/component_tastypie/urls.py
+++ b/tests/component_tastypie/urls.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 try:
-    from django.conf.urls import url, include
+    from django.conf.urls import include, url
 except ImportError:
     try:
-        from django.conf.urls.defaults import url, include
+        from django.conf.urls.defaults import include, url
     except ImportError:
-        from django.urls import re_path as url, include
-
-from tastypie.api import Api
+        from django.urls import include
+        from django.urls import re_path as url
 
 import views
-
 from api import SimpleResource
+from tastypie.api import Api
 
 simple_resource = SimpleResource()
 

--- a/tests/coroutines_asyncio/conftest.py
+++ b/tests/coroutines_asyncio/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (
-    event_loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/coroutines_asyncio/conftest.py
+++ b/tests/coroutines_asyncio/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/cross_agent/conftest.py
+++ b/tests/cross_agent/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/cross_agent/conftest.py
+++ b/tests/cross_agent/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/cross_agent/fixtures/ecs_container_id/ecs_mock_server.py
+++ b/tests/cross_agent/fixtures/ecs_container_id/ecs_mock_server.py
@@ -1,5 +1,6 @@
-import pytest
 import json
+
+import pytest
 from testing_support.mock_external_http_server import MockExternalHTTPServer
 
 STANDARD_RESPONSE = {

--- a/tests/cross_agent/test_agent_attributes.py
+++ b/tests/cross_agent/test_agent_attributes.py
@@ -14,12 +14,12 @@
 
 import json
 import os
+
 import pytest
+from testing_support.fixtures import override_application_settings
 
 from newrelic.core import attribute_filter as af
-from newrelic.core.config import global_settings, Settings
-
-from testing_support.fixtures import override_application_settings
+from newrelic.core.config import Settings, global_settings
 
 
 def _default_settings():

--- a/tests/cross_agent/test_aws_utilization_data.py
+++ b/tests/cross_agent/test_aws_utilization_data.py
@@ -14,12 +14,12 @@
 
 import json
 import os
-import pytest
 
-from newrelic.common.utilization import AWSUtilization
+import pytest
 from testing_support.mock_http_client import create_client_cls
 from testing_support.validators.validate_internal_metrics import validate_internal_metrics
 
+from newrelic.common.utilization import AWSUtilization
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "utilization_vendor_specific", "aws.json"))

--- a/tests/cross_agent/test_azure_utilization_data.py
+++ b/tests/cross_agent/test_azure_utilization_data.py
@@ -14,12 +14,12 @@
 
 import json
 import os
-import pytest
 
-from newrelic.common.utilization import AzureUtilization
+import pytest
 from testing_support.mock_http_client import create_client_cls
 from testing_support.validators.validate_internal_metrics import validate_internal_metrics
 
+from newrelic.common.utilization import AzureUtilization
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "utilization_vendor_specific", "azure.json"))

--- a/tests/cross_agent/test_boot_id_utilization_data.py
+++ b/tests/cross_agent/test_boot_id_utilization_data.py
@@ -14,14 +14,13 @@
 
 import json
 import os
-import pytest
 import sys
 import tempfile
 
-from newrelic.common.system_info import BootIdUtilization
-
+import pytest
 from testing_support.validators.validate_internal_metrics import validate_internal_metrics
 
+from newrelic.common.system_info import BootIdUtilization
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 SYS_PLATFORM = sys.platform

--- a/tests/cross_agent/test_cat_map.py
+++ b/tests/cross_agent/test_cat_map.py
@@ -20,12 +20,10 @@ can be found in test/framework_tornado_r3/test_cat_map.py
 
 import json
 import os
+from urllib.request import urlopen
 
 import pytest
 import webtest
-
-from urllib.request import urlopen
-
 from testing_support.fixtures import (
     make_cross_agent_headers,
     override_application_name,

--- a/tests/cross_agent/test_collector_hostname.py
+++ b/tests/cross_agent/test_collector_hostname.py
@@ -17,11 +17,9 @@ import multiprocessing
 import os
 import sys
 import tempfile
-
 from importlib import reload
 
 import pytest
-
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "collector_hostname.json"))

--- a/tests/cross_agent/test_distributed_tracing.py
+++ b/tests/cross_agent/test_distributed_tracing.py
@@ -165,8 +165,7 @@ def test_distributed_tracing(
         # False in this instance, we defer.
         extra_inbound_payloads.append((inbound_payloads, False))
     elif len(inbound_payloads) > 1:
-        for payload in inbound_payloads[1:]:
-            extra_inbound_payloads.append((payload, False))
+        extra_inbound_payloads.extend((payload, False) for payload in inbound_payloads[1:])
 
     global test_settings
     test_settings = {

--- a/tests/cross_agent/test_docker_container_id.py
+++ b/tests/cross_agent/test_docker_container_id.py
@@ -41,10 +41,10 @@ def _load_docker_test_attributes():
 def mock_open(mock_file):
     def _mock_open(filename, mode):
         if filename == "/proc/self/mountinfo":
-            raise FileNotFoundError()
+            raise FileNotFoundError
         elif filename == "/proc/self/cgroup":
             return mock_file
-        raise RuntimeError()
+        raise RuntimeError
 
     return _mock_open
 

--- a/tests/cross_agent/test_docker_container_id.py
+++ b/tests/cross_agent/test_docker_container_id.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import json
-import mock
 import os
+
+import mock
 import pytest
 
 import newrelic.common.utilization as u

--- a/tests/cross_agent/test_docker_container_id.py
+++ b/tests/cross_agent/test_docker_container_id.py
@@ -28,13 +28,11 @@ def _load_docker_test_attributes():
     [(<filename>, <containerId>), ...]
 
     """
-    docker_test_attributes = []
     test_cases = os.path.join(DOCKER_FIXTURE, "cases.json")
     with open(test_cases, "r") as fh:
         js = fh.read()
     json_list = json.loads(js)
-    for json_record in json_list:
-        docker_test_attributes.append((json_record["filename"], json_record["containerId"]))
+    docker_test_attributes = [(json_record["filename"], json_record["containerId"]) for json_record in json_list]
     return docker_test_attributes
 
 

--- a/tests/cross_agent/test_docker_container_id_v2.py
+++ b/tests/cross_agent/test_docker_container_id_v2.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import json
-import mock
 import os
+
+import mock
 import pytest
 
 import newrelic.common.utilization as u

--- a/tests/cross_agent/test_docker_container_id_v2.py
+++ b/tests/cross_agent/test_docker_container_id_v2.py
@@ -28,13 +28,11 @@ def _load_docker_test_attributes():
     [(<filename>, <containerId>), ...]
 
     """
-    docker_test_attributes = []
     test_cases = os.path.join(DOCKER_FIXTURE, "cases.json")
     with open(test_cases, "r") as fh:
         js = fh.read()
     json_list = json.loads(js)
-    for json_record in json_list:
-        docker_test_attributes.append((json_record["filename"], json_record["containerId"]))
+    docker_test_attributes = [(json_record["filename"], json_record["containerId"]) for json_record in json_list]
     return docker_test_attributes
 
 

--- a/tests/cross_agent/test_docker_container_id_v2.py
+++ b/tests/cross_agent/test_docker_container_id_v2.py
@@ -41,10 +41,10 @@ def _load_docker_test_attributes():
 def mock_open(mock_file):
     def _mock_open(filename, mode):
         if filename == "/proc/self/cgroup":
-            raise FileNotFoundError()
+            raise FileNotFoundError
         elif filename == "/proc/self/mountinfo":
             return mock_file
-        raise RuntimeError()
+        raise RuntimeError
 
     return _mock_open
 

--- a/tests/cross_agent/test_gcp_utilization_data.py
+++ b/tests/cross_agent/test_gcp_utilization_data.py
@@ -14,12 +14,12 @@
 
 import json
 import os
-import pytest
 
-from newrelic.common.utilization import GCPUtilization
+import pytest
 from testing_support.mock_http_client import create_client_cls
 from testing_support.validators.validate_internal_metrics import validate_internal_metrics
 
+from newrelic.common.utilization import GCPUtilization
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "utilization_vendor_specific", "gcp.json"))

--- a/tests/cross_agent/test_labels_and_rollups.py
+++ b/tests/cross_agent/test_labels_and_rollups.py
@@ -14,12 +14,12 @@
 
 import json
 import os
+
 import pytest
-
-from newrelic.config import _process_labels_setting, _map_as_mapping
-from newrelic.core.config import global_settings
-
 from testing_support.fixtures import override_application_settings
+
+from newrelic.config import _map_as_mapping, _process_labels_setting
+from newrelic.core.config import global_settings
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.join(CURRENT_DIR, "fixtures", "labels.json")

--- a/tests/cross_agent/test_pcf_utilization_data.py
+++ b/tests/cross_agent/test_pcf_utilization_data.py
@@ -14,12 +14,11 @@
 
 import json
 import os
+
 import pytest
-
-from newrelic.common.utilization import PCFUtilization
-
 from testing_support.validators.validate_internal_metrics import validate_internal_metrics
 
+from newrelic.common.utilization import PCFUtilization
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 INITIAL_ENV = os.environ

--- a/tests/cross_agent/test_rules.py
+++ b/tests/cross_agent/test_rules.py
@@ -14,14 +14,14 @@
 
 import json
 import os
+
 import pytest
+from testing_support.validators.validate_metric_payload import validate_metric_payload
 
 from newrelic.api.application import application_instance
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import record_custom_metric
 from newrelic.core.rules_engine import RulesEngine
-
-from testing_support.validators.validate_metric_payload import validate_metric_payload
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURE = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "rules.json"))

--- a/tests/cross_agent/test_sql_obfuscation.py
+++ b/tests/cross_agent/test_sql_obfuscation.py
@@ -14,10 +14,10 @@
 
 import json
 import os
+
 import pytest
 
 from newrelic.core.database_utils import SQLStatement
-
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_DIR = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures", "sql_obfuscation"))

--- a/tests/cross_agent/test_system_info.py
+++ b/tests/cross_agent/test_system_info.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import os
+
 import pytest
 
 from newrelic.common.system_info import (
-    logical_processor_count,
-    physical_processor_count,
-    total_physical_memory,
-    physical_memory_used,
     _linux_physical_processor_count,
     _linux_total_physical_memory,
+    logical_processor_count,
+    physical_memory_used,
+    physical_processor_count,
+    total_physical_memory,
 )
 
 

--- a/tests/cross_agent/test_transaction_segment_terms.py
+++ b/tests/cross_agent/test_transaction_segment_terms.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import json
 import os
-
 from contextlib import contextmanager
+
+import pytest
 
 from newrelic.api.application import application_instance as current_application
 from newrelic.api.background_task import BackgroundTask
-from newrelic.core.rules_engine import SegmentCollapseEngine
 from newrelic.core.agent import agent_instance
+from newrelic.core.rules_engine import SegmentCollapseEngine
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 JSON_DIR = os.path.normpath(os.path.join(CURRENT_DIR, "fixtures"))

--- a/tests/cross_agent/test_utilization_configs.py
+++ b/tests/cross_agent/test_utilization_configs.py
@@ -16,7 +16,6 @@ import json
 import os
 import sys
 import tempfile
-
 from importlib import reload
 
 import pytest
@@ -30,7 +29,6 @@ from newrelic.common.object_wrapper import function_wrapper
 from newrelic.common.system_info import BootIdUtilization
 from newrelic.common.utilization import CommonUtilization
 from newrelic.core.agent_protocol import AgentProtocol
-
 
 INITIAL_ENV = os.environ
 

--- a/tests/datastore_aiomcache/conftest.py
+++ b/tests/datastore_aiomcache/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_aiomcache/conftest.py
+++ b/tests/datastore_aiomcache/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_aiomysql/conftest.py
+++ b/tests/datastore_aiomysql/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_aiomysql/conftest.py
+++ b/tests/datastore_aiomysql/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -66,7 +66,7 @@ def client(request, loop):
         elif request.param == "StrictRedis":
             return aioredis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
         else:
-            raise NotImplementedError()
+            raise NotImplementedError
     else:
         if request.param == "Redis":
             return loop.run_until_complete(
@@ -75,7 +75,7 @@ def client(request, loop):
         elif request.param == "StrictRedis":
             pytest.skip("StrictRedis not implemented.")
         else:
-            raise NotImplementedError()
+            raise NotImplementedError
 
 
 @pytest.fixture(scope="session")

--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -16,13 +16,8 @@ import os
 
 import pytest
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.common.package_version_utils import get_package_version_tuple
 

--- a/tests/datastore_aioredis/conftest.py
+++ b/tests/datastore_aioredis/conftest.py
@@ -16,10 +16,10 @@ import os
 
 import pytest
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_aioredis/test_custom_conn_pool.py
+++ b/tests/datastore_aioredis/test_custom_conn_pool.py
@@ -18,7 +18,7 @@ will not result in an error.
 """
 
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
@@ -104,7 +104,7 @@ async def exercise_redis(client):
     background_task=True,
 )
 @background_task()
-def test_fake_conn_pool_enable_instance(client, loop, monkeypatch):  # noqa
+def test_fake_conn_pool_enable_instance(client, loop, monkeypatch):
     # Get a real connection
     conn = getattr(client, "_pool_or_conn", None)
     if conn is None:
@@ -129,7 +129,7 @@ def test_fake_conn_pool_enable_instance(client, loop, monkeypatch):  # noqa
     background_task=True,
 )
 @background_task()
-def test_fake_conn_pool_disable_instance(client, loop, monkeypatch):  # noqa
+def test_fake_conn_pool_disable_instance(client, loop, monkeypatch):
     # Get a real connection
     conn = getattr(client, "_pool_or_conn", None)
     if conn is None:

--- a/tests/datastore_aioredis/test_execute_command.py
+++ b/tests/datastore_aioredis/test_execute_command.py
@@ -75,7 +75,7 @@ async def exercise_redis_single_arg(client):
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_one_arg_enable(client, loop):  # noqa
+def test_redis_execute_command_as_one_arg_enable(client, loop):
     loop.run_until_complete(exercise_redis_single_arg(client))
 
 
@@ -88,7 +88,7 @@ def test_redis_execute_command_as_one_arg_enable(client, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_one_arg_disable(client, loop):  # noqa
+def test_redis_execute_command_as_one_arg_disable(client, loop):
     loop.run_until_complete(exercise_redis_single_arg(client))
 
 
@@ -100,7 +100,7 @@ def test_redis_execute_command_as_one_arg_disable(client, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_two_args_enable(client, loop):  # noqa
+def test_redis_execute_command_as_two_args_enable(client, loop):
     loop.run_until_complete(exercise_redis_multi_args(client))
 
 
@@ -112,5 +112,5 @@ def test_redis_execute_command_as_two_args_enable(client, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_two_args_disable(client, loop):  # noqa
+def test_redis_execute_command_as_two_args_disable(client, loop):
     loop.run_until_complete(exercise_redis_multi_args(client))

--- a/tests/datastore_aioredis/test_execute_command.py
+++ b/tests/datastore_aioredis/test_execute_command.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from conftest import AIOREDIS_VERSION, loop  # noqa # pylint: disable=E0611,W0611
+from conftest import AIOREDIS_VERSION, loop
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname

--- a/tests/datastore_aioredis/test_instance_info.py
+++ b/tests/datastore_aioredis/test_instance_info.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from inspect import isawaitable
+
 import pytest
+from conftest import AIOREDIS_VERSION, SKIPIF_AIOREDIS_V1, aioredis
 
 from newrelic.hooks.datastore_aioredis import _conn_attrs_to_dict, _instance_info
-from conftest import aioredis, AIOREDIS_VERSION, SKIPIF_AIOREDIS_V1
 
 _instance_info_tests = [
     ({}, ("localhost", "6379", "0")),

--- a/tests/datastore_aioredis/test_multiple_dbs.py
+++ b/tests/datastore_aioredis/test_multiple_dbs.py
@@ -96,7 +96,7 @@ def client_set(request, loop):
                     aioredis.StrictRedis(host=DB_SETTINGS[1]["host"], port=DB_SETTINGS[1]["port"], db=0),
                 )
             else:
-                raise NotImplementedError()
+                raise NotImplementedError
         else:
             if request.param == "Redis":
                 return (
@@ -110,7 +110,7 @@ def client_set(request, loop):
             elif request.param == "StrictRedis":
                 pytest.skip("StrictRedis not implemented.")
             else:
-                raise NotImplementedError()
+                raise NotImplementedError
 
 
 async def exercise_redis(client_1, client_2):

--- a/tests/datastore_aioredis/test_multiple_dbs.py
+++ b/tests/datastore_aioredis/test_multiple_dbs.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from conftest import aioredis
-
 import pytest
-from conftest import AIOREDIS_VERSION, loop
+from conftest import AIOREDIS_VERSION, aioredis, loop
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname

--- a/tests/datastore_aioredis/test_multiple_dbs.py
+++ b/tests/datastore_aioredis/test_multiple_dbs.py
@@ -15,7 +15,7 @@
 from conftest import aioredis
 
 import pytest
-from conftest import AIOREDIS_VERSION, loop  # noqa
+from conftest import AIOREDIS_VERSION, loop
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
@@ -82,7 +82,7 @@ if len(DB_SETTINGS) > 1:
 
 
 @pytest.fixture(params=("Redis", "StrictRedis"))
-def client_set(request, loop):  # noqa
+def client_set(request, loop):
     if len(DB_SETTINGS) > 1:
         if AIOREDIS_VERSION >= (2, 0):
             if request.param == "Redis":
@@ -132,7 +132,7 @@ async def exercise_redis(client_1, client_2):
     background_task=True,
 )
 @background_task()
-def test_multiple_datastores_enabled(client_set, loop):  # noqa
+def test_multiple_datastores_enabled(client_set, loop):
     loop.run_until_complete(exercise_redis(client_set[0], client_set[1]))
 
 
@@ -145,7 +145,7 @@ def test_multiple_datastores_enabled(client_set, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_multiple_datastores_disabled(client_set, loop):  # noqa
+def test_multiple_datastores_disabled(client_set, loop):
     loop.run_until_complete(exercise_redis(client_set[0], client_set[1]))
 
 
@@ -158,7 +158,7 @@ def test_multiple_datastores_disabled(client_set, loop):  # noqa
 )
 @override_application_settings(_enable_instance_settings)
 @background_task()
-def test_concurrent_calls(client_set, loop):  # noqa
+def test_concurrent_calls(client_set, loop):
     # Concurrent calls made with original instrumenation taken from synchonous Redis
     # instrumentation had a bug where datastore info on concurrent calls to multiple instances
     # would result in all instances reporting as the host/port of the final call made.

--- a/tests/datastore_aioredis/test_span_event.py
+++ b/tests/datastore_aioredis/test_span_event.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import pytest
-
-from newrelic.api.transaction import current_transaction
-from newrelic.api.background_task import background_task
-
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 
 DB_SETTINGS = redis_settings()[0]
 

--- a/tests/datastore_aredis/conftest.py
+++ b/tests/datastore_aredis/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_aredis/conftest.py
+++ b/tests/datastore_aredis/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_aredis/test_custom_conn_pool.py
+++ b/tests/datastore_aredis/test_custom_conn_pool.py
@@ -17,16 +17,15 @@ connection pool that does not have a `connection_kwargs` attribute
 will not result in an error.
 """
 
-import pytest
 import aredis
-
-from newrelic.api.background_task import background_task
-
+import pytest
+from testing_support.db_settings import redis_settings
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import redis_settings
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
 
 DB_SETTINGS = redis_settings()[0]
 REDIS_PY_VERSION = aredis.VERSION

--- a/tests/datastore_aredis/test_execute_command.py
+++ b/tests/datastore_aredis/test_execute_command.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import aredis
+import pytest
+from testing_support.db_settings import redis_settings
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.db_settings import redis_settings
-from testing_support.util import instance_hostname
 
 DB_SETTINGS = redis_settings()[0]
 REDIS_PY_VERSION = aredis.VERSION

--- a/tests/datastore_aredis/test_get_and_set.py
+++ b/tests/datastore_aredis/test_get_and_set.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import aredis
-
-from newrelic.api.background_task import background_task
-
+from testing_support.db_settings import redis_settings
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import redis_settings
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
 
 DB_SETTINGS = redis_settings()[0]
 

--- a/tests/datastore_aredis/test_instance_info.py
+++ b/tests/datastore_aredis/test_instance_info.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import aredis
+import pytest
 
 from newrelic.hooks.datastore_redis import _conn_attrs_to_dict, _instance_info
 

--- a/tests/datastore_aredis/test_multiple_dbs.py
+++ b/tests/datastore_aredis/test_multiple_dbs.py
@@ -16,8 +16,8 @@ import aredis
 import pytest
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 

--- a/tests/datastore_aredis/test_span_event.py
+++ b/tests/datastore_aredis/test_span_event.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import aredis
-
-from newrelic.api.transaction import current_transaction
-from newrelic.api.background_task import background_task
-
+import pytest
 from testing_support.db_settings import redis_settings
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 
 DB_SETTINGS = redis_settings()[0]
 DATABASE_NUMBER = 0

--- a/tests/datastore_aredis/test_trace_node.py
+++ b/tests/datastore_aredis/test_trace_node.py
@@ -14,7 +14,7 @@
 
 import aredis
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa: F401
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_tt_collector_json import validate_tt_collector_json

--- a/tests/datastore_aredis/test_uninstrumented_methods.py
+++ b/tests/datastore_aredis/test_uninstrumented_methods.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import aredis
-
 from testing_support.db_settings import redis_settings
 
 DB_SETTINGS = redis_settings()[0]

--- a/tests/datastore_asyncpg/conftest.py
+++ b/tests/datastore_asyncpg/conftest.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_asyncpg/conftest.py
+++ b/tests/datastore_asyncpg/conftest.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixture.event_loop import (
-    event_loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_bmemcached/conftest.py
+++ b/tests/datastore_bmemcached/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_bmemcached/conftest.py
+++ b/tests/datastore_bmemcached/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_cassandradriver/conftest.py
+++ b/tests/datastore_cassandradriver/conftest.py
@@ -16,7 +16,7 @@ import sys
 
 import pytest
 from testing_support.db_settings import cassandra_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_cassandradriver/conftest.py
+++ b/tests/datastore_cassandradriver/conftest.py
@@ -16,10 +16,7 @@ import sys
 
 import pytest
 from testing_support.db_settings import cassandra_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 DB_SETTINGS = cassandra_settings()
 PYTHON_VERSION = sys.version_info

--- a/tests/datastore_elasticsearch/conftest.py
+++ b/tests/datastore_elasticsearch/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 from testing_support.db_settings import elasticsearch_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_elasticsearch/conftest.py
+++ b/tests/datastore_elasticsearch/conftest.py
@@ -14,10 +14,7 @@
 
 import pytest
 from testing_support.db_settings import elasticsearch_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.common.package_version_utils import get_package_version
 

--- a/tests/datastore_elasticsearch/test_connection.py
+++ b/tests/datastore_elasticsearch/test_connection.py
@@ -20,8 +20,7 @@ except ImportError:
     from elastic_transport._models import NodeConfig
     from elastic_transport._node._base import BaseNode as Connection
 
-from conftest import ES_VERSION, ES_SETTINGS
-
+from conftest import ES_SETTINGS, ES_VERSION
 
 HOST = {"scheme": "http", "host": ES_SETTINGS["host"], "port": int(ES_SETTINGS["port"])}
 

--- a/tests/datastore_elasticsearch/test_database_duration.py
+++ b/tests/datastore_elasticsearch/test_database_duration.py
@@ -14,11 +14,10 @@
 
 import sqlite3
 
+from conftest import ES_VERSION
 from testing_support.validators.validate_database_duration import validate_database_duration
 
 from newrelic.api.background_task import background_task
-
-from conftest import ES_VERSION
 
 
 def _exercise_es_v7(es):

--- a/tests/datastore_elasticsearch/test_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_elasticsearch.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import elasticsearch.client
+from conftest import ES_SETTINGS, ES_VERSION
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from conftest import ES_VERSION, ES_SETTINGS
-
 
 # Settings
 

--- a/tests/datastore_elasticsearch/test_trace_node.py
+++ b/tests/datastore_elasticsearch/test_trace_node.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from conftest import ES_SETTINGS, ES_VERSION
 from testing_support.fixtures import override_application_settings, validate_tt_parenting
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_tt_collector_json import validate_tt_collector_json
 
 from newrelic.api.background_task import background_task
-
-from conftest import ES_SETTINGS, ES_VERSION
 
 # Settings
 

--- a/tests/datastore_firestore/conftest.py
+++ b/tests/datastore_firestore/conftest.py
@@ -17,13 +17,8 @@ import uuid
 import pytest
 from google.cloud.firestore import AsyncClient, Client
 from testing_support.db_settings import firestore_settings
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.api.datastore_trace import DatastoreTrace
 from newrelic.api.time_trace import current_trace

--- a/tests/datastore_firestore/conftest.py
+++ b/tests/datastore_firestore/conftest.py
@@ -17,10 +17,10 @@ import uuid
 import pytest
 from google.cloud.firestore import AsyncClient, Client
 from testing_support.db_settings import firestore_settings
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_firestore/conftest.py
+++ b/tests/datastore_firestore/conftest.py
@@ -101,7 +101,9 @@ def assert_trace_for_generator():
         # Check for generator trace on collections
         _trace_check = []
         for _ in generator_func(*args, **kwargs):
-            _trace_check.append(isinstance(current_trace(), DatastoreTrace))
+            # Iterate over generator and check trace is correct for each item.
+            # Ignore linter, don't use list comprehensions or it's harder to understand the behavior.
+            _trace_check.append(isinstance(current_trace(), DatastoreTrace))  # noqa: PERF401
         assert _trace_check and all(_trace_check)  # All checks are True, and at least 1 is present.
         assert current_trace() is txn  # Generator trace has exited.
 
@@ -118,7 +120,9 @@ def assert_trace_for_async_generator(loop):
         async def coro():
             # Check for generator trace on collections
             async for _ in generator_func(*args, **kwargs):
-                _trace_check.append(isinstance(current_trace(), DatastoreTrace))
+                # Iterate over async generator and check trace is correct for each item.
+                # Ignore linter, don't use list comprehensions or it's harder to understand the behavior.
+                _trace_check.append(isinstance(current_trace(), DatastoreTrace))  # noqa: PERF401
 
         loop.run_until_complete(coro())
 

--- a/tests/datastore_firestore/test_async_transaction.py
+++ b/tests/datastore_firestore/test_async_transaction.py
@@ -73,7 +73,7 @@ def exercise_async_transaction_rollback(async_client, async_collection):
             # set and delete methods
             async_transaction.set(async_collection.document("doc2"), {"x": 99})
             async_transaction.delete(async_collection.document("doc1"))
-            raise RuntimeError()
+            raise RuntimeError
 
         with pytest.raises(RuntimeError):
             await _exercise(async_client.transaction())

--- a/tests/datastore_firestore/test_transaction.py
+++ b/tests/datastore_firestore/test_transaction.py
@@ -63,7 +63,7 @@ def exercise_transaction_rollback(client, collection):
             # set and delete methods
             transaction.set(collection.document("doc2"), {"x": 99})
             transaction.delete(collection.document("doc1"))
-            raise RuntimeError()
+            raise RuntimeError
 
         with pytest.raises(RuntimeError):
             _exercise(client.transaction())

--- a/tests/datastore_memcache/conftest.py
+++ b/tests/datastore_memcache/conftest.py
@@ -18,10 +18,7 @@ import string
 import memcache
 import pytest
 from testing_support.db_settings import memcached_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_memcache/conftest.py
+++ b/tests/datastore_memcache/conftest.py
@@ -18,7 +18,7 @@ import string
 import memcache
 import pytest
 from testing_support.db_settings import memcached_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_memcache/test_all_methods_wrapped.py
+++ b/tests/datastore_memcache/test_all_methods_wrapped.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import memcache
+
 from newrelic.hooks.datastore_memcache import _memcache_client_methods, _memcache_multi_methods
 
 

--- a/tests/datastore_memcache/test_memcache.py
+++ b/tests/datastore_memcache/test_memcache.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import memcache
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.db_settings import memcached_settings
+from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 from newrelic.common.object_wrapper import wrap_function_wrapper

--- a/tests/datastore_memcache/test_multiple_dbs.py
+++ b/tests/datastore_memcache/test_multiple_dbs.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import memcache
+import pytest
+from testing_support.db_settings import memcached_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import memcached_settings
-from testing_support.util import instance_hostname
 
 DB_MULTIPLE_SETTINGS = memcached_settings()
 

--- a/tests/datastore_memcache/test_span_event.py
+++ b/tests/datastore_memcache/test_span_event.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import memcache
-
-from newrelic.api.transaction import current_transaction
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
+import pytest
 from testing_support.db_settings import memcached_settings
+from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 
 from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 
 DB_SETTINGS = memcached_settings()[0]
 MEMCACHED_ADDR = f"{DB_SETTINGS['host']}:{DB_SETTINGS['port']}"

--- a/tests/datastore_motor/conftest.py
+++ b/tests/datastore_motor/conftest.py
@@ -15,10 +15,7 @@
 import pytest
 from testing_support.db_settings import mongodb_settings
 from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_motor/conftest.py
+++ b/tests/datastore_motor/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 from testing_support.db_settings import mongodb_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
     collector_agent_registration_fixture,
     collector_available_fixture,

--- a/tests/datastore_motor/conftest.py
+++ b/tests/datastore_motor/conftest.py
@@ -15,7 +15,7 @@
 import pytest
 from testing_support.db_settings import mongodb_settings
 from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_mysql/conftest.py
+++ b/tests/datastore_mysql/conftest.py
@@ -15,7 +15,7 @@
 import os
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_mysql/conftest.py
+++ b/tests/datastore_mysql/conftest.py
@@ -15,10 +15,7 @@
 import os
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_postgresql/conftest.py
+++ b/tests/datastore_postgresql/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_postgresql/conftest.py
+++ b/tests/datastore_postgresql/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_psycopg/conftest.py
+++ b/tests/datastore_psycopg/conftest.py
@@ -15,10 +15,7 @@
 import pytest
 from testing_support.db_settings import postgresql_settings
 from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_psycopg/conftest.py
+++ b/tests/datastore_psycopg/conftest.py
@@ -14,8 +14,8 @@
 
 import pytest
 from testing_support.db_settings import postgresql_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa: F401
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_psycopg2/conftest.py
+++ b/tests/datastore_psycopg2/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_psycopg2/conftest.py
+++ b/tests/datastore_psycopg2/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_psycopg2/test_as_string.py
+++ b/tests/datastore_psycopg2/test_as_string.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import psycopg2
+import pytest
 
 try:
     from psycopg2 import sql
@@ -21,6 +21,7 @@ except ImportError:
     sql = None
 
 from testing_support.db_settings import postgresql_settings
+
 from newrelic.api.background_task import background_task
 
 DB_SETTINGS = postgresql_settings()[0]

--- a/tests/datastore_psycopg2/test_async.py
+++ b/tests/datastore_psycopg2/test_async.py
@@ -15,19 +15,17 @@
 import psycopg2
 import psycopg2.extras
 import pytest
-
-from testing_support.fixtures import validate_stats_engine_explain_plan_output_is_none, override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
-from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
-from testing_support.validators.validate_transaction_slow_sql_count import validate_transaction_slow_sql_count
-from testing_support.util import instance_hostname
 from testing_support.db_settings import postgresql_settings
+from testing_support.fixtures import override_application_settings, validate_stats_engine_explain_plan_output_is_none
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+from testing_support.validators.validate_transaction_slow_sql_count import validate_transaction_slow_sql_count
 
 DB_SETTINGS = postgresql_settings()[0]
 
 from newrelic.api.background_task import background_task
-
 
 # Settings
 

--- a/tests/datastore_psycopg2/test_cursor.py
+++ b/tests/datastore_psycopg2/test_cursor.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import psycopg2
 import psycopg2.extensions
 import psycopg2.extras
+import pytest
 
 try:
     from psycopg2 import sql
@@ -23,13 +23,12 @@ except ImportError:
     sql = None
 
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from utils import DB_SETTINGS
 
 from newrelic.api.background_task import background_task
-
 
 # Settings
 _enable_instance_settings = {"datastore_tracer.instance_reporting.enabled": True}

--- a/tests/datastore_psycopg2/test_database_instance_info.py
+++ b/tests/datastore_psycopg2/test_database_instance_info.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import pytest
-from newrelic.hooks.database_psycopg2 import instance_info, _add_defaults, _parse_connect_params
+
+from newrelic.hooks.database_psycopg2 import _add_defaults, _parse_connect_params, instance_info
 
 
 def test_kwargs():

--- a/tests/datastore_psycopg2/test_explain_plans.py
+++ b/tests/datastore_psycopg2/test_explain_plans.py
@@ -13,19 +13,17 @@
 # limitations under the License.
 
 import psycopg2
-import psycopg2.extras
 import psycopg2.extensions
+import psycopg2.extras
 import pytest
-
 from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
 from testing_support.validators.validate_database_node import validate_database_node
 from testing_support.validators.validate_transaction_slow_sql_count import validate_transaction_slow_sql_count
-from newrelic.core.database_utils import SQLConnections
-from testing_support.util import instance_hostname
 from utils import DB_SETTINGS
 
 from newrelic.api.background_task import background_task
-
+from newrelic.core.database_utils import SQLConnections
 
 _host = instance_hostname(DB_SETTINGS["host"])
 _port = DB_SETTINGS["port"]

--- a/tests/datastore_psycopg2/test_forward_compat.py
+++ b/tests/datastore_psycopg2/test_forward_compat.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import psycopg2
+import pytest
 from psycopg2 import extensions as ext
 from utils import DB_SETTINGS
+
 from newrelic.common.object_wrapper import wrap_function_wrapper
 from newrelic.hooks.database_psycopg2 import wrapper_psycopg2_as_string
 

--- a/tests/datastore_psycopg2/test_multiple_dbs.py
+++ b/tests/datastore_psycopg2/test_multiple_dbs.py
@@ -14,16 +14,14 @@
 
 import psycopg2
 import pytest
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
-from testing_support.util import instance_hostname
-from utils import DB_MULTIPLE_SETTINGS
 from testing_support.db_settings import postgresql_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+from utils import DB_MULTIPLE_SETTINGS
 
 from newrelic.api.background_task import background_task
-
 
 # Settings
 

--- a/tests/datastore_psycopg2/test_obfuscation.py
+++ b/tests/datastore_psycopg2/test_obfuscation.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import pytest
-
-from newrelic.api.background_task import background_task
-from newrelic.core.database_utils import SQLConnections
-
 from testing_support.validators.validate_database_node import validate_database_node
 from testing_support.validators.validate_sql_obfuscation import validate_sql_obfuscation
 from utils import DB_SETTINGS
+
+from newrelic.api.background_task import background_task
+from newrelic.core.database_utils import SQLConnections
 
 
 @pytest.fixture()

--- a/tests/datastore_psycopg2/test_register.py
+++ b/tests/datastore_psycopg2/test_register.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import os
+
 import psycopg2
 import psycopg2.extras
-
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from utils import DB_SETTINGS

--- a/tests/datastore_psycopg2/test_rollback.py
+++ b/tests/datastore_psycopg2/test_rollback.py
@@ -14,15 +14,13 @@
 
 import psycopg2
 import pytest
-
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from utils import DB_SETTINGS
 
 from newrelic.api.background_task import background_task
-
 
 # Settings
 

--- a/tests/datastore_psycopg2/test_span_event.py
+++ b/tests/datastore_psycopg2/test_span_event.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import psycopg2
-
-from newrelic.api.transaction import current_transaction
+import pytest
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 from utils import DB_SETTINGS
 
 from newrelic.api.background_task import background_task
-
+from newrelic.api.transaction import current_transaction
 
 # Settings
 

--- a/tests/datastore_psycopg2/utils.py
+++ b/tests/datastore_psycopg2/utils.py
@@ -14,6 +14,5 @@
 
 from testing_support.db_settings import postgresql_settings
 
-
 DB_MULTIPLE_SETTINGS = postgresql_settings()
 DB_SETTINGS = DB_MULTIPLE_SETTINGS[0]

--- a/tests/datastore_psycopg2cffi/conftest.py
+++ b/tests/datastore_psycopg2cffi/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_psycopg2cffi/conftest.py
+++ b/tests/datastore_psycopg2cffi/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_psycopg2cffi/test_explain_plans.py
+++ b/tests/datastore_psycopg2cffi/test_explain_plans.py
@@ -16,14 +16,13 @@ import psycopg2cffi
 import psycopg2cffi.extensions
 import psycopg2cffi.extras
 import pytest
-
+from testing_support.db_settings import postgresql_settings
 from testing_support.fixtures import override_application_settings
 from testing_support.validators.validate_database_node import validate_database_node
 from testing_support.validators.validate_transaction_slow_sql_count import validate_transaction_slow_sql_count
+
 from newrelic.api.background_task import background_task
 from newrelic.core.database_utils import SQLConnections
-
-from testing_support.db_settings import postgresql_settings
 
 DB_SETTINGS = postgresql_settings()[0]
 

--- a/tests/datastore_pylibmc/conftest.py
+++ b/tests/datastore_pylibmc/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pylibmc/conftest.py
+++ b/tests/datastore_pylibmc/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pymemcache/conftest.py
+++ b/tests/datastore_pymemcache/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pymemcache/conftest.py
+++ b/tests/datastore_pymemcache/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pymemcache/test_memcache.py
+++ b/tests/datastore_pymemcache/test_memcache.py
@@ -18,7 +18,6 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import set_background_task
-
 from newrelic.common import system_info
 
 DB_SETTINGS = memcached_settings()[0]

--- a/tests/datastore_pymongo/conftest.py
+++ b/tests/datastore_pymongo/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixture.event_loop import event_loop as loop  # noqa
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
     collector_agent_registration_fixture,
     collector_available_fixture,

--- a/tests/datastore_pymongo/conftest.py
+++ b/tests/datastore_pymongo/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pymongo/conftest.py
+++ b/tests/datastore_pymongo/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 from testing_support.fixture.event_loop import event_loop as loop
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pymongo/test_collection.py
+++ b/tests/datastore_pymongo/test_collection.py
@@ -35,11 +35,11 @@ INSTANCE_METRIC_NAME = f"Datastore/instance/MongoDB/{INSTANCE_METRIC_HOST}/{MONG
 
 # Find correct metric name based on import availability.
 try:
-    from pymongo.synchronous.mongo_client import MongoClient  # noqa
+    from pymongo.synchronous.mongo_client import MongoClient
 
     INIT_FUNCTION_METRIC = "Function/pymongo.synchronous.mongo_client:MongoClient.__init__"
 except ImportError:
-    from pymongo.mongo_client import MongoClient  # noqa
+    from pymongo.mongo_client import MongoClient
 
     INIT_FUNCTION_METRIC = "Function/pymongo.mongo_client:MongoClient.__init__"
 

--- a/tests/datastore_pymssql/conftest.py
+++ b/tests/datastore_pymssql/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pymssql/conftest.py
+++ b/tests/datastore_pymssql/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pymssql/test_database.py
+++ b/tests/datastore_pymssql/test_database.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import pymssql
-
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
-
 from testing_support.db_settings import mssql_settings
+from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 

--- a/tests/datastore_pymysql/conftest.py
+++ b/tests/datastore_pymysql/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pymysql/conftest.py
+++ b/tests/datastore_pymysql/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pyodbc/conftest.py
+++ b/tests/datastore_pyodbc/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pyodbc/conftest.py
+++ b/tests/datastore_pyodbc/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_pysolr/conftest.py
+++ b/tests/datastore_pysolr/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_pysolr/conftest.py
+++ b/tests/datastore_pysolr/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_redis/conftest.py
+++ b/tests/datastore_redis/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_redis/conftest.py
+++ b/tests/datastore_redis/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_redis/test_asyncio.py
+++ b/tests/datastore_redis/test_asyncio.py
@@ -16,7 +16,7 @@ import asyncio
 
 import pytest
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa: F401
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/datastore_redis/test_asyncio.py
+++ b/tests/datastore_redis/test_asyncio.py
@@ -76,14 +76,14 @@ _base_pool_rollup_metrics = [
 
 
 @pytest.fixture()
-def client(loop):  # noqa
+def client(loop):
     import redis.asyncio
 
     return loop.run_until_complete(redis.asyncio.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0))
 
 
 @pytest.fixture()
-def client_pool(loop):  # noqa
+def client_pool(loop):
     import redis.asyncio
 
     connection_pool = redis.asyncio.ConnectionPool(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
@@ -98,7 +98,7 @@ def client_pool(loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_async_connection_pool(client_pool, loop):  # noqa
+def test_async_connection_pool(client_pool, loop):
     async def _test_async_pool(client_pool):
         await client_pool.set("key1", "value1")
         await client_pool.get("key1")
@@ -110,7 +110,7 @@ def test_async_connection_pool(client_pool, loop):  # noqa
 @pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")
 @validate_transaction_metrics("test_asyncio:test_async_pipeline", background_task=True)
 @background_task()
-def test_async_pipeline(client, loop):  # noqa
+def test_async_pipeline(client, loop):
     async def _test_pipeline(client):
         async with client.pipeline(transaction=True) as pipe:
             await pipe.set("key1", "value1")
@@ -127,7 +127,7 @@ def test_async_pipeline(client, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_async_pubsub(client, loop):  # noqa
+def test_async_pubsub(client, loop):
     messages_received = []
 
     async def reader(pubsub):

--- a/tests/datastore_redis/test_execute_command.py
+++ b/tests/datastore_redis/test_execute_command.py
@@ -14,14 +14,13 @@
 
 import pytest
 import redis
+from testing_support.db_settings import redis_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import redis_settings
-from testing_support.util import instance_hostname
 
 DB_SETTINGS = redis_settings()[0]
 REDIS_PY_VERSION = get_package_version_tuple("redis")

--- a/tests/datastore_redis/test_get_and_set.py
+++ b/tests/datastore_redis/test_get_and_set.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import redis
+from testing_support.db_settings import redis_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import redis_settings
-from testing_support.util import instance_hostname
 
 DB_SETTINGS = redis_settings()[0]
 

--- a/tests/datastore_redis/test_multiple_dbs.py
+++ b/tests/datastore_redis/test_multiple_dbs.py
@@ -14,14 +14,13 @@
 
 import pytest
 import redis
+from testing_support.db_settings import redis_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import redis_settings
-from testing_support.util import instance_hostname
 
 DB_MULTIPLE_SETTINGS = redis_settings()
 REDIS_PY_VERSION = get_package_version_tuple("redis")

--- a/tests/datastore_redis/test_span_event.py
+++ b/tests/datastore_redis/test_span_event.py
@@ -14,15 +14,13 @@
 
 import pytest
 import redis
-
-from newrelic.api.transaction import current_transaction
-from newrelic.api.background_task import background_task
-
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 
 DB_SETTINGS = redis_settings()[0]
 DATABASE_NUMBER = 0

--- a/tests/datastore_rediscluster/conftest.py
+++ b/tests/datastore_rediscluster/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_rediscluster/conftest.py
+++ b/tests/datastore_rediscluster/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_solrpy/conftest.py
+++ b/tests/datastore_solrpy/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_solrpy/conftest.py
+++ b/tests/datastore_solrpy/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_sqlite/conftest.py
+++ b/tests/datastore_sqlite/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_sqlite/conftest.py
+++ b/tests/datastore_sqlite/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_sqlite/test_database.py
+++ b/tests/datastore_sqlite/test_database.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sqlite3 as database
 import os
+import sqlite3 as database
 import sys
 
 is_pypy = hasattr(sys, "pypy_version_info")
 
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 

--- a/tests/datastore_sqlite/test_obfuscation.py
+++ b/tests/datastore_sqlite/test_obfuscation.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import pytest
+from testing_support.validators.validate_sql_obfuscation import validate_sql_obfuscation
 
 from newrelic.api.background_task import background_task
-
-from testing_support.validators.validate_sql_obfuscation import validate_sql_obfuscation
 
 
 @pytest.fixture()

--- a/tests/datastore_valkey/conftest.py
+++ b/tests/datastore_valkey/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/datastore_valkey/conftest.py
+++ b/tests/datastore_valkey/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/datastore_valkey/test_asyncio.py
+++ b/tests/datastore_valkey/test_asyncio.py
@@ -71,14 +71,14 @@ _base_pool_rollup_metrics = [
 
 
 @pytest.fixture()
-def client(loop):  # noqa
+def client(loop):
     import valkey.asyncio
 
     return loop.run_until_complete(valkey.asyncio.Valkey(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0))
 
 
 @pytest.fixture()
-def client_pool(loop):  # noqa
+def client_pool(loop):
     import valkey.asyncio
 
     connection_pool = valkey.asyncio.ConnectionPool(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
@@ -92,7 +92,7 @@ def client_pool(loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_async_connection_pool(client_pool, loop):  # noqa
+def test_async_connection_pool(client_pool, loop):
     async def _test_async_pool(client_pool):
         await client_pool.set("key1", "value1")
         await client_pool.get("key1")
@@ -103,7 +103,7 @@ def test_async_connection_pool(client_pool, loop):  # noqa
 
 @validate_transaction_metrics("test_asyncio:test_async_pipeline", background_task=True)
 @background_task()
-def test_async_pipeline(client, loop):  # noqa
+def test_async_pipeline(client, loop):
     async def _test_pipeline(client):
         async with client.pipeline(transaction=True) as pipe:
             await pipe.set("key1", "value1")
@@ -119,7 +119,7 @@ def test_async_pipeline(client, loop):  # noqa
     background_task=True,
 )
 @background_task()
-def test_async_pubsub(client, loop):  # noqa
+def test_async_pubsub(client, loop):
     messages_received = []
 
     async def reader(pubsub):

--- a/tests/datastore_valkey/test_asyncio.py
+++ b/tests/datastore_valkey/test_asyncio.py
@@ -16,7 +16,7 @@ import asyncio
 
 import pytest
 from testing_support.db_settings import valkey_settings
-from testing_support.fixture.event_loop import event_loop as loop  # noqa: F401
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/datastore_valkey/test_execute_command.py
+++ b/tests/datastore_valkey/test_execute_command.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import valkey
+from testing_support.db_settings import valkey_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import valkey_settings
-from testing_support.util import instance_hostname
 
 DB_SETTINGS = valkey_settings()[0]
 

--- a/tests/datastore_valkey/test_get_and_set.py
+++ b/tests/datastore_valkey/test_get_and_set.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import valkey
+from testing_support.db_settings import valkey_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import valkey_settings
-from testing_support.util import instance_hostname
 
 DB_SETTINGS = valkey_settings()[0]
 

--- a/tests/datastore_valkey/test_multiple_dbs.py
+++ b/tests/datastore_valkey/test_multiple_dbs.py
@@ -14,13 +14,12 @@
 
 import pytest
 import valkey
+from testing_support.db_settings import valkey_settings
+from testing_support.fixtures import override_application_settings
+from testing_support.util import instance_hostname
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
-from testing_support.db_settings import valkey_settings
-from testing_support.util import instance_hostname
 
 DB_MULTIPLE_SETTINGS = valkey_settings()
 

--- a/tests/datastore_valkey/test_span_event.py
+++ b/tests/datastore_valkey/test_span_event.py
@@ -14,15 +14,13 @@
 
 import pytest
 import valkey
-
-from newrelic.api.transaction import current_transaction
-from newrelic.api.background_task import background_task
-
 from testing_support.db_settings import valkey_settings
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.util import instance_hostname
+from testing_support.validators.validate_span_events import validate_span_events
 
+from newrelic.api.background_task import background_task
+from newrelic.api.transaction import current_transaction
 
 DB_SETTINGS = valkey_settings()[0]
 DATABASE_NUMBER = 0

--- a/tests/external_aiobotocore/conftest.py
+++ b/tests/external_aiobotocore/conftest.py
@@ -19,10 +19,10 @@ import threading
 
 import moto.server
 import werkzeug.serving
-from testing_support.fixture.event_loop import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_aiobotocore/conftest.py
+++ b/tests/external_aiobotocore/conftest.py
@@ -19,13 +19,8 @@ import threading
 
 import moto.server
 import werkzeug.serving
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 PORT = 4443
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"

--- a/tests/external_aiobotocore/test_aiobotocore_dynamodb.py
+++ b/tests/external_aiobotocore/test_aiobotocore_dynamodb.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    PORT,
-    MotoService,
-    loop,
-)
+from conftest import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, PORT, MotoService, loop
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/external_aiobotocore/test_aiobotocore_dynamodb.py
+++ b/tests/external_aiobotocore/test_aiobotocore_dynamodb.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (  # noqa: F401, pylint: disable=W0611
+from conftest import (
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     PORT,

--- a/tests/external_aiobotocore/test_aiobotocore_s3.py
+++ b/tests/external_aiobotocore/test_aiobotocore_s3.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 
 import aiobotocore
-from conftest import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    PORT,
-    MotoService,
-    loop,
-)
+from conftest import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, PORT, MotoService, loop
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/external_aiobotocore/test_aiobotocore_s3.py
+++ b/tests/external_aiobotocore/test_aiobotocore_s3.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import aiobotocore
-from conftest import (  # noqa: F401, pylint: disable=W0611
+from conftest import (
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     PORT,

--- a/tests/external_aiobotocore/test_aiobotocore_sns.py
+++ b/tests/external_aiobotocore/test_aiobotocore_sns.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    PORT,
-    MotoService,
-    loop,
-)
+from conftest import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, PORT, MotoService, loop
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/external_aiobotocore/test_aiobotocore_sns.py
+++ b/tests/external_aiobotocore/test_aiobotocore_sns.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (  # noqa: F401, pylint: disable=W0611
+from conftest import (
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     PORT,

--- a/tests/external_aiobotocore/test_aiobotocore_sqs.py
+++ b/tests/external_aiobotocore/test_aiobotocore_sqs.py
@@ -13,13 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (
-    AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY,
-    PORT,
-    MotoService,
-    loop,
-)
+from conftest import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, PORT, MotoService, loop
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/external_aiobotocore/test_aiobotocore_sqs.py
+++ b/tests/external_aiobotocore/test_aiobotocore_sqs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from aiobotocore.session import get_session
-from conftest import (  # noqa: F401, pylint: disable=W0611
+from conftest import (
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     PORT,

--- a/tests/external_botocore/conftest.py
+++ b/tests/external_botocore/conftest.py
@@ -20,7 +20,7 @@ import re
 import pytest
 from _mock_external_bedrock_server import MockExternalBedrockServer, extract_shortened_prompt
 from botocore.response import StreamingBody
-from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
     override_application_settings,

--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -34,7 +34,7 @@ from _test_bedrock_chat_completion import (
 )
 from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
+++ b/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
@@ -19,10 +19,7 @@ from _test_bedrock_chat_completion import (
 )
 from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (
-    events_with_context_attrs,
-    set_trace_info,
-)
+from testing_support.ml_testing_utils import events_with_context_attrs, set_trace_info
 from testing_support.validators.validate_custom_event import validate_custom_event_count
 from testing_support.validators.validate_custom_events import validate_custom_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics

--- a/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
+++ b/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
@@ -19,7 +19,7 @@ from _test_bedrock_chat_completion import (
 )
 from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     events_with_context_attrs,
     set_trace_info,
 )

--- a/tests/external_botocore/test_bedrock_embeddings.py
+++ b/tests/external_botocore/test_bedrock_embeddings.py
@@ -27,7 +27,7 @@ from _test_bedrock_embeddings import (
 )
 from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/external_feedparser/conftest.py
+++ b/tests/external_feedparser/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_feedparser/conftest.py
+++ b/tests/external_feedparser/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPServer
 
 _default_settings = {

--- a/tests/external_feedparser/test_feedparser.py
+++ b/tests/external_feedparser/test_feedparser.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import pytest
-from newrelic.api.background_task import background_task
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
 
 
 @pytest.fixture(scope="session")

--- a/tests/external_http/conftest.py
+++ b/tests/external_http/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_http/conftest.py
+++ b/tests/external_http/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
 
 _default_settings = {

--- a/tests/external_http/test_http.py
+++ b/tests/external_http/test_http.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.client
+
 import pytest
 from testing_support.external_fixtures import cache_outgoing_headers, insert_incoming_headers
 from testing_support.fixtures import cat_enabled, override_application_settings
@@ -20,8 +22,6 @@ from testing_support.validators.validate_external_node_params import validate_ex
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-
-import http.client
 
 
 @pytest.fixture(scope="session")

--- a/tests/external_httplib/conftest.py
+++ b/tests/external_httplib/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_httplib/conftest.py
+++ b/tests/external_httplib/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
 
 _default_settings = {

--- a/tests/external_httplib/test_httplib.py
+++ b/tests/external_httplib/test_httplib.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import http.client as httplib
 
+import pytest
 from testing_support.external_fixtures import cache_outgoing_headers, insert_incoming_headers
 from testing_support.fixtures import cat_enabled, override_application_settings
 from testing_support.validators.validate_cross_process_headers import validate_cross_process_headers

--- a/tests/external_httplib/test_urllib.py
+++ b/tests/external_httplib/test_urllib.py
@@ -23,9 +23,9 @@ except:
 
 from testing_support.external_fixtures import cache_outgoing_headers, insert_incoming_headers
 from testing_support.fixtures import cat_enabled
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_cross_process_headers import validate_cross_process_headers
 from testing_support.validators.validate_external_node_params import validate_external_node_params
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 

--- a/tests/external_httplib/test_urllib2.py
+++ b/tests/external_httplib/test_urllib2.py
@@ -13,16 +13,14 @@
 # limitations under the License.
 
 import os
-
-import pytest
-
 import urllib.request as urllib2
 
+import pytest
 from testing_support.external_fixtures import cache_outgoing_headers, insert_incoming_headers
 from testing_support.fixtures import cat_enabled
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_cross_process_headers import validate_cross_process_headers
 from testing_support.validators.validate_external_node_params import validate_external_node_params
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 

--- a/tests/external_httplib2/conftest.py
+++ b/tests/external_httplib2/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_httplib2/conftest.py
+++ b/tests/external_httplib2/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
 
 _default_settings = {

--- a/tests/external_httpx/conftest.py
+++ b/tests/external_httpx/conftest.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_httpx/conftest.py
+++ b/tests/external_httpx/conftest.py
@@ -13,14 +13,9 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
 from testing_support.db_settings import nginx_settings
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/external_httpx/test_client.py
+++ b/tests/external_httpx/test_client.py
@@ -295,7 +295,7 @@ def test_sync_client_event_hook_exception(httpx, mock_server):
 
     def exception_event_hook(response):
         if response.status_code >= 400:
-            raise RuntimeError()
+            raise RuntimeError
 
     def empty_hook(response):
         pass
@@ -341,7 +341,7 @@ def test_async_client_event_hook_exception(httpx, mock_server, loop):
 
     def exception_event_hook(response):
         if response.status_code >= 400:
-            raise RuntimeError()
+            raise RuntimeError
 
     def empty_hook(response):
         pass

--- a/tests/external_requests/conftest.py
+++ b/tests/external_requests/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_requests/conftest.py
+++ b/tests/external_requests/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
 
 _default_settings = {

--- a/tests/external_requests/test_span_event.py
+++ b/tests/external_requests/test_span_event.py
@@ -14,10 +14,10 @@
 
 import pytest
 import requests
-
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.mock_external_http_server import MockExternalHTTPServer
+from testing_support.validators.validate_span_events import validate_span_events
+
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import current_transaction
 

--- a/tests/external_urllib3/conftest.py
+++ b/tests/external_urllib3/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/external_urllib3/conftest.py
+++ b/tests/external_urllib3/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
 
 _default_settings = {

--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -28,7 +28,7 @@ async def index(request):
 
 
 async def hang(request):
-    while True:
+    while True:  # noqa
         await asyncio.sleep(0)
 
 

--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -37,15 +37,15 @@ async def error(request):
 
 
 async def non_500_error(request):
-    raise web.HTTPGone()
+    raise web.HTTPGone
 
 
 async def raise_403(request):
-    raise web.HTTPForbidden()
+    raise web.HTTPForbidden
 
 
 async def raise_404(request):
-    raise web.HTTPNotFound()
+    raise web.HTTPNotFound
 
 
 @function_trace()

--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -28,8 +28,8 @@ async def index(request):
 
 
 async def hang(request):
-    while True:
-        await asyncio.sleep(0)
+    while True:  # noqa: ASYNC110
+        await asyncio.sleep(0)  # noqa: ASYNC110
 
 
 async def error(request):

--- a/tests/framework_aiohttp/_target_application.py
+++ b/tests/framework_aiohttp/_target_application.py
@@ -28,7 +28,7 @@ async def index(request):
 
 
 async def hang(request):
-    while True:  # noqa
+    while True:
         await asyncio.sleep(0)
 
 

--- a/tests/framework_aiohttp/conftest.py
+++ b/tests/framework_aiohttp/conftest.py
@@ -19,13 +19,8 @@ import pytest
 from _target_application import make_app
 from aiohttp.test_utils import AioHTTPTestCase
 from aiohttp.test_utils import TestClient as _TestClient
-from testing_support.fixture.event_loop import (
-    event_loop,
-)
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixture.event_loop import event_loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer, MockExternalHTTPServer
 
 _default_settings = {

--- a/tests/framework_aiohttp/conftest.py
+++ b/tests/framework_aiohttp/conftest.py
@@ -19,10 +19,10 @@ import pytest
 from _target_application import make_app
 from aiohttp.test_utils import AioHTTPTestCase
 from aiohttp.test_utils import TestClient as _TestClient
-from testing_support.fixture.event_loop import (  # noqa: F401 pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_aiohttp/test_client_cat.py
+++ b/tests/framework_aiohttp/test_client_cat.py
@@ -151,8 +151,7 @@ class PoorResolvingConnector(aiohttp.TCPConnector):
     async def _resolve_host(self, host, port, *args, **kwargs):
         res = [{"hostname": host, "host": host, "port": 1234, "family": self._family, "proto": 0, "flags": 0}]
         hosts = await super(PoorResolvingConnector, self)._resolve_host(host, port, *args, **kwargs)
-        for hinfo in hosts:
-            res.append(hinfo)
+        res.extend(hosts)
         return res
 
 

--- a/tests/framework_aiohttp/test_server_cat.py
+++ b/tests/framework_aiohttp/test_server_cat.py
@@ -35,7 +35,7 @@ test_uris = [
 
 def record_aiohttp1_raw_headers(raw_headers):
     try:
-        import aiohttp.protocol  # noqa: F401, pylint: disable=W0611
+        import aiohttp.protocol
     except ImportError:
 
         def pass_through(function):

--- a/tests/framework_ariadne/_target_application.py
+++ b/tests/framework_ariadne/_target_application.py
@@ -16,13 +16,14 @@
 import asyncio
 import json
 
+from graphql import MiddlewareManager
+
 from framework_ariadne._target_schema_async import target_asgi_application as target_asgi_application_async
 from framework_ariadne._target_schema_async import target_schema as target_schema_async
+from framework_ariadne._target_schema_sync import ariadne_version_tuple
 from framework_ariadne._target_schema_sync import target_asgi_application as target_asgi_application_sync
 from framework_ariadne._target_schema_sync import target_schema as target_schema_sync
 from framework_ariadne._target_schema_sync import target_wsgi_application as target_wsgi_application_sync
-from framework_ariadne._target_schema_sync import ariadne_version_tuple
-from graphql import MiddlewareManager
 
 
 def check_response(query, success, response):

--- a/tests/framework_ariadne/_target_schema_async.py
+++ b/tests/framework_ariadne/_target_schema_async.py
@@ -16,8 +16,7 @@ import os
 
 from ariadne import MutationType, QueryType, UnionType, load_schema_from_path, make_executable_schema
 from ariadne.asgi import GraphQL as GraphQLASGI
-from framework_graphql._target_schema_sync import books, magazines, libraries
-
+from framework_graphql._target_schema_sync import books, libraries, magazines
 from testing_support.asgi_testing import AsgiTest
 
 schema_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "schema.graphql")

--- a/tests/framework_ariadne/_target_schema_sync.py
+++ b/tests/framework_ariadne/_target_schema_sync.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import os
-import webtest
 
+import webtest
 from ariadne import MutationType, QueryType, UnionType, load_schema_from_path, make_executable_schema
 from ariadne.wsgi import GraphQL as GraphQLWSGI
-from framework_graphql._target_schema_sync import books, magazines, libraries
-
+from framework_graphql._target_schema_sync import books, libraries, magazines
 from testing_support.asgi_testing import AsgiTest
+
 from framework_ariadne.test_application import ARIADNE_VERSION
 
 ariadne_version_tuple = tuple(map(int, ARIADNE_VERSION.split(".")))

--- a/tests/framework_ariadne/conftest.py
+++ b/tests/framework_ariadne/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_ariadne/conftest.py
+++ b/tests/framework_ariadne/conftest.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_bottle/_target_application.py
+++ b/tests/framework_bottle/_target_application.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import webtest
-
+from bottle import HTTPError, default_app, error, route
 from bottle import __version__ as version
-from bottle import route, error, default_app, HTTPError
 
 version = [int(x) for x in version.split("-")[0].split(".")]
 

--- a/tests/framework_bottle/conftest.py
+++ b/tests/framework_bottle/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_bottle/conftest.py
+++ b/tests/framework_bottle/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_cherrypy/conftest.py
+++ b/tests/framework_cherrypy/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_cherrypy/conftest.py
+++ b/tests/framework_cherrypy/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_cherrypy/test_application.py
+++ b/tests/framework_cherrypy/test_application.py
@@ -34,7 +34,7 @@ class Application:
 
     @cherrypy.expose
     def not_found(self):
-        raise cherrypy.NotFound()
+        raise cherrypy.NotFound
 
     @cherrypy.expose
     def not_found_as_http_error(self):

--- a/tests/framework_cherrypy/test_application.py
+++ b/tests/framework_cherrypy/test_application.py
@@ -19,7 +19,6 @@ from testing_support.fixtures import override_application_settings, override_ign
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 
-
 CHERRYPY_VERSION = tuple(int(v) for v in cherrypy.__version__.split("."))
 
 

--- a/tests/framework_cherrypy/test_dispatch.py
+++ b/tests/framework_cherrypy/test_dispatch.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cherrypy
 import pytest
 import webtest
-
-
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
-
-import cherrypy
 
 is_ge_cherrypy32 = tuple(map(int, cherrypy.__version__.split(".")[:2])) >= (3, 2)
 

--- a/tests/framework_cherrypy/test_resource.py
+++ b/tests/framework_cherrypy/test_resource.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import webtest
-
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-
 import cherrypy
+import webtest
+from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 
 
 class Resource:

--- a/tests/framework_cherrypy/test_routes.py
+++ b/tests/framework_cherrypy/test_routes.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import sys
-import webtest
-
-from testing_support.validators.validate_transaction_errors import validate_transaction_errors
-from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 
 import cherrypy
+import pytest
+import webtest
+from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 
 
 class EndPoint:

--- a/tests/framework_django/_target_application.py
+++ b/tests/framework_django/_target_application.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import webtest
-
 from wsgi import application
-
 
 _target_application = webtest.TestApp(application)

--- a/tests/framework_django/conftest.py
+++ b/tests/framework_django/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_django/conftest.py
+++ b/tests/framework_django/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_django/settings.py
+++ b/tests/framework_django/settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import django
 
 BASE_DIR = os.path.dirname(__file__)

--- a/tests/framework_django/test_asgi_application.py
+++ b/tests/framework_django/test_asgi_application.py
@@ -13,19 +13,20 @@
 # limitations under the License.
 
 import os
-import pytest
-import django
 
-from newrelic.core.config import global_settings
-from newrelic.common.encoding_utils import gzip_decompress
+import django
+import pytest
 from testing_support.fixtures import (
     override_application_settings,
     override_generic_settings,
     override_ignore_status_codes,
 )
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.common.encoding_utils import gzip_decompress
+from newrelic.core.config import global_settings
 
 DJANGO_VERSION = tuple(map(int, django.get_version().split(".")[:2]))
 
@@ -33,7 +34,6 @@ if DJANGO_VERSION[0] < 3:
     pytest.skip("support for asgi added in django 3", allow_module_level=True)
 
 from testing_support.asgi_testing import AsgiTest
-
 
 scoped_metrics = [
     ("Function/django.contrib.sessions.middleware:SessionMiddleware", 1),

--- a/tests/framework_django/views.py
+++ b/tests/framework_django/views.py
@@ -30,11 +30,11 @@ def exception(request):
 
 
 def permission_denied(request):
-    raise PermissionDenied()
+    raise PermissionDenied
 
 
 def middleware_410(request):
-    raise Custom410()
+    raise Custom410
 
 
 class MyView(View):

--- a/tests/framework_falcon/_target_application.py
+++ b/tests/framework_falcon/_target_application.py
@@ -15,7 +15,6 @@
 import falcon
 import webtest
 
-
 try:
     from falcon import HTTPRouteNotFound
 

--- a/tests/framework_falcon/_target_application.py
+++ b/tests/framework_falcon/_target_application.py
@@ -49,10 +49,10 @@ class Index:
 
 class BadResponse:
     def on_get(self, req, resp):
-        raise BadGetRequest()
+        raise BadGetRequest
 
     def on_put(self, req, resp):
-        raise BadPutRequest()
+        raise BadPutRequest
 
 
 try:

--- a/tests/framework_falcon/conftest.py
+++ b/tests/framework_falcon/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_falcon/conftest.py
+++ b/tests/framework_falcon/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_falcon/test_application.py
+++ b/tests/framework_falcon/test_application.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import pytest
-from newrelic.core.config import global_settings
-from testing_support.fixtures import override_ignore_status_codes, override_generic_settings
+from testing_support.fixtures import override_generic_settings, override_ignore_status_codes
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.core.config import global_settings
 
 SETTINGS = global_settings()
 

--- a/tests/framework_fastapi/_target_application.py
+++ b/tests/framework_fastapi/_target_application.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from fastapi import FastAPI
+from testing_support.asgi_testing import AsgiTest
 
 from newrelic.api.transaction import current_transaction
-from testing_support.asgi_testing import AsgiTest
 
 app = FastAPI()
 

--- a/tests/framework_fastapi/conftest.py
+++ b/tests/framework_fastapi/conftest.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-from testing_support.fixtures import (
-    newrelic_caplog as caplog,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
+from testing_support.fixtures import newrelic_caplog as caplog
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_fastapi/conftest.py
+++ b/tests/framework_fastapi/conftest.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     newrelic_caplog as caplog,
 )
 

--- a/tests/framework_fastapi/test_application.py
+++ b/tests/framework_fastapi/test_application.py
@@ -15,8 +15,8 @@
 import logging
 
 import pytest
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 
 @pytest.mark.parametrize(

--- a/tests/framework_flask/_test_application.py
+++ b/tests/framework_flask/_test_application.py
@@ -46,7 +46,7 @@ def abort_404_page():
 
 @application.route("/exception_404")
 def exception_404_page():
-    raise NotFound()
+    raise NotFound
 
 
 @application.route("/template_string")

--- a/tests/framework_flask/_test_application.py
+++ b/tests/framework_flask/_test_application.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import webtest
-
-from flask import Flask, render_template_string, render_template, abort
+from flask import Flask, abort, render_template, render_template_string
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import Rule
 

--- a/tests/framework_flask/_test_application_async.py
+++ b/tests/framework_flask/_test_application_async.py
@@ -14,7 +14,6 @@
 
 import webtest
 from _test_application import application
-
 from conftest import async_handler_support
 
 # Async handlers only supported in Flask >2.0.0

--- a/tests/framework_flask/_test_not_found.py
+++ b/tests/framework_flask/_test_not_found.py
@@ -14,7 +14,6 @@
 
 import pytest
 import webtest
-
 from flask import Flask
 
 application = Flask(__name__)

--- a/tests/framework_flask/_test_user_exceptions.py
+++ b/tests/framework_flask/_test_user_exceptions.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import webtest
-
 from flask import Flask
 
 

--- a/tests/framework_flask/_test_views.py
+++ b/tests/framework_flask/_test_views.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import webtest
-
 import flask
 import flask.views
+import webtest
 
 app = flask.Flask(__name__)
 

--- a/tests/framework_flask/_test_views_async.py
+++ b/tests/framework_flask/_test_views_async.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import webtest
 import flask.views
-
+import webtest
 from _test_views import app
-
 from conftest import async_handler_support
 
 # Async view support added in flask v2

--- a/tests/framework_flask/conftest.py
+++ b/tests/framework_flask/conftest.py
@@ -15,9 +15,7 @@
 import platform
 
 import pytest
-from flask import (
-    __version__ as flask_version,  # required for python 3.7 in lieu of get_package_version_tuple
-)
+from flask import __version__ as flask_version  # required for python 3.7 in lieu of get_package_version_tuple
 
 from newrelic.common.package_version_utils import get_package_version_tuple
 
@@ -28,10 +26,7 @@ except:
     # This only works for flaskmaster
     FLASK_VERSION = get_package_version_tuple("flask")
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_flask/conftest.py
+++ b/tests/framework_flask/conftest.py
@@ -28,7 +28,7 @@ except:
     # This only works for flaskmaster
     FLASK_VERSION = get_package_version_tuple("flask")
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_flask/test_application.py
+++ b/tests/framework_flask/test_application.py
@@ -19,7 +19,6 @@ from testing_support.validators.validate_code_level_metrics import validate_code
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
-
 try:
     # The __version__ attribute was only added in 0.7.0.
     # Flask team does not use semantic versioning during development.

--- a/tests/framework_flask/test_not_found.py
+++ b/tests/framework_flask/test_not_found.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/framework_flask/test_user_exceptions.py
+++ b/tests/framework_flask/test_user_exceptions.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from conftest import (  # pylint: disable=E0611
-    async_handler_support,
-    skip_if_not_async_handler_support,
-)
+from conftest import async_handler_support, skip_if_not_async_handler_support  # pylint: disable=E0611
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics

--- a/tests/framework_graphene/_target_application.py
+++ b/tests/framework_graphene/_target_application.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from framework_graphene.test_application import GRAPHENE_VERSION
+
 from ._target_schema_async import target_schema as target_schema_async
 from ._target_schema_sync import target_schema as target_schema_sync
-from framework_graphene.test_application import GRAPHENE_VERSION
 
 
 def check_response(query, response):

--- a/tests/framework_graphene/_target_schema_async.py
+++ b/tests/framework_graphene/_target_schema_async.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from graphene import Field, Int, List
+from graphene import Field, Int, List, NonNull, ObjectType, Schema, String, Union
 from graphene import Mutation as GrapheneMutation
-from graphene import NonNull, ObjectType, Schema, String, Union
 
-from ._target_schema_sync import Author, Book, Magazine, Item, Library, Storage, authors, books, magazines, libraries
-
+from ._target_schema_sync import Author, Book, Item, Library, Magazine, Storage, authors, books, libraries, magazines
 
 storage = []
 

--- a/tests/framework_graphene/_target_schema_sync.py
+++ b/tests/framework_graphene/_target_schema_sync.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from graphene import Field, Int, List
+from graphene import Field, Int, List, NonNull, ObjectType, Schema, String, Union
 from graphene import Mutation as GrapheneMutation
-from graphene import NonNull, ObjectType, Schema, String, Union
 
 
 class Author(ObjectType):

--- a/tests/framework_graphene/conftest.py
+++ b/tests/framework_graphene/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_graphene/conftest.py
+++ b/tests/framework_graphene/conftest.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_graphene/test_application.py
+++ b/tests/framework_graphene/test_application.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import pytest
-
 from framework_graphql.test_application import *
+
 from newrelic.common.package_version_utils import get_package_version
 
 GRAPHENE_VERSION = get_package_version("graphene")

--- a/tests/framework_graphql/conftest.py
+++ b/tests/framework_graphql/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_graphql/conftest.py
+++ b/tests/framework_graphql/conftest.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
-
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -50,12 +50,12 @@ def to_graphql_source(query):
     return delay_import
 
 
-def example_middleware(next, root, info, **args):
+def example_middleware(next, root, info, **args):  # noqa: A002
     return_value = next(root, info, **args)
     return return_value
 
 
-def error_middleware(next, root, info, **args):
+def error_middleware(next, root, info, **args):  # noqa: A002
     raise RuntimeError("Runtime Error!")
 
 

--- a/tests/framework_graphql/test_application.py
+++ b/tests/framework_graphql/test_application.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-from framework_graphql.test_application_async import error_middleware_async, example_middleware_async
 from testing_support.fixtures import dt_enabled, override_application_settings
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 from testing_support.validators.validate_span_events import validate_span_events
@@ -21,6 +20,7 @@ from testing_support.validators.validate_transaction_count import validate_trans
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
+from framework_graphql.test_application_async import error_middleware_async, example_middleware_async
 from newrelic.api.background_task import background_task
 from newrelic.common.object_names import callable_name
 from newrelic.common.package_version_utils import get_package_version

--- a/tests/framework_graphql/test_application_async.py
+++ b/tests/framework_graphql/test_application_async.py
@@ -16,12 +16,12 @@ from inspect import isawaitable
 
 
 # Async Functions not allowed in Py2
-async def example_middleware_async(next, root, info, **args):
+async def example_middleware_async(next, root, info, **args):  # noqa: A002
     return_value = next(root, info, **args)
     if isawaitable(return_value):
         return await return_value
     return return_value
 
 
-async def error_middleware_async(next, root, info, **args):
+async def error_middleware_async(next, root, info, **args):  # noqa: A002
     raise RuntimeError("Runtime Error!")

--- a/tests/framework_grpc/conftest.py
+++ b/tests/framework_grpc/conftest.py
@@ -16,7 +16,7 @@ import gc
 
 import grpc
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_grpc/conftest.py
+++ b/tests/framework_grpc/conftest.py
@@ -16,12 +16,8 @@ import gc
 
 import grpc
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 from testing_support.mock_external_grpc_server import MockExternalgRPCServer
-
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_grpc/test_distributed_tracing.py
+++ b/tests/framework_grpc/test_distributed_tracing.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 
 import json
-import pytest
-from newrelic.api.application import application_instance
-from newrelic.api.transaction import Transaction, current_transaction
-from newrelic.api.background_task import background_task
-from newrelic.api.external_trace import ExternalTrace
-from newrelic.common.encoding_utils import DistributedTracePayload, W3CTraceParent, W3CTraceState, NrTraceState
 
+import pytest
+from _test_common import create_request, wait_for_transaction_completion
 from testing_support.fixtures import override_application_settings
 from testing_support.validators.validate_span_events import validate_span_events
-from _test_common import create_request, wait_for_transaction_completion
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.application import application_instance
+from newrelic.api.background_task import background_task
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.api.transaction import Transaction, current_transaction
+from newrelic.common.encoding_utils import DistributedTracePayload, NrTraceState, W3CTraceParent, W3CTraceState
 
 _test_matrix = (
     "method_name,streaming_request",

--- a/tests/framework_grpc/test_server.py
+++ b/tests/framework_grpc/test_server.py
@@ -22,10 +22,8 @@ from testing_support.validators.validate_transaction_errors import validate_tran
 from testing_support.validators.validate_transaction_event_attributes import validate_transaction_event_attributes
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
-from newrelic.core.config import global_settings
-
 from newrelic.common.package_version_utils import get_package_version
-
+from newrelic.core.config import global_settings
 
 GRPC_VERSION = get_package_version("grpc")
 

--- a/tests/framework_pyramid/_test_append_slash_app.py
+++ b/tests/framework_pyramid/_test_append_slash_app.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import webtest
-
-from pyramid.response import Response
-from pyramid.view import view_config, notfound_view_config
-from pyramid.config import Configurator
 import pyramid.httpexceptions as exc
+import webtest
+from pyramid.config import Configurator
+from pyramid.response import Response
+from pyramid.view import notfound_view_config, view_config
 
 
 @view_config(route_name="home")

--- a/tests/framework_pyramid/_test_application.py
+++ b/tests/framework_pyramid/_test_application.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pyramid.httpexceptions as exc
 import webtest
-
+from pyramid.config import Configurator
 from pyramid.response import Response
 from pyramid.view import view_config
-from pyramid.config import Configurator
-import pyramid.httpexceptions as exc
 
 
 @view_config(route_name="home")

--- a/tests/framework_pyramid/_test_application.py
+++ b/tests/framework_pyramid/_test_application.py
@@ -37,7 +37,7 @@ def not_found_exception_response(request):
 
 @view_config(route_name="raise_not_found")
 def raise_not_found(request):
-    raise exc.HTTPNotFound()
+    raise exc.HTTPNotFound
 
 
 @view_config(route_name="return_not_found")

--- a/tests/framework_pyramid/conftest.py
+++ b/tests/framework_pyramid/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_pyramid/conftest.py
+++ b/tests/framework_pyramid/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_pyramid/test_cornice.py
+++ b/tests/framework_pyramid/test_cornice.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import pytest
-
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/tests/framework_sanic/_target_application.py
+++ b/tests/framework_sanic/_target_application.py
@@ -19,7 +19,6 @@ from sanic.response import json
 from sanic.router import Router
 from sanic.views import HTTPMethodView
 
-
 try:
     # Old style response streaming
     from sanic.response import stream

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -15,14 +15,9 @@
 import asyncio
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
-from newrelic.common.object_wrapper import (
-    transient_function_wrapper,
-)
+from newrelic.common.object_wrapper import transient_function_wrapper
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -15,12 +15,12 @@
 import asyncio
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )
 
-from newrelic.common.object_wrapper import (  # noqa: F401 pylint: disable=W0611
+from newrelic.common.object_wrapper import (
     transient_function_wrapper,
 )
 

--- a/tests/framework_starlette/_test_graphql.py
+++ b/tests/framework_starlette/_test_graphql.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from graphene import ObjectType, Schema, String
+from graphql.execution.executors.asyncio import AsyncioExecutor
 from starlette.applications import Starlette
+from starlette.graphql import GraphQLApp
 from starlette.routing import Route
 from testing_support.asgi_testing import AsgiTest
-
-from graphene import ObjectType, String, Schema
-from graphql.execution.executors.asyncio import AsyncioExecutor
-from starlette.graphql import GraphQLApp
 
 
 class Query(ObjectType):

--- a/tests/framework_starlette/conftest.py
+++ b/tests/framework_starlette/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_starlette/conftest.py
+++ b/tests/framework_starlette/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_starlette/test_bg_tasks.py
+++ b/tests/framework_starlette/test_bg_tasks.py
@@ -23,7 +23,7 @@ from newrelic.common.package_version_utils import get_package_version_tuple
 starlette_version = get_package_version_tuple("starlette")[:3]
 
 try:
-    from starlette.middleware import Middleware  # noqa: F401
+    from starlette.middleware import Middleware
 
     no_middleware = False
 except ImportError:

--- a/tests/framework_strawberry/_target_application.py
+++ b/tests/framework_strawberry/_target_application.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 
 import pytest
+
 from framework_strawberry._target_schema_async import target_asgi_application as target_asgi_application_async
 from framework_strawberry._target_schema_async import target_schema as target_schema_async
 from framework_strawberry._target_schema_sync import target_asgi_application as target_asgi_application_sync

--- a/tests/framework_strawberry/_target_schema_async.py
+++ b/tests/framework_strawberry/_target_schema_async.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import List, Optional
 
 import strawberry
@@ -22,11 +23,12 @@ try:
 except ImportError:
     import strawberry.types.mutation
 
-from framework_strawberry._target_schema_sync import Item, Library, Storage, books, libraries, magazines
 from strawberry import Schema, field
 from strawberry.asgi import GraphQL
 from strawberry.schema.config import StrawberryConfig
 from testing_support.asgi_testing import AsgiTest
+
+from framework_strawberry._target_schema_sync import Item, Library, Storage, books, libraries, magazines
 
 storage = []
 

--- a/tests/framework_strawberry/_target_schema_async.py
+++ b/tests/framework_strawberry/_target_schema_async.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from typing import List, Optional
 
 import strawberry

--- a/tests/framework_strawberry/_target_schema_sync.py
+++ b/tests/framework_strawberry/_target_schema_sync.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 from typing import List, Optional, Union
 
 import strawberry

--- a/tests/framework_strawberry/_target_schema_sync.py
+++ b/tests/framework_strawberry/_target_schema_sync.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 from typing import List, Optional, Union
 
 import strawberry

--- a/tests/framework_strawberry/conftest.py
+++ b/tests/framework_strawberry/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_strawberry/conftest.py
+++ b/tests/framework_strawberry/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_tornado/conftest.py
+++ b/tests/framework_tornado/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/framework_tornado/conftest.py
+++ b/tests/framework_tornado/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/framework_tornado/test_custom_handler.py
+++ b/tests/framework_tornado/test_custom_handler.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import pytest
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 pytestmark = pytest.mark.custom_app
 

--- a/tests/framework_tornado/test_externals.py
+++ b/tests/framework_tornado/test_externals.py
@@ -18,10 +18,10 @@ import sys
 
 import pytest
 from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer, MockExternalHTTPServer
 from testing_support.validators.validate_distributed_tracing_header import validate_distributed_tracing_header
 from testing_support.validators.validate_outbound_headers import validate_outbound_headers
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTrace

--- a/tests/framework_tornado/test_inbound_cat.py
+++ b/tests/framework_tornado/test_inbound_cat.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import json
+
 import pytest
 from testing_support.fixtures import make_cross_agent_headers, override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_event_attributes import validate_transaction_event_attributes
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 ENCODING_KEY = "1234567890123456789012345678901234567890"
 

--- a/tests/logger_logging/conftest.py
+++ b/tests/logger_logging/conftest.py
@@ -15,7 +15,7 @@
 import logging
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/logger_logging/conftest.py
+++ b/tests/logger_logging/conftest.py
@@ -15,10 +15,7 @@
 import logging
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.api.log import NewRelicLogForwardingHandler
 

--- a/tests/logger_logging/test_attributes.py
+++ b/tests/logger_logging/test_attributes.py
@@ -64,7 +64,7 @@ def test_logging_exc_info_context_attributes(logger):
     try:
         raise RuntimeError("Oops")
     except Exception:
-        logger.error("exc_info", exc_info=True)
+        logger.exception("exc_info")
 
 
 @validate_log_events([{"message": "stack_info"}], required_attrs=["context.stack_info"])

--- a/tests/logger_logging/test_local_decorating.py
+++ b/tests/logger_logging/test_local_decorating.py
@@ -15,7 +15,6 @@
 import platform
 
 import pytest
-
 from testing_support.fixtures import reset_core_stats_engine
 from testing_support.validators.validate_log_event_count import validate_log_event_count
 from testing_support.validators.validate_log_event_count_outside_transaction import (

--- a/tests/logger_logging/test_metrics.py
+++ b/tests/logger_logging/test_metrics.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.background_task import background_task
 from testing_support.fixtures import reset_core_stats_engine
 from testing_support.validators.validate_custom_metrics_outside_transaction import (
     validate_custom_metrics_outside_transaction,
 )
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
 
 
 def exercise_logging(logger):

--- a/tests/logger_logging/test_settings.py
+++ b/tests/logger_logging/test_settings.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import pytest
+from testing_support.fixtures import override_application_settings, reset_core_stats_engine
+from testing_support.validators.validate_log_event_count import validate_log_event_count
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-from testing_support.fixtures import reset_core_stats_engine
-from testing_support.validators.validate_log_event_count import validate_log_event_count
-from testing_support.fixtures import override_application_settings
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 
 def basic_logging(logger):

--- a/tests/logger_loguru/conftest.py
+++ b/tests/logger_loguru/conftest.py
@@ -15,7 +15,7 @@
 import logging
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/logger_loguru/conftest.py
+++ b/tests/logger_loguru/conftest.py
@@ -15,10 +15,7 @@
 import logging
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/logger_structlog/conftest.py
+++ b/tests/logger_structlog/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/logger_structlog/conftest.py
+++ b/tests/logger_structlog/conftest.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.api.time_trace import current_trace
 from newrelic.api.transaction import current_transaction

--- a/tests/logger_structlog/test_attributes.py
+++ b/tests/logger_structlog/test_attributes.py
@@ -73,7 +73,7 @@ def test_structlog_exc_info_context_attributes(logger):
     try:
         raise RuntimeError("Oops")
     except Exception:
-        logger.error("exc_info", exc_info=True)
+        logger.exception("exc_info")
 
 
 @validate_log_events([{"message": "stack_info"}], required_attrs=["context.stack"])

--- a/tests/logger_structlog/test_local_decorating.py
+++ b/tests/logger_structlog/test_local_decorating.py
@@ -14,13 +14,14 @@
 
 import platform
 
-from newrelic.api.application import application_settings
-from newrelic.api.background_task import background_task
 from testing_support.fixtures import reset_core_stats_engine
 from testing_support.validators.validate_log_event_count import validate_log_event_count
 from testing_support.validators.validate_log_event_count_outside_transaction import (
     validate_log_event_count_outside_transaction,
 )
+
+from newrelic.api.application import application_settings
+from newrelic.api.background_task import background_task
 
 
 def get_metadata_string(log_message, is_txn):

--- a/tests/logger_structlog/test_metrics.py
+++ b/tests/logger_structlog/test_metrics.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.api.background_task import background_task
 from testing_support.fixtures import reset_core_stats_engine
-from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_custom_metrics_outside_transaction import (
     validate_custom_metrics_outside_transaction,
 )
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
+from newrelic.api.background_task import background_task
 
 _test_logging_unscoped_metrics = [
     ("Logging/lines", 3),

--- a/tests/messagebroker_confluentkafka/conftest.py
+++ b/tests/messagebroker_confluentkafka/conftest.py
@@ -17,10 +17,7 @@ import uuid
 
 import pytest
 from testing_support.db_settings import kafka_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import transient_function_wrapper

--- a/tests/messagebroker_confluentkafka/conftest.py
+++ b/tests/messagebroker_confluentkafka/conftest.py
@@ -176,7 +176,7 @@ def topic(broker):
     admin = AdminClient({"bootstrap.servers": broker})
     new_topics = [NewTopic(topic, num_partitions=1, replication_factor=1)]
     topics = admin.create_topics(new_topics)
-    for _, f in topics.items():
+    for f in topics.values():
         f.result()  # Block until topic is created.
 
     yield topic

--- a/tests/messagebroker_confluentkafka/conftest.py
+++ b/tests/messagebroker_confluentkafka/conftest.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 from testing_support.db_settings import kafka_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/messagebroker_kafkapython/conftest.py
+++ b/tests/messagebroker_kafkapython/conftest.py
@@ -18,7 +18,7 @@ import uuid
 import kafka
 import pytest
 from testing_support.db_settings import kafka_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/messagebroker_kafkapython/conftest.py
+++ b/tests/messagebroker_kafkapython/conftest.py
@@ -18,10 +18,7 @@ import uuid
 import kafka
 import pytest
 from testing_support.db_settings import kafka_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import transient_function_wrapper

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -172,7 +172,7 @@ def test_distributed_tracing_headers(topic, producer, consumer, serialize, expec
 @pytest.fixture()
 def consumer_next_raises(consumer):
     def _poll(*args, **kwargs):
-        raise RuntimeError()
+        raise RuntimeError
 
     consumer.poll = _poll
     return consumer

--- a/tests/messagebroker_pika/conftest.py
+++ b/tests/messagebroker_pika/conftest.py
@@ -20,7 +20,7 @@ import pytest
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 from testing_support.db_settings import rabbitmq_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/messagebroker_pika/conftest.py
+++ b/tests/messagebroker_pika/conftest.py
@@ -16,14 +16,10 @@ import uuid
 
 import pika
 import pytest
+from testing_support.db_settings import rabbitmq_settings
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 from newrelic.common.package_version_utils import get_package_version_tuple
-
-from testing_support.db_settings import rabbitmq_settings
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
 
 PIKA_VERSION_INFO = get_package_version_tuple("pika")
 

--- a/tests/messagebroker_pika/test_memory_leak.py
+++ b/tests/messagebroker_pika/test_memory_leak.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import gc
-import pika
 
-from newrelic.api.background_task import background_task
+import pika
 from testing_support.db_settings import rabbitmq_settings
 
+from newrelic.api.background_task import background_task
 
 DB_SETTINGS = rabbitmq_settings()[0]
 

--- a/tests/messagebroker_pika/test_pika_async_connection_consume.py
+++ b/tests/messagebroker_pika/test_pika_async_connection_consume.py
@@ -18,8 +18,7 @@ import pika
 import pytest
 import tornado
 from compat import basic_consume
-from conftest import BODY, CORRELATION_ID, EXCHANGE, EXCHANGE_2, HEADERS, QUEUE, QUEUE_2, REPLY_TO
-from conftest import PIKA_VERSION_INFO
+from conftest import BODY, CORRELATION_ID, EXCHANGE, EXCHANGE_2, HEADERS, PIKA_VERSION_INFO, QUEUE, QUEUE_2, REPLY_TO
 from pika.adapters.tornado_connection import TornadoConnection
 from testing_support.db_settings import rabbitmq_settings
 from testing_support.fixtures import (

--- a/tests/messagebroker_pika/test_pika_blocking_connection_consume_generator.py
+++ b/tests/messagebroker_pika/test_pika_blocking_connection_consume_generator.py
@@ -118,7 +118,7 @@ def test_blocking_connection_consume_exception_in_for_loop(producer):
             # We should still create the metric in this case even if there is
             # an exception
             for result in channel.consume(QUEUE):
-                1 / 0  # noqa
+                1 / 0
         except ZeroDivisionError:
             # Expected error
             pass

--- a/tests/mlmodel_langchain/_mock_external_openai_server.py
+++ b/tests/mlmodel_langchain/_mock_external_openai_server.py
@@ -519,7 +519,7 @@ def extract_shortened_prompt(openai_version):
 def get_openai_version():
     # Import OpenAI so that get package version can catpure the version from the
     # system module. OpenAI does not have a package version in v0.
-    import openai  # noqa: F401; pylint: disable=W0611
+    import openai
 
     return get_package_version_tuple("openai")
 

--- a/tests/mlmodel_langchain/conftest.py
+++ b/tests/mlmodel_langchain/conftest.py
@@ -16,7 +16,7 @@ import json
 import os
 
 import pytest
-from _mock_external_openai_server import (  # noqa: F401; pylint: disable=W0611
+from _mock_external_openai_server import (
     MockExternalOpenAIServer,
     extract_shortened_prompt,
     get_openai_version,
@@ -24,10 +24,10 @@ from _mock_external_openai_server import (  # noqa: F401; pylint: disable=W0611
     simple_get,
 )
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
     override_application_settings,

--- a/tests/mlmodel_langchain/conftest.py
+++ b/tests/mlmodel_langchain/conftest.py
@@ -24,9 +24,7 @@ from _mock_external_openai_server import (
     simple_get,
 )
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,

--- a/tests/mlmodel_langchain/new_vectorstore_adder.py
+++ b/tests/mlmodel_langchain/new_vectorstore_adder.py
@@ -27,14 +27,16 @@ def add_to_config(directory, instrumented_class=None):
         text = file.read()
         text = text.replace(
             "VectorStores with similarity_search method",
-            dedent(f"""
-                VectorStores with similarity_search method
-                    _process_module_definition(
-                        "{directory}",
-                        "newrelic.hooks.mlmodel_langchain",
-                        "instrument_langchain_vectorstore_similarity_search",
-                    )
-            """.lstrip("\n")),
+            dedent(
+                f"""
+                    VectorStores with similarity_search method
+                        _process_module_definition(
+                            "{directory}",
+                            "newrelic.hooks.mlmodel_langchain",
+                            "instrument_langchain_vectorstore_similarity_search",
+                        )
+                """.lstrip("\n")
+            ),
             1,
         )
         file.seek(0)

--- a/tests/mlmodel_langchain/new_vectorstore_adder.py
+++ b/tests/mlmodel_langchain/new_vectorstore_adder.py
@@ -7,6 +7,7 @@ copy of the newrelic-python-agent repository.
 """
 
 import os
+from textwrap import dedent
 
 from langchain_community import vectorstores
 
@@ -26,12 +27,14 @@ def add_to_config(directory, instrumented_class=None):
         text = file.read()
         text = text.replace(
             "VectorStores with similarity_search method",
-            "VectorStores with similarity_search method\n    "
-            + "_process_module_definition(\n        "
-            + f'"{directory}",\n        '
-            + '"newrelic.hooks.mlmodel_langchain",\n        '
-            + '"instrument_langchain_vectorstore_similarity_search",\n    '
-            + ")\n",
+            dedent(f"""
+                VectorStores with similarity_search method
+                    _process_module_definition(
+                        "{directory}",
+                        "newrelic.hooks.mlmodel_langchain",
+                        "instrument_langchain_vectorstore_similarity_search",
+                    )
+            """.lstrip("\n")),
             1,
         )
         file.seek(0)

--- a/tests/mlmodel_langchain/test_chain.py
+++ b/tests/mlmodel_langchain/test_chain.py
@@ -24,7 +24,7 @@ from langchain.chains.openai_functions import create_structured_output_chain, cr
 from langchain_community.vectorstores.faiss import FAISS
 from mock import patch
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_sans_content,

--- a/tests/mlmodel_langchain/test_tool.py
+++ b/tests/mlmodel_langchain/test_tool.py
@@ -22,7 +22,7 @@ import pytest
 from langchain.tools import tool
 from mock import patch
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_with_context_attrs,

--- a/tests/mlmodel_langchain/test_vectorstore.py
+++ b/tests/mlmodel_langchain/test_vectorstore.py
@@ -20,7 +20,7 @@ import pytest
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_community.vectorstores.faiss import FAISS
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_with_context_attrs,

--- a/tests/mlmodel_openai/_mock_external_openai_server.py
+++ b/tests/mlmodel_openai/_mock_external_openai_server.py
@@ -746,7 +746,7 @@ def extract_shortened_prompt(openai_version):
 def get_openai_version():
     # Import OpenAI so that get package version can catpure the version from the
     # system module. OpenAI does not have a package version in v0.
-    import openai  # noqa: F401; pylint: disable=W0611
+    import openai
 
     return get_package_version_tuple("openai")
 

--- a/tests/mlmodel_openai/conftest.py
+++ b/tests/mlmodel_openai/conftest.py
@@ -16,17 +16,17 @@ import json
 import os
 
 import pytest
-from _mock_external_openai_server import (  # noqa: F401; pylint: disable=W0611
+from _mock_external_openai_server import (
     MockExternalOpenAIServer,
     extract_shortened_prompt,
     get_openai_version,
     openai_version,
     simple_get,
 )
-from testing_support.fixture.event_loop import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixture.event_loop import (
     event_loop as loop,
 )
-from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
     override_application_settings,

--- a/tests/mlmodel_openai/conftest.py
+++ b/tests/mlmodel_openai/conftest.py
@@ -23,9 +23,7 @@ from _mock_external_openai_server import (
     openai_version,
     simple_get,
 )
-from testing_support.fixture.event_loop import (
-    event_loop as loop,
-)
+from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,

--- a/tests/mlmodel_openai/test_chat_completion.py
+++ b/tests/mlmodel_openai/test_chat_completion.py
@@ -14,7 +14,7 @@
 
 import openai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_openai/test_chat_completion_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_error.py
@@ -16,7 +16,7 @@
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_chat_completion_error_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_error_v1.py
@@ -15,7 +15,7 @@
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_chat_completion_stream.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream.py
@@ -14,7 +14,7 @@
 
 import openai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_openai/test_chat_completion_stream_error.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_error.py
@@ -16,7 +16,7 @@
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_error_v1.py
@@ -16,7 +16,7 @@
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_chat_completion_stream_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_v1.py
@@ -16,7 +16,7 @@ import openai
 import pytest
 from conftest import get_openai_version  # pylint: disable=E0611
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_openai/test_chat_completion_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_v1.py
@@ -14,7 +14,7 @@
 
 import openai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_openai/test_embeddings.py
+++ b/tests/mlmodel_openai/test_embeddings.py
@@ -18,7 +18,7 @@ from testing_support.fixtures import (  # override_application_settings,
     reset_core_stats_engine,
     validate_attributes,
 )
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_openai/test_embeddings_error.py
+++ b/tests/mlmodel_openai/test_embeddings_error.py
@@ -15,7 +15,7 @@
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_embeddings_error_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_error_v1.py
@@ -17,7 +17,7 @@ import sys
 import openai
 import pytest
 from testing_support.fixtures import dt_enabled, override_llm_token_callback_settings, reset_core_stats_engine
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     events_sans_content,

--- a/tests/mlmodel_openai/test_embeddings_stream_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_stream_v1.py
@@ -15,7 +15,7 @@
 import pytest
 from conftest import get_openai_version  # pylint: disable=E0611
 from testing_support.fixtures import reset_core_stats_engine
-from testing_support.ml_testing_utils import set_trace_info  # noqa: F401
+from testing_support.ml_testing_utils import set_trace_info
 from testing_support.validators.validate_custom_event import validate_custom_event_count
 
 from newrelic.api.background_task import background_task

--- a/tests/mlmodel_openai/test_embeddings_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_v1.py
@@ -14,7 +14,7 @@
 
 import openai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
-from testing_support.ml_testing_utils import (  # noqa: F401
+from testing_support.ml_testing_utils import (
     add_token_count_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,

--- a/tests/mlmodel_sklearn/conftest.py
+++ b/tests/mlmodel_sklearn/conftest.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sklearn import __version__  # noqa: this is needed for get_package_version
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from sklearn import __version__
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/mlmodel_sklearn/conftest.py
+++ b/tests/mlmodel_sklearn/conftest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from sklearn import __version__  # noqa: this is needed for get_package_version
-from testing_support.fixtures import (  # noqa: F401, pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -15,7 +15,7 @@
 import sys
 
 import numpy as np
-import pandas
+import pandas as pd
 from testing_support.fixtures import override_application_settings, reset_core_stats_engine
 from testing_support.fixtures import override_application_settings
 from testing_support.validators.validate_ml_event_count import validate_ml_event_count
@@ -50,11 +50,11 @@ def test_pandas_df_categorical_feature_event():
 
         clf = getattr(sklearn.tree, "DecisionTreeClassifier")(random_state=0)
         model = clf.fit(
-            pandas.DataFrame({"col1": [27.0, 24.0], "col2": [23.0, 25.0]}, dtype="category"),
-            pandas.DataFrame({"label": [27.0, 28.0]}),
+            pd.DataFrame({"col1": [27.0, 24.0], "col2": [23.0, 25.0]}, dtype="category"),
+            pd.DataFrame({"label": [27.0, 28.0]}),
         )
 
-        labels = model.predict(pandas.DataFrame({"col1": [2.0], "col2": [4.0]}, dtype="category"))
+        labels = model.predict(pd.DataFrame({"col1": [2.0], "col2": [4.0]}, dtype="category"))
         return model
 
     _test()
@@ -89,9 +89,9 @@ def test_pandas_df_bool_feature_event():
         import sklearn.tree
 
         dtype_name = "bool" if sys.version_info < (3, 8) else "boolean"
-        x_train = pandas.DataFrame({"col1": [True, False], "col2": [True, False]}, dtype=dtype_name)
-        y_train = pandas.DataFrame({"label": [True, False]}, dtype=dtype_name)
-        x_test = pandas.DataFrame({"col1": [True], "col2": [True]}, dtype=dtype_name)
+        x_train = pd.DataFrame({"col1": [True, False], "col2": [True, False]}, dtype=dtype_name)
+        y_train = pd.DataFrame({"label": [True, False]}, dtype=dtype_name)
+        x_test = pd.DataFrame({"col1": [True], "col2": [True]}, dtype=dtype_name)
 
         clf = getattr(sklearn.tree, "DecisionTreeClassifier")(random_state=0)
         model = clf.fit(x_train, y_train)
@@ -127,9 +127,9 @@ def test_pandas_df_float_feature_event():
     def _test():
         import sklearn.tree
 
-        x_train = pandas.DataFrame({"col1": [120.0, 254.0], "col2": [236.9, 234.5]}, dtype="float64")
-        y_train = pandas.DataFrame({"label": [345.6, 456.7]}, dtype="float64")
-        x_test = pandas.DataFrame({"col1": [100.0], "col2": [300.0]}, dtype="float64")
+        x_train = pd.DataFrame({"col1": [120.0, 254.0], "col2": [236.9, 234.5]}, dtype="float64")
+        y_train = pd.DataFrame({"label": [345.6, 456.7]}, dtype="float64")
+        x_test = pd.DataFrame({"col1": [100.0], "col2": [300.0]}, dtype="float64")
 
         clf = getattr(sklearn.tree, "DecisionTreeRegressor")(random_state=0)
 

--- a/tests/mlmodel_sklearn/test_inference_events.py
+++ b/tests/mlmodel_sklearn/test_inference_events.py
@@ -17,7 +17,6 @@ import sys
 import numpy as np
 import pandas as pd
 from testing_support.fixtures import override_application_settings, reset_core_stats_engine
-from testing_support.fixtures import override_application_settings
 from testing_support.validators.validate_ml_event_count import validate_ml_event_count
 from testing_support.validators.validate_ml_events import validate_ml_events
 

--- a/tests/mlmodel_sklearn/test_ml_model.py
+++ b/tests/mlmodel_sklearn/test_ml_model.py
@@ -14,7 +14,7 @@
 
 import logging
 
-import pandas
+import pandas as pd
 from testing_support.fixtures import reset_core_stats_engine
 from testing_support.validators.validate_ml_event_count import validate_ml_event_count
 from testing_support.validators.validate_ml_events import validate_ml_events
@@ -174,9 +174,9 @@ def test_wrapper_attrs_custom_model_pandas_df():
     @validate_ml_events(pandas_df_recorded_custom_events)
     @background_task()
     def _test():
-        x_train = pandas.DataFrame({"col1": [0, 1], "col2": [0, 1], "col3": [1, 2]}, dtype="category")
+        x_train = pd.DataFrame({"col1": [0, 1], "col2": [0, 1], "col3": [1, 2]}, dtype="category")
         y_train = [0, 1]
-        x_test = pandas.DataFrame({"col1": [0], "col2": [0], "col3": [1]}, dtype="category")
+        x_test = pd.DataFrame({"col1": [0], "col2": [0], "col3": [1]}, dtype="category")
 
         model = CustomTestModel(random_state=0).fit(x_train, y_train)
         wrap_mlmodel(
@@ -217,9 +217,9 @@ def test_wrapper_attrs_builtin_model():
     def _test():
         import sklearn.tree
 
-        x_train = pandas.DataFrame({"col1": [0, 0], "col2": [1, 1]}, dtype="int")
-        y_train = pandas.DataFrame({"label": [0, 1]}, dtype="int")
-        x_test = pandas.DataFrame({"col1": [12], "col2": [14]}, dtype="int")
+        x_train = pd.DataFrame({"col1": [0, 0], "col2": [1, 1]}, dtype="int")
+        y_train = pd.DataFrame({"label": [0, 1]}, dtype="int")
+        x_test = pd.DataFrame({"col1": [12], "col2": [14]}, dtype="int")
 
         clf = getattr(sklearn.tree, "DecisionTreeClassifier")(random_state=0)
 
@@ -264,9 +264,9 @@ def test_wrapper_mismatched_features_and_labels_df():
     def _test():
         import sklearn.tree
 
-        x_train = pandas.DataFrame({"col1": [7, 8], "col2": [9, 10], "col3": [24, 25]}, dtype="int")
-        y_train = pandas.DataFrame({"label": [0, 1]}, dtype="int")
-        x_test = pandas.DataFrame({"col1": [12], "col2": [14], "col3": [16]}, dtype="int")
+        x_train = pd.DataFrame({"col1": [7, 8], "col2": [9, 10], "col3": [24, 25]}, dtype="int")
+        y_train = pd.DataFrame({"label": [0, 1]}, dtype="int")
+        x_test = pd.DataFrame({"col1": [12], "col2": [14], "col3": [16]}, dtype="int")
 
         clf = getattr(sklearn.tree, "DecisionTreeClassifier")(random_state=0)
 

--- a/tests/template_genshi/conftest.py
+++ b/tests/template_genshi/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/template_genshi/conftest.py
+++ b/tests/template_genshi/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/template_jinja2/conftest.py
+++ b/tests/template_jinja2/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/template_jinja2/conftest.py
+++ b/tests/template_jinja2/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/template_mako/conftest.py
+++ b/tests/template_mako/conftest.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
+from testing_support.fixtures import (
     collector_agent_registration_fixture,
     collector_available_fixture,
 )

--- a/tests/template_mako/conftest.py
+++ b/tests/template_mako/conftest.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import (
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.

--- a/tests/testing_support/external_fixtures.py
+++ b/tests/testing_support/external_fixtures.py
@@ -16,8 +16,8 @@ import http.client as httplib
 
 from newrelic.api.external_trace import ExternalTrace
 from newrelic.api.transaction import current_transaction
-from newrelic.common.object_wrapper import transient_function_wrapper
 from newrelic.common.encoding_utils import json_encode, obfuscate
+from newrelic.common.object_wrapper import transient_function_wrapper
 
 
 def create_incoming_headers(transaction):

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -20,12 +20,9 @@ import subprocess
 import sys
 import threading
 import time
-
 from queue import Queue
 
 import pytest
-
-from testing_support.sample_applications import error_user_params_added, user_attributes_added
 
 from newrelic.admin.record_deploy import record_deploy
 from newrelic.api.application import application_instance, application_settings, register_application
@@ -45,6 +42,7 @@ from newrelic.core.attribute import create_attributes
 from newrelic.core.attribute_filter import DST_ERROR_COLLECTOR, DST_TRANSACTION_TRACER, AttributeFilter
 from newrelic.core.config import apply_config_setting, flatten_settings, global_settings
 from newrelic.network.exceptions import RetryDataForRequest
+from testing_support.sample_applications import error_user_params_added, user_attributes_added
 
 _logger = logging.getLogger("newrelic.tests")
 

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -1345,7 +1345,7 @@ class Environ:
         for key, val in self._environ_dict.items():
             os.environ[key] = str(val)
 
-    def __exit__(self, type, value, traceback):  # pylint: disable=redefined-builtin
+    def __exit__(self, exc, val, tb):
         os.environ.clear()
         os.environ = self._original_environ
 
@@ -1356,7 +1356,7 @@ class TerminatingPopen(subprocess.Popen):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):  # pylint: disable=redefined-builtin,arguments-differ
+    def __exit__(self, exc, val, tb):
         if self.stdout:
             self.stdout.close()
         if self.stderr:

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -311,7 +311,7 @@ def raise_background_exceptions(timeout=5.0):
                 if exc_info[1] is not None:
                     raise exc_info[1]
                 else:
-                    raise exc_info[0]()
+                    raise exc_info[0]
 
         return result
 

--- a/tests/testing_support/ml_testing_utils.py
+++ b/tests/testing_support/ml_testing_utils.py
@@ -14,9 +14,9 @@
 import copy
 
 import pytest
-from testing_support.fixtures import override_application_settings
 
 from newrelic.api.transaction import current_transaction
+from testing_support.fixtures import override_application_settings
 
 disabled_ai_monitoring_settings = override_application_settings({"ai_monitoring.enabled": False})
 disabled_ai_monitoring_streaming_settings = override_application_settings({"ai_monitoring.streaming.enabled": False})

--- a/tests/testing_support/mock_external_grpc_server.py
+++ b/tests/testing_support/mock_external_grpc_server.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent import futures
-import grpc
 import socket
+from concurrent import futures
 
+import grpc
 
 # This defines an external grpc server test apps can use for testing.
 #

--- a/tests/testing_support/mock_external_grpc_server.py
+++ b/tests/testing_support/mock_external_grpc_server.py
@@ -62,7 +62,7 @@ class MockExternalgRPCServer:
         self.server.start()
         return self.server
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, exc, val, tb):
         # Set grace period to None so that the server shuts down immediately
         # when the context manager exits. This will hopefully prevent tests
         # from hanging while waiting for the server to shut down.

--- a/tests/testing_support/mock_external_http_server.py
+++ b/tests/testing_support/mock_external_http_server.py
@@ -14,7 +14,6 @@
 
 import socket
 import threading
-
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 # This defines an external server test apps can make requests to (instead of

--- a/tests/testing_support/mock_external_http_server.py
+++ b/tests/testing_support/mock_external_http_server.py
@@ -92,7 +92,7 @@ class MockExternalHTTPServer(threading.Thread):
         self.start()
         return self
 
-    def __exit__(self, type, value, tb):
+    def __exit__(self, exc, val, tb):
         self.stop()
 
     def run(self):

--- a/tests/testing_support/mock_http_client.py
+++ b/tests/testing_support/mock_http_client.py
@@ -15,7 +15,6 @@
 from urllib.parse import urlencode
 
 import newrelic.packages.urllib3 as urllib3
-
 from newrelic.common.agent_http import BaseClient
 
 

--- a/tests/testing_support/sample_applications.py
+++ b/tests/testing_support/sample_applications.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import logging
-
-from urllib.request import urlopen
-
 import sqlite3 as db
+from urllib.request import urlopen
 
 from newrelic.api.time_trace import notice_error
 from newrelic.api.transaction import add_custom_attribute, get_browser_timing_header, record_custom_event

--- a/tests/testing_support/validators/validate_apdex_metrics.py
+++ b/tests/testing_support/validators/validate_apdex_metrics.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from testing_support.fixtures import catch_background_exceptions
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
 
 
 def validate_apdex_metrics(name, group="Function", count=1, apdex_t_min=0.5, apdex_t_max=0.5):

--- a/tests/testing_support/validators/validate_application_error_event_count.py
+++ b/tests/testing_support/validators/validate_application_error_event_count.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import core_application_stats_engine
-
 from newrelic.common.object_wrapper import function_wrapper
+from testing_support.fixtures import core_application_stats_engine
 
 
 def validate_application_error_event_count(num_errors):

--- a/tests/testing_support/validators/validate_application_error_trace_count.py
+++ b/tests/testing_support/validators/validate_application_error_trace_count.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import core_application_stats_engine
-
 from newrelic.common.object_wrapper import function_wrapper
+from testing_support.fixtures import core_application_stats_engine
 
 
 def validate_application_error_trace_count(num_errors):

--- a/tests/testing_support/validators/validate_code_level_metrics.py
+++ b/tests/testing_support/validators/validate_code_level_metrics.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.validators.validate_span_events import validate_span_events
-from testing_support.fixtures import dt_enabled
 from newrelic.common.object_wrapper import function_wrapper
+from testing_support.fixtures import dt_enabled
+from testing_support.validators.validate_span_events import validate_span_events
 
 
 def validate_code_level_metrics(namespace, function, builtin=False, count=1, index=-1):

--- a/tests/testing_support/validators/validate_custom_event.py
+++ b/tests/testing_support/validators/validate_custom_event.py
@@ -14,9 +14,8 @@
 
 import time
 
-from testing_support.fixtures import core_application_stats_engine
-
 from newrelic.common.object_wrapper import function_wrapper
+from testing_support.fixtures import core_application_stats_engine
 
 
 def _validate_custom_event(recorded_event, required_event):

--- a/tests/testing_support/validators/validate_custom_events.py
+++ b/tests/testing_support/validators/validate_custom_events.py
@@ -15,9 +15,8 @@
 import copy
 import time
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_custom_events(events):

--- a/tests/testing_support/validators/validate_custom_metrics_outside_transaction.py
+++ b/tests/testing_support/validators/validate_custom_metrics_outside_transaction.py
@@ -14,8 +14,8 @@
 
 import copy
 
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from testing_support.fixtures import catch_background_exceptions
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
 
 
 def validate_custom_metrics_outside_transaction(custom_metrics=None):

--- a/tests/testing_support/validators/validate_database_node.py
+++ b/tests/testing_support/validators/validate_database_node.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_database_node(validator):

--- a/tests/testing_support/validators/validate_database_trace_inputs.py
+++ b/tests/testing_support/validators/validate_database_trace_inputs.py
@@ -14,7 +14,6 @@
 
 
 from newrelic.common.object_wrapper import transient_function_wrapper
-
 from testing_support.fixtures import catch_background_exceptions
 
 

--- a/tests/testing_support/validators/validate_datastore_trace_inputs.py
+++ b/tests/testing_support/validators/validate_datastore_trace_inputs.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 """
 operation: method name

--- a/tests/testing_support/validators/validate_dimensional_metrics_outside_transaction.py
+++ b/tests/testing_support/validators/validate_dimensional_metrics_outside_transaction.py
@@ -14,8 +14,8 @@
 
 import copy
 
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from testing_support.fixtures import catch_background_exceptions
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
 
 
 def validate_dimensional_metrics_outside_transaction(dimensional_metrics=None):

--- a/tests/testing_support/validators/validate_error_event_attributes.py
+++ b/tests/testing_support/validators/validate_error_event_attributes.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import check_event_attributes
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import check_event_attributes
 
 
 def validate_error_event_attributes(required_params=None, forgone_params=None, exact_attrs=None):

--- a/tests/testing_support/validators/validate_error_event_attributes.py
+++ b/tests/testing_support/validators/validate_error_event_attributes.py
@@ -36,8 +36,7 @@ def validate_error_event_attributes(required_params=None, forgone_params=None, e
                 raise
 
             event_data = instance.error_events
-            for sample in event_data:
-                error_data_samples.append(sample)
+            error_data_samples.extend(event_data)
 
             check_event_attributes(event_data, required_params, forgone_params, exact_attrs)
 

--- a/tests/testing_support/validators/validate_error_event_attributes_outside_transaction.py
+++ b/tests/testing_support/validators/validate_error_event_attributes_outside_transaction.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import check_event_attributes
-
 from newrelic.common.object_wrapper import transient_function_wrapper
+from testing_support.fixtures import check_event_attributes
 
 
 def validate_error_event_attributes_outside_transaction(

--- a/tests/testing_support/validators/validate_error_trace_attributes.py
+++ b/tests/testing_support/validators/validate_error_trace_attributes.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from testing_support.fixtures import check_error_attributes
-
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
 
 
 def validate_error_trace_attributes(err_name, required_params=None, forgone_params=None, exact_attrs=None):

--- a/tests/testing_support/validators/validate_error_trace_attributes_outside_transaction.py
+++ b/tests/testing_support/validators/validate_error_trace_attributes_outside_transaction.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import check_error_attributes, core_application_stats_engine_error
-
 from newrelic.common.object_wrapper import transient_function_wrapper
+from testing_support.fixtures import check_error_attributes, core_application_stats_engine_error
 
 
 def validate_error_trace_attributes_outside_transaction(

--- a/tests/testing_support/validators/validate_function_called.py
+++ b/tests/testing_support/validators/validate_function_called.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_function_called(module, name):

--- a/tests/testing_support/validators/validate_internal_metrics.py
+++ b/tests/testing_support/validators/validate_internal_metrics.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
-from newrelic.core.stats_engine import CustomMetrics
 from newrelic.core.internal_metrics import InternalTraceContext
+from newrelic.core.stats_engine import CustomMetrics
 
 
 def validate_internal_metrics(metrics=None):

--- a/tests/testing_support/validators/validate_log_event_collector_json.py
+++ b/tests/testing_support/validators/validate_log_event_collector_json.py
@@ -15,7 +15,7 @@
 import json
 
 from newrelic.common.encoding_utils import json_encode
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_log_event_collector_json(num_logs=1):

--- a/tests/testing_support/validators/validate_log_event_count.py
+++ b/tests/testing_support/validators/validate_log_event_count.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_log_event_count(count=1):

--- a/tests/testing_support/validators/validate_log_event_count_outside_transaction.py
+++ b/tests/testing_support/validators/validate_log_event_count_outside_transaction.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_log_event_count_outside_transaction(count=1):

--- a/tests/testing_support/validators/validate_log_events.py
+++ b/tests/testing_support/validators/validate_log_events.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_log_events(events=None, required_attrs=None, forgone_attrs=None):

--- a/tests/testing_support/validators/validate_log_events_outside_transaction.py
+++ b/tests/testing_support/validators/validate_log_events_outside_transaction.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_log_events_outside_transaction(events=None, required_attrs=None, forgone_attrs=None):

--- a/tests/testing_support/validators/validate_messagebroker_headers.py
+++ b/tests/testing_support/validators/validate_messagebroker_headers.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import function_wrapper
 from newrelic.api.transaction import current_transaction
+from newrelic.common.object_wrapper import function_wrapper
 from testing_support.validators.validate_distributed_tracing_header import validate_distributed_tracing_header
 from testing_support.validators.validate_outbound_headers import validate_outbound_headers
 

--- a/tests/testing_support/validators/validate_metric_payload.py
+++ b/tests/testing_support/validators/validate_metric_payload.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_metric_payload(metrics=[]):

--- a/tests/testing_support/validators/validate_ml_event_count.py
+++ b/tests/testing_support/validators/validate_ml_event_count.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_ml_event_count(count=1):

--- a/tests/testing_support/validators/validate_ml_event_count_outside_transaction.py
+++ b/tests/testing_support/validators/validate_ml_event_count_outside_transaction.py
@@ -14,9 +14,8 @@
 
 import copy
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_ml_event_count_outside_transaction(count=1):

--- a/tests/testing_support/validators/validate_ml_events.py
+++ b/tests/testing_support/validators/validate_ml_events.py
@@ -15,9 +15,8 @@
 import copy
 import time
 
-from testing_support.fixtures import catch_background_exceptions
-
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
+from testing_support.fixtures import catch_background_exceptions
 
 
 def validate_ml_events(events):

--- a/tests/testing_support/validators/validate_ml_events_outside_transaction.py
+++ b/tests/testing_support/validators/validate_ml_events_outside_transaction.py
@@ -14,10 +14,9 @@
 
 import copy
 
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from testing_support.fixtures import catch_background_exceptions
 from testing_support.validators.validate_ml_events import _check_event_attributes, _event_details
-
-from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_ml_events_outside_transaction(events):

--- a/tests/testing_support/validators/validate_non_transaction_error_event.py
+++ b/tests/testing_support/validators/validate_non_transaction_error_event.py
@@ -14,9 +14,8 @@
 
 from time import time
 
-from testing_support.fixtures import core_application_stats_engine
-
 from newrelic.common.object_wrapper import function_wrapper
+from testing_support.fixtures import core_application_stats_engine
 
 
 def validate_non_transaction_error_event(required_intrinsics=None, num_errors=1, required_user=None, forgone_user=None):

--- a/tests/testing_support/validators/validate_outbound_headers.py
+++ b/tests/testing_support/validators/validate_outbound_headers.py
@@ -15,7 +15,6 @@
 from newrelic.api.transaction import current_transaction
 from newrelic.common.encoding_utils import deobfuscate, json_decode
 
-
 OUTBOUND_TRACE_KEYS_REQUIRED = ("ty", "ac", "ap", "tr", "pr", "sa", "ti")
 
 

--- a/tests/testing_support/validators/validate_serverless_data.py
+++ b/tests/testing_support/validators/validate_serverless_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_serverless_data(expected_methods=(), forgone_methods=()):

--- a/tests/testing_support/validators/validate_serverless_metadata.py
+++ b/tests/testing_support/validators/validate_serverless_metadata.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.encoding_utils import serverless_payload_decode, json_decode
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.encoding_utils import json_decode, serverless_payload_decode
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_serverless_metadata(exact_metadata=None):

--- a/tests/testing_support/validators/validate_serverless_payload.py
+++ b/tests/testing_support/validators/validate_serverless_payload.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.encoding_utils import serverless_payload_decode, json_decode
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.encoding_utils import json_decode, serverless_payload_decode
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_serverless_payload(count=1):

--- a/tests/testing_support/validators/validate_sql_obfuscation.py
+++ b/tests/testing_support/validators/validate_sql_obfuscation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_sql_obfuscation(expected_sqls):

--- a/tests/testing_support/validators/validate_synthetics_event.py
+++ b/tests/testing_support/validators/validate_synthetics_event.py
@@ -37,8 +37,7 @@ def validate_synthetics_event(required_attrs=None, forgone_attrs=None, should_ex
                 def _flatten(event):
                     result = {}
                     for elem in event:
-                        for k, v in elem.items():
-                            result[k] = v
+                        result.update({k: v for k, v in elem.items()})
                     return result
 
                 flat_event = _flatten(event)

--- a/tests/testing_support/validators/validate_transaction_count.py
+++ b/tests/testing_support/validators/validate_transaction_count.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.object_wrapper import transient_function_wrapper, function_wrapper
+from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 
 
 def validate_transaction_count(count):

--- a/tests/testing_support/validators/validate_transaction_error_trace_attributes.py
+++ b/tests/testing_support/validators/validate_transaction_error_trace_attributes.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-from testing_support.fixtures import check_error_attributes
-
 from newrelic.common.object_wrapper import transient_function_wrapper
+from testing_support.fixtures import check_error_attributes
 
 
 def validate_transaction_error_trace_attributes(required_params=None, forgone_params=None, exact_attrs=None):

--- a/tests/testing_support/validators/validate_transaction_trace_attributes.py
+++ b/tests/testing_support/validators/validate_transaction_trace_attributes.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from testing_support.fixtures import check_attributes
-
 from newrelic.common.encoding_utils import unpack_field
 from newrelic.common.object_wrapper import function_wrapper, transient_function_wrapper
 from newrelic.core.database_utils import SQLConnections
+from testing_support.fixtures import check_attributes
 
 
 def validate_transaction_trace_attributes(


### PR DESCRIPTION
# Rationale

Running our large amount of linters has proved ineffective. There is a large amount of spam for 100s of rule violations on every PR due to old Python 2 or just poorly written code. This results in everyone ignoring the results of the linter for any old files due to alert fatigue, and trains the brain to ignore it for new files as well. We may as well have no linters at all.

To fix this, this PR first disables almost all linters. I'm proposing an incremental code quality cleanup approach, where we get the easiest linters (by number of violations) online and slowly ratchet up our code quality until we have very strict standards. By removing ALL failing linters (or rules from enabled linters) that can't easily be fixed, we can make the linters a hard enforced requirement for merging code. Then over time we fix more and more issues and ratchet up the quality in our codebase. We'll enable linters 1 at a time, and any rules that have too many violations to immediately fix we disable and leave a comment on. Later, we can enable the really bad rules one at a time as well.

This PR therefore disables most linters in the first commit, then slowly improves code quality by cleaning up easy wins turning on only 1 linter per commit, along with the fixes to keep the linters 100% passing. To keep the linters passing even when there's outstanding items, I've disabled a number of rules we flagrantly violate. Those can be readdressed later to further improve quality.

# Overview

This PR should be reviewed 1 commit at a time to see the changes clearly. The commits are descriptive for what linters they are handling.

* Disable most linters in `ruff`.
* Enable linters in individual commits alongside fully fixing all rules violations, adding `# noqa: RULECODE` for intentional violations, or disabling individual rules.
* Finally, run isort to sort imports (technically this is a linter now, run on its own with `ruff check --fix --select=I`).

