### PR TITLE
Pin setuptools to v70.x.x.

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -U pip
-          pip install -U setuptools==75.8.1
+          pip install -U setuptools<71.0.0
 
       - name: Build Source Package
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -U pip
-          pip install -U wheel setuptools==75.8.1 twine
+          pip install -U wheel setuptools<71.0.0 twine
 
       - name: Download Artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # 4.1.4


### PR DESCRIPTION
Pin setuptools to address breaking changes introduced in v71.0.0.
