### PR TITLE
Add Missing MySQL Libs to CI Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"runArgs": ["--network=host"],
 	"features": {
 	// Available Features: https://containers.dev/features
-		// "ghcr.io/devcontainers/features/docker-from-docker:1": {"moby": false},
+		// "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {"moby": false},
 		// "ghcr.io/devcontainers/features/aws-cli:1": {},
 		// "ghcr.io/devcontainers/features/github-cli:1": {}
 	},

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -22,6 +22,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bash \
         build-essential \
         curl \
+        default-libmysqlclient-dev \
         expat \
         fish \
         fontconfig \
@@ -45,6 +46,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         make \
         odbc-postgresql \
         openssl \
+        pkg-config \
         python3-dev \
         python3-pip \
         sudo \


### PR DESCRIPTION
# Overview

* Add missing libs for building `mysqlclient` in CI.
* Update renamed feature in `devcontainer.json`

# Testing

Build is here https://github.com/newrelic/newrelic-python-agent/actions/runs/14043517773