### PR TITLE
Add Wait on Publish Before Triggering Additional Workflows

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -185,6 +185,11 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
+      - name: Wait for release to be available
+        id: wait
+        run: |
+          sleep 60
+
       - name: Create release tags for Lambda and K8s Init Containers
         run: |
           RELEASE_TITLE="New Relic Python Agent ${GITHUB_REF_NAME}.0"


### PR DESCRIPTION
# Overview

* Prevent race condition in publish steps by giving PyPi time to propagate the new release through the CDN.