### PR TITLE
Enable pylint

### DIFF
--- a/newrelic/api/database_trace.py
+++ b/newrelic/api/database_trace.py
@@ -249,7 +249,7 @@ def DatabaseTraceWrapper(wrapped, sql, dbapi2_module=None, async_wrapper=None):
 
         trace = DatabaseTrace(_sql, dbapi2_module, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/datastore_trace.py
+++ b/newrelic/api/datastore_trace.py
@@ -226,7 +226,7 @@ def DatastoreTraceWrapper(
             _product, _target, _operation, _host, _port_path_or_id, _database_name, parent=parent, source=wrapped
         )
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/external_trace.py
+++ b/newrelic/api/external_trace.py
@@ -92,7 +92,7 @@ def ExternalTraceWrapper(wrapped, library, url, method=None, async_wrapper=None)
 
         trace = ExternalTrace(library, _url, _method, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:
@@ -109,7 +109,7 @@ def ExternalTraceWrapper(wrapped, library, url, method=None, async_wrapper=None)
 
         trace = ExternalTrace(library, url, method, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/function_trace.py
+++ b/newrelic/api/function_trace.py
@@ -131,7 +131,7 @@ def FunctionTraceWrapper(
 
         trace = FunctionTrace(_name, _group, _label, _params, terminal, rollup, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:
@@ -150,7 +150,7 @@ def FunctionTraceWrapper(
 
         trace = FunctionTrace(_name, group, label, params, terminal, rollup, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/graphql_trace.py
+++ b/newrelic/api/graphql_trace.py
@@ -112,7 +112,7 @@ def GraphQLOperationTraceWrapper(wrapped, async_wrapper=None):
 
         trace = GraphQLOperationTrace(parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:
@@ -202,7 +202,7 @@ def GraphQLResolverTraceWrapper(wrapped, async_wrapper=None):
 
         trace = GraphQLResolverTrace(parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/memcache_trace.py
+++ b/newrelic/api/memcache_trace.py
@@ -71,7 +71,7 @@ def MemcacheTraceWrapper(wrapped, command, async_wrapper=None):
 
         trace = MemcacheTrace(_command, parent=parent, source=wrapped)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/message_trace.py
+++ b/newrelic/api/message_trace.py
@@ -145,7 +145,7 @@ def MessageTraceWrapper(
             source=wrapped,
         )
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/api/transaction.py
+++ b/newrelic/api/transaction.py
@@ -109,7 +109,7 @@ class Sentinel(TimeTrace):
             self.exited = True
 
     @staticmethod
-    def complete_trace():  # pylint: disable=arguments-differ
+    def complete_trace():
         pass
 
     @property

--- a/newrelic/api/web_transaction.py
+++ b/newrelic/api/web_transaction.py
@@ -468,7 +468,7 @@ class WebTransaction(Transaction):
 
             except UnicodeError:
                 if not WebTransaction.unicode_error_reported:
-                    _logger.error("ASCII encoding of js-agent-header failed.", header)
+                    _logger.error("ASCII encoding of js-agent-header failed: %s", header)
                     WebTransaction.unicode_error_reported = True
 
                 header = ""

--- a/newrelic/common/agent_http.py
+++ b/newrelic/common/agent_http.py
@@ -18,7 +18,6 @@ import time
 import zlib
 from pprint import pprint
 
-import newrelic.packages.urllib3 as urllib3
 from newrelic import version
 from newrelic.common import certs
 from newrelic.common.encoding_utils import json_decode, json_encode, obfuscate_license_key
@@ -26,6 +25,7 @@ from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import patch_function_wrapper
 from newrelic.core.internal_metrics import internal_count_metric, internal_metric
 from newrelic.network.exceptions import NetworkInterfaceException
+from newrelic.packages import urllib3
 
 try:
     from ssl import get_default_verify_paths

--- a/newrelic/common/agent_http.py
+++ b/newrelic/common/agent_http.py
@@ -239,7 +239,7 @@ class HttpClient(BaseClient):
         default_content_encoding_header="Identity",
     ):
         self._host = host
-        port = self._port = port
+        self._port = port
         self._compression_threshold = compression_threshold
         self._compression_level = compression_level
         self._compression_method = compression_method

--- a/newrelic/common/object_wrapper.py
+++ b/newrelic/common/object_wrapper.py
@@ -26,12 +26,7 @@ from newrelic.packages.wrapt import BoundFunctionWrapper as _BoundFunctionWrappe
 from newrelic.packages.wrapt import CallableObjectProxy as _CallableObjectProxy
 from newrelic.packages.wrapt import FunctionWrapper as _FunctionWrapper
 from newrelic.packages.wrapt import ObjectProxy as _ObjectProxy
-from newrelic.packages.wrapt import (  # noqa: F401; pylint: disable=W0611
-    apply_patch,
-    resolve_path,
-    wrap_object,
-    wrap_object_attribute,
-)
+from newrelic.packages.wrapt import apply_patch, resolve_path, wrap_object, wrap_object_attribute  # noqa: F401
 
 # We previously had our own pure Python implementation of the generic
 # object wrapper but we now defer to using the wrapt module as its C

--- a/newrelic/common/package_version_utils.py
+++ b/newrelic/common/package_version_utils.py
@@ -99,14 +99,14 @@ def _get_package_version(name):
     if "importlib" in sys.modules and hasattr(sys.modules["importlib"], "metadata"):
         try:
             # In Python3.10+ packages_distribution can be checked for as well
-            if hasattr(sys.modules["importlib"].metadata, "packages_distributions"):  # pylint: disable=E1101
-                distributions = sys.modules["importlib"].metadata.packages_distributions()  # pylint: disable=E1101
+            if hasattr(sys.modules["importlib"].metadata, "packages_distributions"):
+                distributions = sys.modules["importlib"].metadata.packages_distributions()
                 distribution_name = distributions.get(name, name)
                 distribution_name = distribution_name[0] if isinstance(distribution_name, list) else distribution_name
             else:
                 distribution_name = name
 
-            version = sys.modules["importlib"].metadata.version(distribution_name)  # pylint: disable=E1101
+            version = sys.modules["importlib"].metadata.version(distribution_name)
             if version not in NULL_VERSIONS:
                 return version
         except Exception:

--- a/newrelic/common/streaming_utils.py
+++ b/newrelic/common/streaming_utils.py
@@ -159,8 +159,8 @@ class SpanProtoAttrs(dict):
                 for k, v in arg:
                     self[k] = v
 
-        for k in kwargs:
-            self[k] = kwargs[k]
+        for k, v in kwargs.items():
+            self[k] = v
 
     def __setitem__(self, key, value):
         super(SpanProtoAttrs, self).__setitem__(key, SpanProtoAttrs.get_attribute_value(value))

--- a/newrelic/common/system_info.py
+++ b/newrelic/common/system_info.py
@@ -349,7 +349,6 @@ def gethostname(use_dyno_names=False, dyno_shorten_prefixes=()):
     """
 
     global _nr_cached_hostname
-    global _nr_cached_hostname_lock
 
     if _nr_cached_hostname:
         return _nr_cached_hostname
@@ -371,7 +370,6 @@ def getips():
     """
 
     global _nr_cached_ip_address
-    global _nr_cached_ipaddress_lock
 
     if _nr_cached_ip_address is not None:
         return _nr_cached_ip_address

--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -19,10 +19,10 @@ import re
 import socket
 import string
 
-import newrelic.packages.urllib3 as urllib3
 from newrelic.common.agent_http import InsecureHttpClient
 from newrelic.common.encoding_utils import json_decode
 from newrelic.core.internal_metrics import internal_count_metric
+from newrelic.packages import urllib3
 
 _logger = logging.getLogger(__name__)
 VALID_CHARS_RE = re.compile(r"[0-9a-zA-Z_ ./-]")

--- a/newrelic/console.py
+++ b/newrelic/console.py
@@ -67,7 +67,7 @@ def shell_command(wrapped):
         prototype = f"{wrapper.__name__[3:]} {doc_signature(wrapped)}"
 
         if hasattr(wrapper, "__doc__") and wrapper.__doc__ is not None:
-            wrapper.__doc__ = "\n".join((prototype, wrapper.__doc__.lstrip("\n")))  # noqa: flynt
+            wrapper.__doc__ = "\n".join((prototype, wrapper.__doc__.lstrip("\n")))
 
     return wrapper
 

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -892,8 +892,8 @@ _settings.infinite_tracing.batching = _environ_as_bool("NEW_RELIC_INFINITE_TRACI
 _settings.infinite_tracing.ssl = True
 _settings.infinite_tracing.span_queue_size = _environ_as_int("NEW_RELIC_INFINITE_TRACING_SPAN_QUEUE_SIZE", 10000)
 
-_settings.instrumentation.graphql.capture_introspection_queries = os.environ.get(
-    "NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES", False
+_settings.instrumentation.graphql.capture_introspection_queries = _environ_as_bool(
+    "NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES", default=False
 )
 
 # celeryev is the monitoring queue for rabbitmq which we do not need to monitor-it just makes a lot of noise.

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -37,7 +37,7 @@ from newrelic.core.attribute_filter import AttributeFilter
 try:
     import grpc
 
-    from newrelic.core.infinite_tracing_pb2 import Span  # pylint: disable=W0611,C0412  # noqa: F401
+    from newrelic.core.infinite_tracing_pb2 import Span  # noqa: F401
 except Exception:
     grpc = None
 

--- a/newrelic/core/database_node.py
+++ b/newrelic/core/database_node.py
@@ -14,9 +14,9 @@
 
 from collections import namedtuple
 
-import newrelic.core.attribute as attribute
 import newrelic.core.trace_node
 from newrelic.common import system_info
+from newrelic.core import attribute
 from newrelic.core.database_utils import explain_plan, sql_statement
 from newrelic.core.metric import TimeMetric
 from newrelic.core.node_mixin import DatastoreNodeMixin

--- a/newrelic/core/external_node.py
+++ b/newrelic/core/external_node.py
@@ -15,8 +15,8 @@
 import urllib.parse as urlparse
 from collections import namedtuple
 
-import newrelic.core.attribute as attribute
 import newrelic.core.trace_node
+from newrelic.core import attribute
 from newrelic.core.metric import TimeMetric
 from newrelic.core.node_mixin import GenericNodeMixin
 

--- a/newrelic/core/infinite_tracing_pb2.py
+++ b/newrelic/core/infinite_tracing_pb2.py
@@ -21,23 +21,8 @@ except Exception:
 
 # Import appropriate generated pb2 file for protobuf version
 if PROTOBUF_VERSION >= (5,):
-    from newrelic.core.infinite_tracing_v5_pb2 import (  # noqa: F401; pylint: disable=W0611
-        AttributeValue,
-        RecordStatus,
-        Span,
-        SpanBatch,
-    )
+    from newrelic.core.infinite_tracing_v5_pb2 import AttributeValue, RecordStatus, Span, SpanBatch  # noqa: F401
 elif PROTOBUF_VERSION >= (4,):
-    from newrelic.core.infinite_tracing_v4_pb2 import (  # noqa: F401; pylint: disable=W0611
-        AttributeValue,
-        RecordStatus,
-        Span,
-        SpanBatch,
-    )
+    from newrelic.core.infinite_tracing_v4_pb2 import AttributeValue, RecordStatus, Span, SpanBatch  # noqa: F401
 else:
-    from newrelic.core.infinite_tracing_v3_pb2 import (  # noqa: F401; pylint: disable=W0611
-        AttributeValue,
-        RecordStatus,
-        Span,
-        SpanBatch,
-    )
+    from newrelic.core.infinite_tracing_v3_pb2 import AttributeValue, RecordStatus, Span, SpanBatch  # noqa: F401

--- a/newrelic/core/node_mixin.py
+++ b/newrelic/core/node_mixin.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import newrelic.core.attribute as attribute
+from newrelic.core import attribute
 from newrelic.core.attribute_filter import DST_SPAN_EVENTS, DST_TRANSACTION_SEGMENTS
 
 

--- a/newrelic/core/otlp_utils.py
+++ b/newrelic/core/otlp_utils.py
@@ -81,7 +81,7 @@ if otlp_content_setting == "json":
 
 
 def otlp_encode(payload):
-    if type(payload) is dict:  # pylint: disable=C0123
+    if type(payload) is dict:
         _logger.warning(
             "Using OTLP integration while protobuf is not installed. This may result in larger payload sizes and data loss."
         )
@@ -159,7 +159,7 @@ def stats_to_otlp_metrics(metric_data, start_time, end_time):
     for name, metric_container in metric_data:
         # Types are checked here using type() instead of isinstance, as CountStats is a subclass of TimeStats.
         # Imporperly checking with isinstance will lead to count metrics being encoded and reported twice.
-        if any(type(metric) is CountStats for metric in metric_container.values()):  # pylint: disable=C0123
+        if any(type(metric) is CountStats for metric in metric_container.values()):
             # Metric contains Sum metric data points.
             yield Metric(
                 name=name,
@@ -174,11 +174,11 @@ def stats_to_otlp_metrics(metric_data, start_time, end_time):
                             attributes=create_key_values_from_iterable(tags),
                         )
                         for tags, value in metric_container.items()
-                        if type(value) is CountStats  # pylint: disable=C0123
+                        if type(value) is CountStats
                     ],
                 ),
             )
-        if any(type(metric) is TimeStats for metric in metric_container.values()):  # pylint: disable=C0123
+        if any(type(metric) is TimeStats for metric in metric_container.values()):
             # Metric contains Summary metric data points.
             yield Metric(
                 name=name,
@@ -191,7 +191,7 @@ def stats_to_otlp_metrics(metric_data, start_time, end_time):
                             attributes=create_key_values_from_iterable(tags),
                         )
                         for tags, value in metric_container.items()
-                        if type(value) is TimeStats  # pylint: disable=C0123
+                        if type(value) is TimeStats
                     ]
                 ),
             )

--- a/newrelic/core/stats_engine.py
+++ b/newrelic/core/stats_engine.py
@@ -415,7 +415,7 @@ class SampledDataSet:
         # Always sample if under capacity
         return True
 
-    def add(self, sample, priority=None):  # pylint: disable=E0202
+    def add(self, sample, priority=None):
         self.num_seen += 1
 
         if priority is None:
@@ -479,7 +479,7 @@ class LimitedDataSet(list):
         self.clear()
         self.num_seen = 0
 
-    def add(self, sample):  # pylint: disable=E0202
+    def add(self, sample):
         if self.should_sample():
             self.append(sample)
         self.num_seen += 1

--- a/newrelic/hooks/external_aiobotocore.py
+++ b/newrelic/hooks/external_aiobotocore.py
@@ -115,6 +115,7 @@ async def wrap_client__make_api_call(wrapped, instance, args, kwargs):
         handle_bedrock_exception(
             exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction
         )
+        raise
 
     if not response or response_streaming and not settings.ai_monitoring.streaming.enabled:
         if ft:

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -1059,7 +1059,7 @@ def dynamodb_datastore_trace(
             _logger.debug("Failed to capture AWS DynamoDB info.", exc_info=True)
         trace.agent_attributes.update(agent_attrs)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:
@@ -1099,7 +1099,7 @@ def aws_function_trace(
         _agent_attrs = extract_agent_attrs(instance, *args, **kwargs) if extract_agent_attrs is not None else {}
         trace.agent_attributes.update(_agent_attrs)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:
@@ -1151,7 +1151,7 @@ def aws_message_trace(
         _agent_attrs = extract_agent_attrs(instance, *args, **kwargs)
         trace.agent_attributes.update(_agent_attrs)
 
-        if wrapper:  # pylint: disable=W0125,W0126
+        if wrapper:
             return wrapper(wrapped, trace)(*args, **kwargs)
 
         with trace:

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -570,8 +570,6 @@ def handle_bedrock_exception(
     except Exception:
         _logger.warning(EXCEPTION_HANDLING_FAILURE_LOG_MESSAGE, traceback.format_exception(*sys.exc_info()))
 
-    raise
-
 
 def run_bedrock_response_extractor(response_extractor, response_body, bedrock_attrs, is_embedding, transaction):
     # Run response extractor for non-streaming responses
@@ -673,6 +671,7 @@ def wrap_bedrock_runtime_invoke_model(response_streaming=False):
             handle_bedrock_exception(
                 exc, is_embedding, model, span_id, trace_id, request_extractor, request_body, ft, transaction
             )
+            raise
 
         if not response or response_streaming and not settings.ai_monitoring.streaming.enabled:
             ft.__exit__(None, None, None)

--- a/newrelic/hooks/framework_aiohttp.py
+++ b/newrelic/hooks/framework_aiohttp.py
@@ -286,7 +286,7 @@ def _nr_aiohttp_request_wrapper_(wrapped, instance, args, kwargs):
             return response
         except Exception as e:
             try:
-                trace.process_response_headers(e.headers.items())  # pylint: disable=E1101
+                trace.process_response_headers(e.headers.items())
             except:
                 pass
 

--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -122,14 +122,14 @@ def wrap_add_middleware(wrapped, instance, args, kwargs):
     return wrapped(wrap_middleware(middleware), *args, **kwargs)
 
 
-def bind_middleware_starlette(debug=False, routes=None, middleware=None, *args, **kwargs):  # pylint: disable=W1113
+def bind_middleware_starlette(debug=False, routes=None, middleware=None, *args, **kwargs):
     return middleware
 
 
 def wrap_starlette(wrapped, instance, args, kwargs):
     middlewares = bind_middleware_starlette(*args, **kwargs)
     if middlewares:
-        for middleware in middlewares:  # pylint: disable=E1133
+        for middleware in middlewares:
             cls = getattr(middleware, "cls", None)
             if cls and not hasattr(cls, "__wrapped__"):
                 middleware.cls = wrap_middleware(cls)

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -76,7 +76,7 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         except Exception as error:
             # Unwrap kafka errors
             while hasattr(error, "exception"):
-                error = error.exception  # pylint: disable=E1101
+                error = error.exception
 
             _, _, tb = sys.exc_info()
             notice_error((type(error), error, tb))
@@ -151,7 +151,7 @@ def wrap_Consumer_poll(wrapped, instance, args, kwargs):
                 source=wrapped,
             )
             instance._nr_transaction = transaction
-            transaction.__enter__()  # pylint: disable=C2801
+            transaction.__enter__()
 
             transaction._add_agent_attribute("kafka.consume.byteCount", received_bytes)
 

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -135,7 +135,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
                 source=wrapped,
             )
             instance._nr_transaction = transaction
-            transaction.__enter__()  # pylint: disable=C2801
+            transaction.__enter__()
 
             # Obtain consumer client_id to send up as agent attribute
             if hasattr(instance, "config") and "client_id" in instance.config:
@@ -167,7 +167,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
 
 
 def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
-    get_config_key = lambda key: kwargs.get(key, instance.DEFAULT_CONFIG[key])  # pylint: disable=C3001 # noqa: E731
+    get_config_key = lambda key: kwargs.get(key, instance.DEFAULT_CONFIG[key])  # noqa: E731
 
     kwargs["key_serializer"] = wrap_serializer(
         instance, "Serialization/Key", "MessageBroker", get_config_key("key_serializer")
@@ -181,13 +181,13 @@ def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
 
 class NewRelicSerializerWrapper(ObjectProxy):
     def __init__(self, wrapped, serializer_name, group_prefix):
-        ObjectProxy.__init__.__get__(self)(wrapped)  # pylint: disable=W0231
+        ObjectProxy.__init__.__get__(self)(wrapped)
 
         self._nr_serializer_name = serializer_name
         self._nr_group_prefix = group_prefix
 
     def serialize(self, topic, object):  # noqa: A002
-        wrapped = self.__wrapped__.serialize  # pylint: disable=W0622
+        wrapped = self.__wrapped__.serialize
         args = (topic, object)
         kwargs = {}
 

--- a/newrelic/hooks/messagebroker_kombu.py
+++ b/newrelic/hooks/messagebroker_kombu.py
@@ -143,7 +143,7 @@ def wrap_consumer_recieve_callback(wrapped, instance, args, kwargs):
                 routing_key=key,
                 source=wrapped,
             )
-            created_transaction.__enter__()  # pylint: disable=C2801
+            created_transaction.__enter__()
             created_transaction.destination_name = destination_name
 
             # Obtain consumer client_id to send up as agent attribute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,16 @@ ignore = [
     "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
     "PERF203",  # try-except-in-loop (most of these are unavoidable)
     "S110",  # try-except-pass (Bandit wants us to log the exception, which is usually pointless. Spot check these later)
+    "PLW0603",  # global-statement (this is currently used extensively)
+    "PLW2901",  # redefined-loop-name (frequently used, not generally an issue)
+    "PLR",  # Pylint Recommendations (too many to fix all at once)
     # Permanently disabled rules
     "D203",  # incorrect-blank-line-before-class
     "D213",  # multi-line-summary-second-line
     "ARG001",  # unused-argument
     "PYI024",  # collections-named-tuple (not currently using type annotations)
+    "PLR0913", # too-many-arguments
+    "PLR0915",  # too-many-statements
     # Ruff recommended linter rules to disable when using formatter
     "W191",  # tab-indentation
     "E111",  # indentation-with-invalid-multiple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ select = [
     # "ARG",  # flake8-unused-arguments
     # "PTH",  # flake8-use-pathlib
     "PGH",  # pygrep-hooks
-    # "PL",  # Pylint
+    "PL",  # Pylint
     # "TRY",  # tryceratops
     "FLY",  # flynt
     "PERF",  # Perflint

--- a/tests/agent_features/test_attribute.py
+++ b/tests/agent_features/test_attribute.py
@@ -488,7 +488,7 @@ def test_sanitize_object():
 
 class TypeErrorString:
     def __str__(self):
-        return 42
+        return 42  # noqa: PLE0307
 
 
 def test_str_raises_type_error():

--- a/tests/agent_features/test_span_events.py
+++ b/tests/agent_features/test_span_events.py
@@ -671,7 +671,7 @@ def test_span_event_notice_error_overrides_observed(trace_type, args):
                 raise ERROR
             except Exception:
                 notice_error()
-                raise ValueError  # pylint: disable (Py2/Py3 compatibility)
+                raise ValueError
     except ValueError:
         pass
 

--- a/tests/agent_unittests/conftest.py
+++ b/tests/agent_unittests/conftest.py
@@ -56,8 +56,8 @@ def global_settings(request, monkeypatch):
         for k, v in env.items():
             monkeypatch.setenv(k, v)
 
-    import newrelic.core.config as core_config  # pylint: disable=R0402
-    from newrelic import config  # pylint: disable=R0402
+    import newrelic.core.config as core_config
+    from newrelic import config
 
     original = {}
     for attr in dir(core_config):

--- a/tests/agent_unittests/conftest.py
+++ b/tests/agent_unittests/conftest.py
@@ -56,8 +56,8 @@ def global_settings(request, monkeypatch):
         for k, v in env.items():
             monkeypatch.setenv(k, v)
 
-    import newrelic.config as config  # pylint: disable=R0402
     import newrelic.core.config as core_config  # pylint: disable=R0402
+    from newrelic import config  # pylint: disable=R0402
 
     original = {}
     for attr in dir(core_config):

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -363,7 +363,7 @@ def connect_payload_asserts(
     ],
 )
 def test_connect(with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_docker, with_kubernetes, with_ip):
-    global AWS, AZURE, GCP, PCF, BOOT_ID, DOCKER, KUBERNETES, IP_ADDRESS
+    global AWS, AZURE, GCP, PCF, DOCKER, KUBERNETES, IP_ADDRESS
     if not with_aws:
         AWS = Exception
     if not with_pcf:

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -135,10 +135,7 @@ def override_system_info(monkeypatch):
 def test_send(status_code):
     HttpClientRecorder.STATUS_CODE = status_code
     settings = finalize_application_settings(
-        {
-            "request_headers_map": {"custom-header": "value"},  # pylint: disable=W1406
-            "agent_run_id": "RUN_TOKEN",
-        }
+        {"request_headers_map": {"custom-header": "value"}, "agent_run_id": "RUN_TOKEN"}
     )
     protocol = AgentProtocol(settings, client_cls=HttpClientRecorder)
     response = protocol.send("metric_data", (1, 2, 3))

--- a/tests/agent_unittests/test_check_environment.py
+++ b/tests/agent_unittests/test_check_environment.py
@@ -19,7 +19,7 @@ import tempfile
 
 import pytest
 
-import newrelic.core.agent as agent
+from newrelic.core import agent
 
 
 @pytest.mark.parametrize("content", [{}, {"opt": [1, 2, 3]}])

--- a/tests/agent_unittests/test_import_hook.py
+++ b/tests/agent_unittests/test_import_hook.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-import newrelic.api.import_hook as import_hook
+from newrelic.api import import_hook
 from newrelic.config import _module_function_glob
 
 

--- a/tests/cross_agent/test_collector_hostname.py
+++ b/tests/cross_agent/test_collector_hostname.py
@@ -64,8 +64,8 @@ def _test_collector_hostname(
         if config_override_host:
             ini_contents += f"\nhost = {config_override_host}"
 
-        import newrelic.config as config
         import newrelic.core.config as core_config
+        from newrelic import config
 
         reload(core_config)
         reload(config)

--- a/tests/datastore_firestore/test_async_query.py
+++ b/tests/datastore_firestore/test_async_query.py
@@ -179,8 +179,8 @@ def patch_partition_queries(monkeypatch, async_client, collection, sample_data):
 def exercise_async_collection_group(async_client, async_collection):
     async def _exercise_async_collection_group():
         async_collection_group = async_client.collection_group(async_collection.id)
-        assert len(await async_collection_group.get()) >= 1
-        assert len([d async for d in async_collection_group.stream()]) >= 1
+        assert await async_collection_group.get()
+        assert [d async for d in async_collection_group.stream()]
 
         partitions = [p async for p in async_collection_group.get_partitions(1)]
         assert len(partitions) == 2

--- a/tests/datastore_firestore/test_async_query.py
+++ b/tests/datastore_firestore/test_async_query.py
@@ -179,8 +179,8 @@ def patch_partition_queries(monkeypatch, async_client, collection, sample_data):
 def exercise_async_collection_group(async_client, async_collection):
     async def _exercise_async_collection_group():
         async_collection_group = async_client.collection_group(async_collection.id)
-        assert len(await async_collection_group.get())
-        assert len([d async for d in async_collection_group.stream()])
+        assert len(await async_collection_group.get()) >= 1
+        assert len([d async for d in async_collection_group.stream()]) >= 1
 
         partitions = [p async for p in async_collection_group.get_partitions(1)]
         assert len(partitions) == 2

--- a/tests/datastore_firestore/test_client.py
+++ b/tests/datastore_firestore/test_client.py
@@ -29,7 +29,7 @@ def sample_data(collection):
 @pytest.fixture()
 def exercise_client(client, sample_data):
     def _exercise_client():
-        assert len([_ for _ in client.collections()]) >= 1
+        assert [_ for _ in client.collections()]
         doc = [_ for _ in client.get_all([sample_data])][0]
         assert doc.to_dict()["x"] == 1
 

--- a/tests/datastore_firestore/test_client.py
+++ b/tests/datastore_firestore/test_client.py
@@ -29,7 +29,7 @@ def sample_data(collection):
 @pytest.fixture()
 def exercise_client(client, sample_data):
     def _exercise_client():
-        assert len([_ for _ in client.collections()])
+        assert len([_ for _ in client.collections()]) >= 1
         doc = [_ for _ in client.get_all([sample_data])][0]
         assert doc.to_dict()["x"] == 1
 

--- a/tests/datastore_firestore/test_query.py
+++ b/tests/datastore_firestore/test_query.py
@@ -172,8 +172,8 @@ def patch_partition_queries(monkeypatch, client, collection, sample_data):
 def exercise_collection_group(client, collection, patch_partition_queries):
     def _exercise_collection_group():
         collection_group = client.collection_group(collection.id)
-        assert len(collection_group.get())
-        assert len([d for d in collection_group.stream()]) >= 1
+        assert collection_group.get()
+        assert [d for d in collection_group.stream()]
 
         partitions = [p for p in collection_group.get_partitions(1)]
         assert len(partitions) == 2

--- a/tests/datastore_firestore/test_query.py
+++ b/tests/datastore_firestore/test_query.py
@@ -173,7 +173,7 @@ def exercise_collection_group(client, collection, patch_partition_queries):
     def _exercise_collection_group():
         collection_group = client.collection_group(collection.id)
         assert len(collection_group.get())
-        assert len([d for d in collection_group.stream()])
+        assert len([d for d in collection_group.stream()]) >= 1
 
         partitions = [p for p in collection_group.get_partitions(1)]
         assert len(partitions) == 2

--- a/tests/datastore_psycopg2/test_explain_plans.py
+++ b/tests/datastore_psycopg2/test_explain_plans.py
@@ -32,7 +32,7 @@ _port = DB_SETTINGS["port"]
 class CustomConnection(psycopg2.extensions.connection):
     def __init__(self, *args, **kwargs):
         self.ready = False
-        return super(CustomConnection, self).__init__(*args, **kwargs)
+        super(CustomConnection, self).__init__(*args, **kwargs)
 
     def cursor(self, *args, **kwargs):
         assert self.ready  # Force a failure when generating an explain plan
@@ -42,7 +42,7 @@ class CustomConnection(psycopg2.extensions.connection):
 class CustomCursor(psycopg2.extensions.cursor):
     def __init__(self, *args, **kwargs):
         self.ready = False
-        return super(CustomCursor, self).__init__(*args, **kwargs)
+        super(CustomCursor, self).__init__(*args, **kwargs)
 
     def execute(self, *args, **kwargs):
         assert self.ready  # Force a failure when generating an explain plan

--- a/tests/external_aiobotocore/test_bedrock_chat_completion.py
+++ b/tests/external_aiobotocore/test_bedrock_chat_completion.py
@@ -19,7 +19,7 @@ import botocore.errorfactory
 import botocore.eventstream
 import botocore.exceptions
 import pytest
-from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from conftest import BOTOCORE_VERSION
 from external_botocore._test_bedrock_chat_completion import (
     chat_completion_expected_events,
     chat_completion_expected_malformed_request_body_events,

--- a/tests/external_aiobotocore/test_bedrock_embeddings.py
+++ b/tests/external_aiobotocore/test_bedrock_embeddings.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 import botocore.exceptions
 import pytest
-from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from conftest import BOTOCORE_VERSION
 from external_botocore._test_bedrock_embeddings import (
     embedding_expected_events,
     embedding_expected_malformed_request_body_events,

--- a/tests/external_botocore/test_bedrock_chat_completion.py
+++ b/tests/external_botocore/test_bedrock_chat_completion.py
@@ -32,7 +32,7 @@ from _test_bedrock_chat_completion import (
     chat_completion_payload_templates,
     chat_completion_streaming_expected_events,
 )
-from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from conftest import BOTOCORE_VERSION
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
     add_token_count_to_events,

--- a/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
+++ b/tests/external_botocore/test_bedrock_chat_completion_via_langchain.py
@@ -17,7 +17,7 @@ from _test_bedrock_chat_completion import (
     chat_completion_langchain_expected_events,
     chat_completion_langchain_expected_streaming_events,
 )
-from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from conftest import BOTOCORE_VERSION
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import events_with_context_attrs, set_trace_info
 from testing_support.validators.validate_custom_event import validate_custom_event_count

--- a/tests/external_botocore/test_bedrock_embeddings.py
+++ b/tests/external_botocore/test_bedrock_embeddings.py
@@ -25,7 +25,7 @@ from _test_bedrock_embeddings import (
     embedding_invalid_access_key_error_events,
     embedding_payload_templates,
 )
-from conftest import BOTOCORE_VERSION  # pylint: disable=E0611
+from conftest import BOTOCORE_VERSION
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
     add_token_count_to_events,

--- a/tests/external_botocore/test_botocore_s3.py
+++ b/tests/external_botocore/test_botocore_s3.py
@@ -24,7 +24,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
 
-MOTO_VERSION = MOTO_VERSION = get_package_version_tuple("moto")
+MOTO_VERSION = get_package_version_tuple("moto")
 BOTOCORE_VERSION = get_package_version_tuple("botocore")
 
 AWS_ACCESS_KEY_ID = "AAAAAAAAAAAACCESSKEY"

--- a/tests/external_httpx/test_client.py
+++ b/tests/external_httpx/test_client.py
@@ -36,7 +36,6 @@ CAT_RESPONSE_CODE = None
 
 
 def cat_response_handler(self):
-    global CAT_RESPONSE_CODE
     if not CAT_RESPONSE_CODE:
         raise ValueError("CAT_RESPONSE_CODE must be a valid status_code.")
 

--- a/tests/framework_ariadne/_target_schema_async.py
+++ b/tests/framework_ariadne/_target_schema_async.py
@@ -40,7 +40,7 @@ item = UnionType("Item")
 async def resolve_type(obj, *args):
     if "isbn" in obj:
         return "Book"
-    elif "issue" in obj:  # pylint: disable=R1705
+    elif "issue" in obj:
         return "Magazine"
 
     return None

--- a/tests/framework_ariadne/_target_schema_sync.py
+++ b/tests/framework_ariadne/_target_schema_sync.py
@@ -51,7 +51,7 @@ item = UnionType("Item")
 def resolve_type(obj, *args):
     if "isbn" in obj:
         return "Book"
-    elif "issue" in obj:  # pylint: disable=R1705
+    elif "issue" in obj:
         return "Magazine"
 
     return None

--- a/tests/framework_flask/test_views.py
+++ b/tests/framework_flask/test_views.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from conftest import async_handler_support, skip_if_not_async_handler_support  # pylint: disable=E0611
+from conftest import async_handler_support, skip_if_not_async_handler_support
 from testing_support.validators.validate_code_level_metrics import validate_code_level_metrics
 from testing_support.validators.validate_transaction_errors import validate_transaction_errors
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics

--- a/tests/framework_sanic/conftest.py
+++ b/tests/framework_sanic/conftest.py
@@ -61,7 +61,7 @@ def create_request_class(app, method, url, headers=None, loop=None):
         from sanic.server import HttpProtocol
 
         class MockProtocol(HttpProtocol):
-            async def send(*args, **kwargs):  # pylint: disable=E0211
+            async def send(*args, **kwargs):
                 return
 
         proto = MockProtocol(loop=loop, app=app)

--- a/tests/framework_tornado/test_externals.py
+++ b/tests/framework_tornado/test_externals.py
@@ -218,7 +218,6 @@ CAT_RESPONSE_CODE = None
 
 
 def cat_response_handler(self):
-    global CAT_RESPONSE_CODE
     # payload
     # (
     #     u'1#1', u'WebTransaction/Function/app:beep',

--- a/tests/logger_logging/conftest.py
+++ b/tests/logger_logging/conftest.py
@@ -70,7 +70,7 @@ def logger(request):
         _logger.addHandler(forwarding_handler)
 
         # Uninstrument Logging
-        logging.Logger.callHandlers = logging.Logger.callHandlers.__wrapped__  # noqa, pylint: disable=E1101
+        logging.Logger.callHandlers = logging.Logger.callHandlers.__wrapped__
 
     yield _logger
     del caplog.records[:]

--- a/tests/logger_logging/test_logging_handler.py
+++ b/tests/logger_logging/test_logging_handler.py
@@ -15,7 +15,7 @@
 import logging
 
 import pytest
-from conftest import instrumented_logger as conf_logger  # noqa, pylint: disable=W0611
+from conftest import instrumented_logger as conf_logger
 from testing_support.fixtures import override_application_settings, reset_core_stats_engine
 from testing_support.validators.validate_function_called import validate_function_called
 from testing_support.validators.validate_log_event_count import validate_log_event_count
@@ -35,7 +35,7 @@ from newrelic.api.transaction import current_transaction
 def uninstrument_logging():
     instrumented = logging.Logger.callHandlers
     while hasattr(logging.Logger.callHandlers, "__wrapped__"):
-        logging.Logger.callHandlers = logging.Logger.callHandlers.__wrapped__  # noqa, pylint: disable=E1101
+        logging.Logger.callHandlers = logging.Logger.callHandlers.__wrapped__
     yield
     logging.Logger.callHandlers = instrumented
 

--- a/tests/logger_loguru/test_attributes.py
+++ b/tests/logger_loguru/test_attributes.py
@@ -50,7 +50,7 @@ def test_loguru_default_context_attributes(logger):
     bound_logger = logger.bind(bound_attr=1)
     bound_logger = bound_logger.patch(_patcher)
     with bound_logger.contextualize(contextual_attr=2):
-        bound_logger.error("context_attrs: {}", "arg1", kwarg_attr=4)
+        bound_logger.error("context_attrs: {}", "arg1", kwarg_attr=4)  # noqa: PLE1205
 
 
 @validate_log_events([{"message": "exc_info"}], required_attrs=["context.exception"])

--- a/tests/messagebroker_kombu/conftest.py
+++ b/tests/messagebroker_kombu/conftest.py
@@ -21,10 +21,7 @@ import pytest
 from amqp.exceptions import NotFound
 from kombu import messaging, serialization
 from testing_support.db_settings import rabbitmq_settings
-from testing_support.fixtures import (  # noqa: F401; pylint: disable=W0611
-    collector_agent_registration_fixture,
-    collector_available_fixture,
-)
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture  # noqa: F401
 from testing_support.validators.validate_distributed_trace_accepted import validate_distributed_trace_accepted
 
 from newrelic.api.transaction import current_transaction

--- a/tests/messagebroker_pika/test_pika_async_connection_consume.py
+++ b/tests/messagebroker_pika/test_pika_async_connection_consume.py
@@ -50,7 +50,7 @@ try:
 
     class MyIOLoop(tornado.ioloop.IOLoop.configured_class()):
         def handle_callback_exception(self, *args, **kwargs):
-            raise
+            raise  # noqa: PLE0704
 
     tornado.ioloop.IOLoop.configure(MyIOLoop)
 except AttributeError:

--- a/tests/mlmodel_openai/test_chat_completion_stream_v1.py
+++ b/tests/mlmodel_openai/test_chat_completion_stream_v1.py
@@ -14,7 +14,7 @@
 
 import openai
 import pytest
-from conftest import get_openai_version  # pylint: disable=E0611
+from conftest import get_openai_version
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
     add_token_count_to_events,

--- a/tests/mlmodel_openai/test_embeddings_stream_v1.py
+++ b/tests/mlmodel_openai/test_embeddings_stream_v1.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from conftest import get_openai_version  # pylint: disable=E0611
+from conftest import get_openai_version
 from testing_support.fixtures import reset_core_stats_engine
 from testing_support.ml_testing_utils import set_trace_info
 from testing_support.validators.validate_custom_event import validate_custom_event_count

--- a/tests/mlmodel_sklearn/test_multioutput_models.py
+++ b/tests/mlmodel_sklearn/test_multioutput_models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from sklearn import __init__  # noqa: Needed for get_package_version
+from sklearn import __init__
 from sklearn.ensemble import AdaBoostClassifier
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 

--- a/tests/mlmodel_sklearn/test_naive_bayes_models.py
+++ b/tests/mlmodel_sklearn/test_naive_bayes_models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from sklearn import __init__  # noqa: needed for get_package_version
+from sklearn import __init__
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task

--- a/tests/mlmodel_sklearn/test_neighbors_models.py
+++ b/tests/mlmodel_sklearn/test_neighbors_models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from sklearn.neighbors import __init__  # noqa: Needed for get_package_version
+from sklearn.neighbors import __init__
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -76,8 +76,8 @@ def initialize_agent(app_name=None, default_settings=None):
         settings.developer_mode = True
         settings.license_key = "DEVELOPERMODELICENSEKEY"
 
-    settings.startup_timeout = float(os.environ.get("NEW_RELIC_STARTUP_TIMEOUT", 20.0))
-    settings.shutdown_timeout = float(os.environ.get("NEW_RELIC_SHUTDOWN_TIMEOUT", 20.0))
+    settings.startup_timeout = float(os.environ.get("NEW_RELIC_STARTUP_TIMEOUT", "20.0"))
+    settings.shutdown_timeout = float(os.environ.get("NEW_RELIC_SHUTDOWN_TIMEOUT", "20.0"))
 
     # Disable the harvest thread during testing so that harvest is explicitly
     # called on test shutdown

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -964,7 +964,7 @@ def dt_enabled(wrapped, instance, args, kwargs):
     wrapped = override_application_settings(settings)(wrapped)
     wrapped = force_sampled(wrapped)
 
-    return wrapped(*args, **kwargs)  # pylint: disable=E1102
+    return wrapped(*args, **kwargs)
 
 
 @function_wrapper

--- a/tests/testing_support/mock_http_client.py
+++ b/tests/testing_support/mock_http_client.py
@@ -14,8 +14,8 @@
 
 from urllib.parse import urlencode
 
-import newrelic.packages.urllib3 as urllib3
 from newrelic.common.agent_http import BaseClient
+from newrelic.packages import urllib3
 
 
 def create_client_cls(status, data, url=None):


### PR DESCRIPTION
# Overview

* Enable `pylint` rules in `ruff`.
  * Disable `pylint` recommendations for now, potentially re-enable later.
  * Disable rules for global statements and redefined loop variables.
    * Too many of these to tackle at once, and most are intentional design choices for better or worse.
  * Fix all other `pylint` rule violations.