### PR TITLE
Enable pycodestyle

### DIFF
--- a/newrelic/admin/run_python.py
+++ b/newrelic/admin/run_python.py
@@ -74,7 +74,7 @@ def run_python(args):
 
     if "PYTHONPATH" in os.environ:
         path = os.environ["PYTHONPATH"].split(os.path.pathsep)
-        if not boot_directory in path:
+        if boot_directory not in path:
             python_path = f"{boot_directory}{os.path.pathsep}{os.environ['PYTHONPATH']}"
 
     os.environ["PYTHONPATH"] = python_path

--- a/newrelic/api/background_task.py
+++ b/newrelic/api/background_task.py
@@ -72,7 +72,7 @@ def BackgroundTaskWrapper(wrapped, application=None, name=None, group=None):
         else:
             _group = group
 
-        if type(application) != Application:
+        if type(application) is not Application:
             _application = application_instance(application)
         else:
             _application = application

--- a/newrelic/api/message_transaction.py
+++ b/newrelic/api/message_transaction.py
@@ -190,7 +190,7 @@ def MessageTransactionWrapper(
 
                 return None
 
-            if type(application) != Application:
+            if type(application) is not Application:
                 _application = application_instance(application)
             else:
                 _application = application

--- a/newrelic/api/web_transaction.py
+++ b/newrelic/api/web_transaction.py
@@ -799,7 +799,7 @@ def WebTransactionWrapper(
     source=None,
 ):
     def wrapper(wrapped, instance, args, kwargs):
-        if type(application) != Application:
+        if type(application) is not Application:
             _application = application_instance(application)
         else:
             _application = application

--- a/newrelic/api/wsgi_application.py
+++ b/newrelic/api/wsgi_application.py
@@ -201,7 +201,9 @@ class _WSGIApplicationMiddleware:
         # works then we are done, else we move to next phase of
         # buffering up content until we find the body element.
 
-        html_to_be_inserted = lambda: self.transaction.browser_timing_header().encode("latin-1")
+        def html_to_be_inserted():
+            return self.transaction.browser_timing_header().encode("latin-1")
+
         if not self.response_data:
             modified = insert_html_snippet(data, html_to_be_inserted)
 

--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -181,7 +181,7 @@ class AWSUtilization(CommonUtilization):
     def fetch(cls):
         try:
             authToken = cls.fetchAuthToken()
-            if authToken == None:
+            if authToken is None:
                 return
             cls.HEADERS = {"X-aws-ec2-metadata-token": authToken}
             with cls.CLIENT_CLS(cls.METADATA_HOST, timeout=cls.FETCH_TIMEOUT) as client:

--- a/newrelic/console.py
+++ b/newrelic/console.py
@@ -442,7 +442,7 @@ class ConnectionManager:
             pass
 
     def __thread_run(self):
-        if type(self.__listener_socket) == type(()):
+        if type(self.__listener_socket) is tuple:
             listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             listener.bind(self.__listener_socket)

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -553,7 +553,7 @@ def _environ_as_bool(name, default=False):
     flag = os.environ.get(name, default)
     if default is None or default:
         try:
-            flag = not flag.lower() in ["off", "false", "0"]
+            flag = flag.lower() not in ["off", "false", "0"]
         except AttributeError:
             pass
     else:

--- a/newrelic/core/internal_metrics.py
+++ b/newrelic/core/internal_metrics.py
@@ -43,7 +43,7 @@ class InternalTrace:
 
 class InternalTraceWrapper:
     def __init__(self, wrapped, name):
-        if type(wrapped) == type(()):
+        if type(wrapped) is tuple:
             (instance, wrapped) = wrapped
         else:
             instance = None

--- a/newrelic/core/stack_trace.py
+++ b/newrelic/core/stack_trace.py
@@ -32,8 +32,8 @@ def _format_stack_trace(frames):
     return result
 
 
-def _extract_stack(f, skip, limit):
-    if f is None:
+def _extract_stack(frame, skip, limit):
+    if frame is None:
         return []
 
     # For calculating the stack trace we have the bottom most frame we
@@ -42,21 +42,21 @@ def _extract_stack(f, skip, limit):
     # order we want as it is more efficient.
 
     n = 0
-    l = []
+    frame_list = []
 
-    while f is not None and skip > 0:
-        f = f.f_back
+    while frame is not None and skip > 0:
+        frame = frame.f_back
         skip -= 1
 
-    while f is not None and n < limit:
-        l.append(dict(source=f.f_code.co_filename, line=f.f_lineno, name=f.f_code.co_name))
+    while frame is not None and n < limit:
+        frame_list.append({"source": frame.f_code.co_filename, "line": frame.f_lineno, "name": frame.f_code.co_name})
 
-        f = f.f_back
+        frame = frame.f_back
         n += 1
 
-    l.reverse()
+    frame_list.reverse()
 
-    return l
+    return frame_list
 
 
 def current_stack(skip=0, limit=None):
@@ -66,9 +66,9 @@ def current_stack(skip=0, limit=None):
     try:
         raise ZeroDivisionError
     except ZeroDivisionError:
-        f = sys.exc_info()[2].tb_frame.f_back
+        frame = sys.exc_info()[2].tb_frame.f_back
 
-    return _format_stack_trace(_extract_stack(f, skip, limit))
+    return _format_stack_trace(_extract_stack(frame, skip, limit))
 
 
 def _extract_tb(tb, limit):
@@ -93,7 +93,7 @@ def _extract_tb(tb, limit):
         n += 1
 
     n = 0
-    l = []
+    frame_list = []
 
     # We have now the top traceback object for the limit of what we are
     # to return. The bottom most will be that where the error occurred.
@@ -101,13 +101,13 @@ def _extract_tb(tb, limit):
     tb = top
 
     while tb is not None and n < limit:
-        f = tb.tb_frame
-        l.append(dict(source=f.f_code.co_filename, line=tb.tb_lineno, name=f.f_code.co_name))
+        frame = tb.tb_frame
+        frame_list.append({"source": frame.f_code.co_filename, "line": tb.tb_lineno, "name": frame.f_code.co_name})
 
         tb = tb.tb_next
         n += 1
 
-    return l
+    return frame_list
 
 
 def exception_stack(tb, limit=None):

--- a/newrelic/core/string_table.py
+++ b/newrelic/core/string_table.py
@@ -19,7 +19,7 @@ class StringTable:
         self.__mapping = {}
 
     def cache(self, value):
-        if not value in self.__mapping:
+        if value not in self.__mapping:
             token = f"`{len(self.__values)}"
             self.__mapping[value] = token
             self.__values.append(value)

--- a/newrelic/hooks/datastore_firestore.py
+++ b/newrelic/hooks/datastore_firestore.py
@@ -42,25 +42,43 @@ def _conn_str_to_port(getter):
 
 
 # Default Target ID and Instance Info
-_get_object_id = lambda obj, *args, **kwargs: getattr(obj, "id", None)
-_get_client_database_string = lambda obj, *args, **kwargs: getattr(
-    getattr(obj, "_client", None), "_database_string", None
-)
-_get_client_target = lambda obj, *args, **kwargs: obj._client._target
+def _get_object_id(obj, *args, **kwargs):
+    return getattr(obj, "id", None)
+
+
+def _get_client_database_string(obj, *args, **kwargs):
+    return getattr(getattr(obj, "_client", None), "_database_string", None)
+
+
+def _get_client_target(obj, *args, **kwargs):
+    return obj._client._target
+
+
 _get_client_target_host = _conn_str_to_host(_get_client_target)
 _get_client_target_port = _conn_str_to_port(_get_client_target)
 
+
 # Client Instance Info
-_get_database_string = lambda obj, *args, **kwargs: getattr(obj, "_database_string", None)
-_get_target = lambda obj, *args, **kwargs: obj._target
+def _get_database_string(obj, *args, **kwargs):
+    return getattr(obj, "_database_string", None)
+
+
+def _get_target(obj, *args, **kwargs):
+    return obj._target
+
+
 _get_target_host = _conn_str_to_host(_get_target)
 _get_target_port = _conn_str_to_port(_get_target)
 
+
 # Query Target ID
-_get_parent_id = lambda obj, *args, **kwargs: getattr(getattr(obj, "_parent", None), "id", None)
+def _get_parent_id(obj, *args, **kwargs):
+    return getattr(getattr(obj, "_parent", None), "id", None)
+
 
 # AggregationQuery Target ID
-_get_collection_ref_id = lambda obj, *args, **kwargs: getattr(getattr(obj, "_collection_ref", None), "id", None)
+def _get_collection_ref_id(obj, *args, **kwargs):
+    return getattr(getattr(obj, "_collection_ref", None), "id", None)
 
 
 def instrument_google_cloud_firestore_v1_base_client(module):

--- a/newrelic/hooks/external_botocore.py
+++ b/newrelic/hooks/external_botocore.py
@@ -495,7 +495,7 @@ def extract_bedrock_cohere_model_streaming_response(response_body, bedrock_attrs
     return bedrock_attrs
 
 
-NULL_EXTRACTOR = lambda *args: {}  # Empty extractor that returns nothing
+NULL_EXTRACTOR = lambda *args: {}  # noqa: E731  # Empty extractor that returns nothing
 MODEL_EXTRACTORS = [  # Order is important here, avoiding dictionaries
     ("amazon.titan-embed", extract_bedrock_titan_embedding_model_request, NULL_EXTRACTOR, NULL_EXTRACTOR),
     ("cohere.embed", extract_bedrock_cohere_embedding_model_request, NULL_EXTRACTOR, NULL_EXTRACTOR),

--- a/newrelic/hooks/external_httpx.py
+++ b/newrelic/hooks/external_httpx.py
@@ -32,14 +32,14 @@ async def newrelic_event_hook_async(response):
         tracer.process_response(getattr(response, "status_code", None), headers)
 
 
-def newrelic_first_gen(l, is_async=False):
+def newrelic_first_gen(wrapped, is_async=False):
     if is_async:
         yield newrelic_event_hook_async
     else:
         yield newrelic_event_hook
     while True:
         try:
-            yield next(l)
+            yield next(wrapped)
         except StopIteration:
             break
 
@@ -50,8 +50,8 @@ class NewRelicFirstList(list):
         self.is_async = is_async
 
     def __iter__(self):
-        l = super().__iter__()
-        return iter(newrelic_first_gen(l, self.is_async))
+        wrapped_iter = super().__iter__()
+        return iter(newrelic_first_gen(wrapped_iter, self.is_async))
 
 
 class NewRelicFirstDict(dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ ignore = [
     "RUF100",  # unused-noqa (TODO: remove this once all linters are enabled)
     "PERF203",  # try-except-in-loop (most of these are unavoidable)
     "S110",  # try-except-pass (Bandit wants us to log the exception, which is usually pointless. Spot check these later)
+    "E722",  # bare-except (too many to fix all at once)
     # Permanently disabled rules
     "D203",  # incorrect-blank-line-before-class
     "D213",  # multi-line-summary-second-line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ ignore = [
     "D213",  # multi-line-summary-second-line
     "ARG001",  # unused-argument
     "PYI024",  # collections-named-tuple (not currently using type annotations)
+    "E501",  # line-too-long (line length handled by formatter)
     # Ruff recommended linter rules to disable when using formatter
     "W191",  # tab-indentation
     "E111",  # indentation-with-invalid-multiple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pep8-naming.extend-ignore-names = ["X", "y"]
 select = [
     # Enabled linters and rules
     # "F",  # Pyflakes
-    # "E",  # pycodestyle
+    "E",  # pycodestyle
     "W",  # pycodestyle
     "I",  # isort
     # "N",  # pep8-naming

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ ignore = [
     "S",  # flake8-bandit (security checks are not necessary in tests)
     "F401",  # unused-import
     "F811",  # redefined-while-unused (pytest fixtures trigger this)
+    "E731",  # lambda-assignment (acceptable in tests)
     "PLR2004",  # magic-value-comparison (comparing to constant values)
     "ASYNC251",  # blocking-sleep-in-async-function (acceptable in tests)
     "B904",  # raise-without-from-inside-except (not necessary in tests)

--- a/tests/adapter_gunicorn/test_aiohttp_app_factory.py
+++ b/tests/adapter_gunicorn/test_aiohttp_app_factory.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 
 import os
-import random
 import socket
 import time
+from urllib.request import urlopen
 
 import pytest
 from testing_support.fixtures import TerminatingPopen
 from testing_support.util import get_open_port
 
 aiohttp = pytest.importorskip("aiohttp")
-from urllib.request import urlopen
 
 version_info = tuple(int(_) for _ in aiohttp.__version__.split(".")[:2])
 

--- a/tests/datastore_psycopg2/test_async.py
+++ b/tests/datastore_psycopg2/test_async.py
@@ -23,9 +23,10 @@ from testing_support.validators.validate_transaction_errors import validate_tran
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 from testing_support.validators.validate_transaction_slow_sql_count import validate_transaction_slow_sql_count
 
+from newrelic.api.background_task import background_task
+
 DB_SETTINGS = postgresql_settings()[0]
 
-from newrelic.api.background_task import background_task
 
 # Settings
 

--- a/tests/datastore_sqlite/test_database.py
+++ b/tests/datastore_sqlite/test_database.py
@@ -16,12 +16,12 @@ import os
 import sqlite3 as database
 import sys
 
-is_pypy = hasattr(sys, "pypy_version_info")
-
 from testing_support.validators.validate_database_trace_inputs import validate_database_trace_inputs
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
+
+is_pypy = hasattr(sys, "pypy_version_info")
 
 DATABASE_DIR = os.environ.get("TOX_ENV_DIR", ".")
 DATABASE_NAME = ":memory:"

--- a/tests/framework_django/test_asgi_application.py
+++ b/tests/framework_django/test_asgi_application.py
@@ -16,6 +16,7 @@ import os
 
 import django
 import pytest
+from testing_support.asgi_testing import AsgiTest
 from testing_support.fixtures import (
     override_application_settings,
     override_generic_settings,
@@ -32,8 +33,6 @@ DJANGO_VERSION = tuple(map(int, django.get_version().split(".")[:2]))
 
 if DJANGO_VERSION[0] < 3:
     pytest.skip("support for asgi added in django 3", allow_module_level=True)
-
-from testing_support.asgi_testing import AsgiTest
 
 scoped_metrics = [
     ("Function/django.contrib.sessions.middleware:SessionMiddleware", 1),

--- a/tests/testing_support/fixtures.py
+++ b/tests/testing_support/fixtures.py
@@ -51,7 +51,7 @@ def _environ_as_bool(name, default=False):
     flag = os.environ.get(name, default)
     if default is None or default:
         try:
-            flag = not flag.lower() in ["off", "false", "0"]
+            flag = flag.lower() not in ["off", "false", "0"]
         except AttributeError:
             pass
     else:


### PR DESCRIPTION
# Overview

* Enable `pycodestyle` E(rror) rules.
* Temporarily disable bare-except rule (`except:` instead of `except Exception:`).
  * Will require a separate effort to track down the intended behavior of each of these, and add `BaseException` or `Exception` depending.
* Disable line-too-long rule, as line length is handled by `ruff format`.
* Fix all other violations.