### PR TITLE
License Header Linter

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # To target other architectures, change the --platform directive in the Dockerfile.
 ARG IMAGE_TAG=latest
 FROM ghcr.io/newrelic/newrelic-python-agent-ci:${IMAGE_TAG}

--- a/.github/LICENSE_HEADER
+++ b/.github/LICENSE_HEADER
@@ -1,0 +1,13 @@
+Copyright 2010 New Relic, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -86,9 +86,10 @@ RUN cd /tmp && \
     rm -rf ./librdkafka-${LIBRDKAFKA_VERSION}
 
 # Setup ODBC config
-RUN sed -i 's|Driver=psqlodbca.so|Driver=/usr/lib/x86_64-linux-gnu/odbc/psqlodbca.so|g' /etc/odbcinst.ini && \
-    sed -i 's|Driver=psqlodbcw.so|Driver=/usr/lib/x86_64-linux-gnu/odbc/psqlodbcw.so|g' /etc/odbcinst.ini && \
-    sed -i 's|Setup=libodbcpsqlS.so|Setup=/usr/lib/x86_64-linux-gnu/odbc/libodbcpsqlS.so|g' /etc/odbcinst.ini
+RUN [[ "$TARGETPLATFORM" == "linux/amd64" ]] && ARCH="x86_64" || ARCH="aarch64" && \
+    sed -i 's|Driver=psqlodbca.so|Driver=/usr/lib/${ARCH}-linux-gnu/odbc/psqlodbca.so|g' /etc/odbcinst.ini && \
+    sed -i 's|Driver=psqlodbcw.so|Driver=/usr/lib/${ARCH}-linux-gnu/odbc/psqlodbcw.so|g' /etc/odbcinst.ini && \
+    sed -i 's|Setup=libodbcpsqlS.so|Setup=/usr/lib/${ARCH}-linux-gnu/odbc/libodbcpsqlS.so|g' /etc/odbcinst.ini
 
 # Set the locale
 RUN locale-gen --no-purge en_US.UTF-8

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 FROM ubuntu:20.04
+ARG TARGETPLATFORM
 
 # Install OS packages
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -60,6 +61,17 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         zlib1g-dev \
         zsh && \
     rm -rf /var/lib/apt/lists/*
+
+# Install addlicense binary
+ARG ADDLICENSE_VERSION=1.1.1
+RUN [[ "$TARGETPLATFORM" == "linux/amd64" ]] && ARCH="x86_64" || ARCH="arm64" && \
+    mkdir -p /tmp/addlicense && \
+    wget https://github.com/google/addlicense/releases/download/v${ADDLICENSE_VERSION}/addlicense_${ADDLICENSE_VERSION}_Linux_${ARCH}.tar.gz \
+        -O /tmp/addlicense/addlicense.tar.gz && \
+        tar -xzvf /tmp/addlicense/addlicense.tar.gz -C /tmp/addlicense && \
+    mv /tmp/addlicense/addlicense /usr/local/bin/addlicense && \
+    rm -rf /tmp/addlicense && \
+    chmod +x /usr/local/bin/addlicense
 
 # Build librdkafka from source
 ARG LIBRDKAFKA_VERSION=2.1.1

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -64,7 +64,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # Install addlicense binary
 ARG ADDLICENSE_VERSION=1.1.1
-RUN [[ "$TARGETPLATFORM" == "linux/amd64" ]] && ARCH="x86_64" || ARCH="arm64" && \
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export ARCH="x86_64"; else export ARCH="arm64"; fi && \
     mkdir -p /tmp/addlicense && \
     wget https://github.com/google/addlicense/releases/download/v${ADDLICENSE_VERSION}/addlicense_${ADDLICENSE_VERSION}_Linux_${ARCH}.tar.gz \
         -O /tmp/addlicense/addlicense.tar.gz && \
@@ -86,7 +86,7 @@ RUN cd /tmp && \
     rm -rf ./librdkafka-${LIBRDKAFKA_VERSION}
 
 # Setup ODBC config
-RUN [[ "$TARGETPLATFORM" == "linux/amd64" ]] && ARCH="x86_64" || ARCH="aarch64" && \
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then export ARCH="x86_64"; else export ARCH="aarch64"; fi && \
     sed -i 's|Driver=psqlodbca.so|Driver=/usr/lib/${ARCH}-linux-gnu/odbc/psqlodbca.so|g' /etc/odbcinst.ini && \
     sed -i 's|Driver=psqlodbcw.so|Driver=/usr/lib/${ARCH}-linux-gnu/odbc/psqlodbcw.so|g' /etc/odbcinst.ini && \
     sed -i 's|Setup=libodbcpsqlS.so|Setup=/usr/lib/${ARCH}-linux-gnu/odbc/libodbcpsqlS.so|g' /etc/odbcinst.ini

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 version: 2
 updates:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # For condition grammar see: https://docs.mergify.com/conditions/#grammar
 
 pull_request_rules:

--- a/.github/workflows/addlicense.yml
+++ b/.github/workflows/addlicense.yml
@@ -33,6 +33,8 @@ jobs:
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
 

--- a/.github/workflows/addlicense.yml
+++ b/.github/workflows/addlicense.yml
@@ -1,0 +1,64 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Check License Headers
+
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - "**"
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  # Tests
+  addlicense:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # 4.1.1
+
+      - name: Fetch git tags
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --tags origin
+
+      - name: Check License Headers
+        shell: bash
+        run: |
+          addlicense -f ./.github/LICENSE_HEADER -check -ignore "newrelic/packages/**/*" $(git ls-tree -r HEAD --name-only) >output.log
+          if [[ $? -eq 0 ]]; then
+            echo "All files have the correct license header."
+          else
+            echo "License header missing from the following files:"
+            cat output.log | sed s'/^/ - /'
+            echo '
+              To automatically add the license header to files that are missing it:
+              Download the addlicense binary for your architecture and add it to your $PATH
+              https://github.com/google/addlicense/releases
+
+              Then run the following command from the repository root directory:
+              addlicense -f ./.github/LICENSE_HEADER -ignore "newrelic/packages/**/*" $(git ls-tree -r HEAD --name-only)' \
+                  | sed 's/^ *//'
+            exit 1
+          fi

--- a/.github/workflows/addlicense.yml
+++ b/.github/workflows/addlicense.yml
@@ -29,8 +29,6 @@ concurrency:
 jobs:
   # Tests
   addlicense:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
@@ -46,13 +44,15 @@ jobs:
       - name: Check License Headers
         shell: bash
         run: |
-          addlicense -f ./.github/LICENSE_HEADER -check -ignore "newrelic/packages/**/*" $(git ls-tree -r HEAD --name-only) >output.log
-          if [[ $? -eq 0 ]]; then
-            echo "All files have the correct license header."
+          # shellcheck disable=SC2046
+          if addlicense -f ./.github/LICENSE_HEADER -check -ignore "newrelic/packages/**/*" $(git ls-tree -r HEAD --name-only) >output.log; then
+          echo "All files have the correct license header."
           else
-            echo "License header missing from the following files:"
-            cat output.log | sed s'/^/ - /'
-            echo '
+          echo "License header missing from the following files:"
+          sed s'/^/ - /' <output.log
+
+          # shellcheck disable=SC2016
+          echo '
               To automatically add the license header to files that are missing it:
               Download the addlicense binary for your architecture and add it to your $PATH
               https://github.com/google/addlicense/releases
@@ -60,5 +60,5 @@ jobs:
               Then run the following command from the repository root directory:
               addlicense -f ./.github/LICENSE_HEADER -ignore "newrelic/packages/**/*" $(git ls-tree -r HEAD --name-only)' \
                   | sed 's/^ *//'
-            exit 1
+          exit 1
           fi

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 # MegaLinter GitHub Action configuration file
 # More info at https://megalinter.io

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Configuration file for Mega-Linter
 # See all available variables at https://oxsecurity.github.io/megalinter/configuration/ and in linters documentation
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ignore:
   - "newreilc/hooks/component_sentry.py"
   - "newrelic/admin/*"

--- a/newrelic/core/infinite_tracing.proto
+++ b/newrelic/core/infinite_tracing.proto
@@ -1,3 +1,17 @@
+// Copyright 2010 New Relic, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Generate pb2 files using the following command:
 // python -m grpc_tools.protoc --proto_path=newrelic/core --python_out=newrelic/core newrelic/core/infinite_tracing.proto
 

--- a/newrelic/hooks/component_graphqlserver.py
+++ b/newrelic/hooks/component_graphqlserver.py
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from newrelic.api.error_trace import ErrorTrace
 from newrelic.api.graphql_trace import GraphQLOperationTrace
 from newrelic.api.transaction import current_transaction

--- a/newrelic/hooks/datastore_aiomcache.py
+++ b/newrelic/hooks/datastore_aiomcache.py
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from newrelic.api.datastore_trace import wrap_datastore_trace
 
 _memcache_client_methods = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [tool.ruff]
 output-format = "grouped"
 line-length = 120

--- a/tests/cross_agent/fixtures/ecs_container_id/ecs_mock_server.py
+++ b/tests/cross_agent/fixtures/ecs_container_id/ecs_mock_server.py
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 
 import pytest

--- a/tests/mlmodel_langchain/new_vectorstore_adder.py
+++ b/tests/mlmodel_langchain/new_vectorstore_adder.py
@@ -1,3 +1,17 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 This script is used to automatically add new vectorstore classes to the newrelic-python-agent.
 To run this script, start from the root of the newrelic-python-agent repository and run:


### PR DESCRIPTION
# Overview

* Add `google/addlicense` license header linter to CI image.
  * Unavailable in Megalinter, and the pre-built docker image is a bit too restrictive with no shell.
* Add GHA job to check license headers.
* Fix all files missing license headers.

# Testing

* Working test run with dev CI image [here](https://github.com/newrelic/newrelic-python-agent/actions/runs/14605392744/job/40973183282?pr=1357).
