### PR TITLE
Add pre-commit Hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Linter
 megalinter-reports/
-.pre-commit-config.yaml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,26 +22,32 @@
 # To revert that, you can use:
 #   git update-index --no-assume-unchanged .pre-commit-config.yaml
 
-default_install_hook_types: 
+default_install_hook_types:
   - pre-commit
   - pre-push
 
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.11.5
-  hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-      stages: [ pre-push ]
-    # Run the formatter.
-    - id: ruff-format
-      stages: [ pre-push ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.11.5
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+        stages: [pre-push]
+      # Run the formatter.
+      - id: ruff-format
+        stages: [pre-push]
 
-- repo: https://github.com/google/addlicense
-  rev: 55a521bf81c24480094950caa3566548fa63875e
-  hooks:
-  - id: addlicense
-    args: [ "-f", "./.github/LICENSE_HEADER", "-ignore", "newrelic/packages/**/*" ]
-    stages: [ pre-push ]
+  - repo: https://github.com/google/addlicense
+    rev: 55a521bf81c24480094950caa3566548fa63875e
+    hooks:
+      - id: addlicense
+        args:
+          [
+            "-f",
+            "./.github/LICENSE_HEADER",
+            "-ignore",
+            "newrelic/packages/**/*",
+          ]
+        stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To install, run:
+#   pip install --upgrade pre-commit
+#   pre-commit install --install-hooks
+#
+# To change this file for local use without git picking it up, you can mark it with:
+#   git update-index --assume-unchanged .pre-commit-config.yaml
+#
+# To revert that, you can use:
+#   git update-index --no-assume-unchanged .pre-commit-config.yaml
+
+default_install_hook_types: 
+  - pre-commit
+  - pre-push
+
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.11.5
+  hooks:
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+      stages: [ pre-push ]
+    # Run the formatter.
+    - id: ruff-format
+      stages: [ pre-push ]
+
+- repo: https://github.com/google/addlicense
+  rev: 55a521bf81c24480094950caa3566548fa63875e
+  hooks:
+  - id: addlicense
+    args: [ "-f", "./.github/LICENSE_HEADER", "-ignore", "newrelic/packages/**/*" ]
+    stages: [ pre-push ]


### PR DESCRIPTION
# Overview

* Adds a default `pre-commit` config file, with `ruff` and `addlicense` hooks set to `pre-push`.
  * Using this file is entirely optional, and includes instructions for editing the defaults.