### PR TITLE
Enable instrospection_queries config setting

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -47,12 +47,7 @@ from newrelic.core.agent_control_health import (
     agent_control_health_instance,
     agent_control_healthcheck_loop,
 )
-from newrelic.core.config import (
-    Settings,
-    apply_config_setting,
-    default_host,
-    fetch_config_setting,
-)
+from newrelic.core.config import Settings, apply_config_setting, default_host, fetch_config_setting
 
 __all__ = ["initialize", "filter_app_factory"]
 

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -47,7 +47,12 @@ from newrelic.core.agent_control_health import (
     agent_control_health_instance,
     agent_control_healthcheck_loop,
 )
-from newrelic.core.config import Settings, apply_config_setting, default_host, fetch_config_setting
+from newrelic.core.config import (
+    Settings,
+    apply_config_setting,
+    default_host,
+    fetch_config_setting,
+)
 
 __all__ = ["initialize", "filter_app_factory"]
 
@@ -503,6 +508,7 @@ def _process_configuration(section):
     _process_setting(section, "k8s_operator.enabled", "getboolean", None)
     _process_setting(section, "azure_operator.enabled", "getboolean", None)
     _process_setting(section, "package_reporting.enabled", "getboolean", None)
+    _process_setting(section, "instrumentation.graphql.capture_introspection_queries", "getboolean", None)
 
 
 # Loading of configuration from specified file and for specified


### PR DESCRIPTION
`instrumentation.graphql.capture_introspection_queries` should be configurable through the `*.ini` file as well as the `NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES` environment variable, but it was missing from the `newrelic/config.py` settings declaration.