### PR TITLE
Enable hidden file uploads for coverage

### DIFF
--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: ${{ github.job }}-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
+          if-no-files-found: fail
           retention-days: 1
 
   build-linux-py3:
@@ -98,6 +99,7 @@ jobs:
         with:
           name: ${{ github.job }}-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
+          if-no-files-found: fail
           retention-days: 1
 
   build-sdist:
@@ -130,6 +132,7 @@ jobs:
           path: |
             ./dist/*.tar.gz
             ./dist/*.tar.gz.md5
+          if-no-files-found: fail
           retention-days: 1
 
   deploy:

--- a/.github/workflows/deploy-python.yml
+++ b/.github/workflows/deploy-python.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           name: ${{ github.job }}-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   build-linux-py3:
@@ -99,7 +99,7 @@ jobs:
         with:
           name: ${{ github.job }}-${{ matrix.wheel }}
           path: ./wheelhouse/*.whl
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   build-sdist:
@@ -132,7 +132,7 @@ jobs:
           path: |
             ./dist/*.tar.gz
             ./dist/*.tar.gz.md5
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   deploy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   grpc:
@@ -213,7 +213,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   nginx:
@@ -278,7 +278,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   postgres16:
@@ -344,7 +344,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   postgres9:
@@ -410,7 +410,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   mssql:
@@ -479,7 +479,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   mysql:
@@ -548,7 +548,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   rediscluster:
@@ -653,7 +653,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   redis:
@@ -717,7 +717,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   solr:
@@ -783,7 +783,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   memcached:
@@ -847,7 +847,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   rabbitmq:
@@ -912,7 +912,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   kafka:
@@ -988,7 +988,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   mongodb3:
@@ -1052,7 +1052,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   mongodb8:
@@ -1116,7 +1116,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   cassandra:
@@ -1185,7 +1185,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   elasticsearchserver07:
@@ -1251,7 +1251,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   elasticsearchserver08:
@@ -1318,7 +1318,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   firestore:
@@ -1389,7 +1389,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1
 
   valkey:
@@ -1453,5 +1453,5 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
-          if-no-files-found: fail
+          if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   grpc:
@@ -210,6 +211,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   nginx:
@@ -273,6 +275,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   postgres16:
@@ -337,6 +340,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   postgres9:
@@ -401,6 +405,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   mssql:
@@ -468,6 +473,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   mysql:
@@ -535,6 +541,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   rediscluster:
@@ -638,6 +645,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   redis:
@@ -700,6 +708,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   solr:
@@ -764,6 +773,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   memcached:
@@ -826,6 +836,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   rabbitmq:
@@ -889,6 +900,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   kafka:
@@ -963,6 +975,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   mongodb3:
@@ -1025,6 +1038,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   mongodb8:
@@ -1087,6 +1101,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   cassandra:
@@ -1154,6 +1169,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   elasticsearchserver07:
@@ -1218,6 +1234,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   elasticsearchserver08:
@@ -1283,6 +1300,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   firestore:
@@ -1352,6 +1370,7 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   valkey:
@@ -1414,4 +1433,5 @@ jobs:
         with:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
+          include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   grpc:
@@ -212,6 +213,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   nginx:
@@ -276,6 +278,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   postgres16:
@@ -341,6 +344,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   postgres9:
@@ -406,6 +410,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   mssql:
@@ -474,6 +479,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   mysql:
@@ -542,6 +548,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   rediscluster:
@@ -646,6 +653,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   redis:
@@ -709,6 +717,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   solr:
@@ -774,6 +783,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   memcached:
@@ -837,6 +847,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   rabbitmq:
@@ -901,6 +912,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   kafka:
@@ -976,6 +988,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   mongodb3:
@@ -1039,6 +1052,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   mongodb8:
@@ -1102,6 +1116,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   cassandra:
@@ -1170,6 +1185,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   elasticsearchserver07:
@@ -1235,6 +1251,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   elasticsearchserver08:
@@ -1301,6 +1318,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   firestore:
@@ -1371,6 +1389,7 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1
 
   valkey:
@@ -1434,4 +1453,5 @@ jobs:
           name: coverage-${{ github.job }}-${{ strategy.job-index }}
           path: ./**/.coverage.*
           include-hidden-files: true
+          if-no-files-found: fail
           retention-days: 1


### PR DESCRIPTION
# Overview

* Fix coverage upload by enabling `include-hidden-files: true` on `actions/upload-artifact`
* Include `if-no-files-found: error` to prevent future issues.