### PR TITLE
Fix Tests Workflow Status

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
   # Aggregate job that provides a single check for all tests passing
   tests:
     runs-on: ubuntu-24.04
+    if: always() # Always run, even on cancellation or failure
     needs:
       - python
       - cassandra
@@ -55,13 +56,23 @@ jobs:
       - valkey
 
     steps:
-      - name: Success
-        run: echo "Success!"
+      - name: Status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Workflow cancelled."
+            exit 1
+          elif [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more jobs failed."
+            exit 1
+          else
+            echo "All jobs completed successfully."
+            exit 0
+          fi
 
   # Combine and upload coverage data
   coverage:
-    if: success() || failure() # Does not run on cancelled workflows
     runs-on: ubuntu-24.04
+    if: success() || failure() # Does not run on cancelled workflows
     needs:
       - tests
 


### PR DESCRIPTION
# Overview

* Fix tests job status check setting to skipped on a test failure rather than failure.

# Testing

Example workflow runs:

* [Cancelled](https://github.com/newrelic/newrelic-python-agent/actions/runs/14784891316/job/41511479416?pr=1381)
* [Failure](https://github.com/newrelic/newrelic-python-agent/actions/runs/14784895255/job/41511806059?pr=1381)
* Success (Current run)