### PR TITLE
Fix pymssql Tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ envlist =
     mongodb3-datastore_pymongo-{py37,py38,py39,py310,py311,py312}-pymongo03,
     mongodb8-datastore_pymongo-{py37,py38,py39,py310,py311,py312,py313,pypy310}-pymongo04,
     mysql-datastore_aiomysql-{py37,py38,py39,py310,py311,py312,py313,pypy310},
-    mssql-datastore_pymssql-{py37,py38,py39,py310,py311,py312,py313},
+    mssql-datastore_pymssql-pymssqllatest-{py39,py310,py311,py312,py313},
+    mssql-datastore_pymssql-pymssql020301-{py37,py38},
     mysql-datastore_mysql-mysqllatest-{py37,py38,py39,py310,py311,py312,py313},
     mysql-datastore_mysqldb-{py38,py39,py310,py311,py312,py313},
     mysql-datastore_pymysql-{py37,py38,py39,py310,py311,py312,py313,pypy310},
@@ -288,7 +289,8 @@ deps =
     datastore_motor-motorlatest: tornado
     datastore_pymongo-pymongo03: pymongo<4.0
     datastore_pymongo-pymongo04: pymongo<5.0
-    datastore_pymssql: pymssql
+    datastore_pymssql-pymssqllatest: pymssql
+    datastore_pymssql-pymssql020301: pymssql==2.3.1
     datastore_pymysql: PyMySQL
     datastore_pymysql: cryptography
     datastore_pysolr: pysolr<4.0


### PR DESCRIPTION
# Overview

* `pymssql` updated to only support Python 3.9+. Pin older Python versions to a compatible version of `pymssql`.
  * v2.3.2 lists support for Python 3.7 and 3.8, but doesn't have prebuilt wheels and fails to build. v2.3.1 is used instead.