### PR TITLE
Modify MCP span naming

### DIFF
--- a/newrelic/hooks/adapter_mcp.py
+++ b/newrelic/hooks/adapter_mcp.py
@@ -29,7 +29,7 @@ async def wrap_call_tool(wrapped, instance, args, kwargs):
     func_name = callable_name(wrapped)
     function_trace_name = f"{func_name}/{tool_name}"
 
-    with FunctionTrace(name=function_trace_name, source=wrapped):
+    with FunctionTrace(name=function_trace_name, group="Llm/tool/MCP", source=wrapped):
         return await wrapped(*args, **kwargs)
 
 

--- a/tests/adapter_mcp/test_tools.py
+++ b/tests/adapter_mcp/test_tools.py
@@ -34,8 +34,8 @@ def fastmcp_server():
 
 @validate_transaction_metrics(
     "test_tools:test_tool_tracing",
-    scoped_metrics=[("Function/mcp.client.session:ClientSession.call_tool/add_exclamation", 1)],
-    rollup_metrics=[("Function/mcp.client.session:ClientSession.call_tool/add_exclamation", 1)],
+    scoped_metrics=[("Llm/tool/MCP/mcp.client.session:ClientSession.call_tool/add_exclamation", 1)],
+    rollup_metrics=[("Llm/tool/MCP/mcp.client.session:ClientSession.call_tool/add_exclamation", 1)],
     background_task=True,
 )
 @background_task()


### PR DESCRIPTION
This PR modifies the function for MCP's `call_tool` to be grouped under `Llm/tool/MCP` 