### PR TITLE
Pin tracerite

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -380,7 +380,8 @@ deps =
     framework_sanic-sanic2290: sanic<22.9.1
     framework_sanic-sanic2406: sanic<24.07
     framework_sanic-saniclatest: sanic
-    ; Pin this temporarily since there is a bug in v1.1.2 in inspector.py, line 119 
+    ; Pin this temporarily since there is a bug in v1.1.2 in inspector.py, line 119
+    framework_sanic-sanic2406: tracerite<1.1.2
     framework_sanic-saniclatest: tracerite<1.1.2
     framework_sanic-sanic{200904,210300,2109,2112,2203,2290}: websockets<11
     ; For test_exception_in_middleware test, anyio is used:


### PR DESCRIPTION
[`tracerite`](https://github.com/sanic-org/tracerite/tree/main), upon which [`sanic`](https://github.com/sanic-org/sanic) is dependent, has released their latest version, but there is a syntax error, causing the latest version of `sanic` to fail.  This PR pins to the previous version of `tracerite`.

There is already an open source PR to fix this issue: https://github.com/sanic-org/tracerite/pull/24