### PR TITLE
Ignore Known Trivy Vulnerabilities

### DIFF
--- a/.github/.trivyignore
+++ b/.github/.trivyignore
@@ -1,0 +1,9 @@
+# =======================
+# Ignored Vulnerabilities
+# =======================
+
+# Accepting risk due to Python 3.7 and 3.8 support.
+CVE-2025-50181
+
+# Not relevant, only affects Pyodide
+CVE-2025-50182

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,6 +43,7 @@ jobs:
           format: table
           exit-code: 1
           severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          trivyignores: ".github/.trivyignore"
 
       - name: Run Trivy vulnerability scanner in repo mode
         if: ${{ github.event_name == 'schedule' }}
@@ -53,6 +54,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          trivyignores: ".github/.trivyignore"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
# Overview

* Add a `.trivyignore` file that contains known and accepted vulnerabilities to unblock the failing check.

# Accepted Risks

* [CVE-2025-50181](https://nvd.nist.gov/vuln/detail/CVE-2025-50181) affects our use of `urllib3` by making it possible to disable redirects, but we already explicitly do this.
* [CVE-2025-50182](https://nvd.nist.gov/vuln/detail/CVE-2025-50182) is related to the use of Python in browsers using tools like `Pyodide`. It's not relevant to our codebase.