### PR TITLE
Update Sanic versions in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -144,7 +144,7 @@ envlist =
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,py313,pypy310}-Pyramid0110-cornice,
     python-framework_sanic-{py37,py38}-sanic2406,
     python-framework_sanic-{py39,py310,py311,py312,py313,pypy310}-saniclatest,
-    python-framework_sanic-{py38,pypy310}-sanic{200904,210300,2109,2112,2203,2290},
+    python-framework_sanic-{py38,pypy310}-sanic{201207,2112,2290},
     python-framework_starlette-{py310,pypy310}-starlette{0014,0015,0019,0028},
     python-framework_starlette-{py37,py38,py39,py310,py311,py312,py313,pypy310}-starlettelatest,
     python-framework_starlette-{py37,py38}-starlette002001,
@@ -376,18 +376,14 @@ deps =
     framework_pyramid: routes
     framework_pyramid-cornice: cornice!=5.0.0
     framework_pyramid-Pyramidlatest: Pyramid
-    framework_sanic-sanic200904: sanic<20.9.5
-    framework_sanic-sanic210300: sanic<21.3.1
-    framework_sanic-sanic2109: sanic<21.10
+    framework_sanic-sanic201207: sanic<20.12.8
     framework_sanic-sanic2112: sanic<21.13
-    framework_sanic-sanic2203: sanic<22.4
     framework_sanic-sanic2290: sanic<22.9.1
     framework_sanic-sanic2406: sanic<24.07
     framework_sanic-saniclatest: sanic
-    ; Pin this temporarily since there is a bug in v1.1.2 in inspector.py, line 119
+    ; This is the last version of tracerite that supports Python 3.7
     framework_sanic-sanic2406: tracerite<1.1.2
-    framework_sanic-saniclatest: tracerite<1.1.2
-    framework_sanic-sanic{200904,210300,2109,2112,2203,2290}: websockets<11
+    framework_sanic-sanic{201207,2112,2290}: websockets<11
     ; For test_exception_in_middleware test, anyio is used:
     ; https://github.com/encode/starlette/pull/1157
     ; but anyiolatest creates breaking changes to our tests


### PR DESCRIPTION
This PR:

- Unpins tracerite due to bug for sanic latest tests
- Keeps tracerite pinned for Python 3.7 tests
- Updates supported Sanic versions by New Relic in tests