### PR TITLE
Fix Changed Paths in Azure Functions Install

### DIFF
--- a/.github/scripts/install_azure_functions_worker.sh
+++ b/.github/scripts/install_azure_functions_worker.sh
@@ -33,14 +33,15 @@ INVOKE="${BUILD_DIR}/.venv/bin/invoke"
 ${PIP} install pip-tools build invoke
 
 # Install proto build dependencies
-$(cd ${BUILD_DIR} && ${PIPCOMPILE} >${BUILD_DIR}/requirements.txt)
+$( cd ${BUILD_DIR}/workers/ && ${PIPCOMPILE} -o ${BUILD_DIR}/requirements.txt )
 ${PIP} install -r ${BUILD_DIR}/requirements.txt
 
-# Build proto files into pb2 files
-cd ${BUILD_DIR}/tests && ${INVOKE} -c test_setup build-protos
+# Build proto files into pb2 files (invoke handles fixing include paths for the protos)
+cd ${BUILD_DIR}/workers/tests && ${INVOKE} -c test_setup build-protos
 
 # Build and install the package into the original environment (not the build venv)
-pip install ${BUILD_DIR}
+# Do NOT use ${PIP} from the venv
+pip install ${BUILD_DIR}/workers/
 
 # Clean up and return to the original directory
 rm -rf ${BUILD_DIR}

--- a/tests/adapter_mcp/test_mcp.py
+++ b/tests/adapter_mcp/test_mcp.py
@@ -61,7 +61,7 @@ def test_tool_tracing(loop, fastmcp_server):
             # Call the MCP tool, so we can validate the trace naming is correct.
             result = await client.call_tool("add_exclamation", {"phrase": "Python is awesome"})
 
-            content = str(result[0])
+            content = str(result.content[0])
         assert "Python is awesome!" in content
 
     loop.run_until_complete(_test())


### PR DESCRIPTION
# Overview

* Fix for path changes in `azure-functions-worker` that prevented installing via `tox` scripting.
* Also patches tiny failure in MCP testing, where result contents are now in a container that needs unpacked.