### PR TITLE
Fix Markdown Link Name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Include a link to the related GitHub issue, if applicable
 # Testing
 The agent includes a suite of tests which should be used to
 verify your changes don't break existing functionality. These tests will run with
-Github Actions when a pull request is made. More details on running the tests locally can be found
-[here](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.md#testing-guidelines),
+Github Actions when a pull request is made. More details on running the tests locally can be found in our
+[testing guidelines](https://github.com/newrelic/newrelic-python-agent/blob/main/CONTRIBUTING.md#testing-guidelines),
 For most contributions it is strongly recommended to add additional tests which
 exercise your changes.


### PR DESCRIPTION
# Overview

* Fix warning from markdown linters about link name being non-descriptive.