### PR TITLE
Add Workflow Permissions

### DIFF
--- a/.github/workflows/addlicense.yml
+++ b/.github/workflows/addlicense.yml
@@ -22,6 +22,9 @@ on:
       - "**"
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -17,6 +17,9 @@ name: Build CI Image
 on:
   workflow_dispatch: # Allow manual trigger
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.ref || github.run_id }}
   cancel-in-progress: true
@@ -24,6 +27,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -45,7 +45,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      statuses: write
     steps:
       # Git Checkout
       - name: Checkout Code
@@ -65,7 +64,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-          GITHUB_STATUS_REPORTER: "true"
           GITHUB_COMMENT_REPORTER: "true"
           PYTHON_RUFF_ARGUMENTS: --config pyproject.toml --config 'output-format="github"'
           PYTHON_RUFF_FORMAT_ARGUMENTS: --config pyproject.toml --config 'output-format="github"'

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -22,6 +22,9 @@ on:
   # push: # Comment this line to trigger action only on pull-requests (not recommended if you don't pay for GH Actions)
   pull_request:
 
+permissions:
+  contents: read
+
 env: # Comment env block if you don't want to apply fixes
   # Apply linter fixes configuration
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.ref || github.run_id }}-${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Upload Trivy data
   trivy:


### PR DESCRIPTION
# Overview

* Add default permissions to all workflows to satisfy security scanning.
* Remove statuses permissions from Megalinter
  * Also removes status reporter, a deprecated and buggy feature.