### PR TITLE
Fix Issues Related to Path.parent with no Parent Directory

### DIFF
--- a/newrelic/admin/run_program.py
+++ b/newrelic/admin/run_program.py
@@ -99,17 +99,18 @@ def run_program(args):
     # be found in current working directory even though '.'
     # not in PATH.
 
-    program_exe_path = Path(args[0])
+    program_exe_path = args[0]
 
-    if not program_exe_path.parent:
+    # Don't use path.parent, as it can't distinguish between ./ and no parent.
+    if not os.path.dirname(program_exe_path):  # noqa: PTH120
         program_search_path = os.environ.get("PATH", "").split(os.pathsep)
         for path in program_search_path:
             path = Path(path) / program_exe_path
             if path.exists() and os.access(path, os.X_OK):
-                program_exe_path = path
+                program_exe_path = str(path)  # Convert to str to match other code path
                 break
 
-    log_message("program_exe_path = %r", str(program_exe_path))
+    log_message("program_exe_path = %r", program_exe_path)
     log_message("execl_arguments = %r", [program_exe_path, *args])
 
     os.execl(program_exe_path, *args)  # noqa: S606

--- a/newrelic/admin/run_python.py
+++ b/newrelic/admin/run_python.py
@@ -96,15 +96,17 @@ def run_python(args):
     # this script in preference to that used to execute this
     # script.
 
-    bin_directory = Path(sys.argv[0]).parent
+    argv_executable = sys.argv[0]
 
+    # Don't use path.parent, as it can't distinguish between ./ and no parent.
+    bin_directory = os.path.dirname(argv_executable)  # noqa: PTH120
     if bin_directory:
         python_exe = Path(sys.executable).name
-        python_exe_path = bin_directory / python_exe
+        python_exe_path = Path(bin_directory) / python_exe
         if not python_exe_path.exists() or not os.access(python_exe_path, os.X_OK):
-            python_exe_path = sys.executable
+            python_exe_path = Path(sys.executable)
     else:
-        python_exe_path = sys.executable
+        python_exe_path = Path(sys.executable)
 
     log_message("python_exe_path = %r", str(python_exe_path))
     log_message("execl_arguments = %r", [python_exe_path, python_exe_path, *args])

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,6 @@ def newrelic_agent_next_version(version):
 
 
 script_directory = Path(__file__).parent
-if not script_directory:
-    script_directory = Path(os.getcwd())
 
 readme_file = script_directory / "README.md"
 with readme_file.open() as f:


### PR DESCRIPTION
# Overview

* Fix instances of calling `pathlib.Path.parent` on a command line path, that may have no parent directory listed.
  * In these cases, this should search the `PATH` to find an executable of this name. Instead, the current change is interpreting no parent as `./`, producing incorrect results.
  * Fix this by reverting to `os.path.dirname` for this specific use case, and ignore `PTH` linter.

# Testing

* Tested locally with `newrelic-admin run-program flask run` and `newrelic-admin run-python main.py`.
* Can't find a decent way to test the `sys.argv[0]` being an executable with no path, but there's probably not a lot of risk. The comments indicate this is generally a Heroku only thing as well.