### PR TITLE
Add LLMAgent events to autogen instrumentation.

### DIFF
--- a/tests/mlmodel_autogen/conftest.py
+++ b/tests/mlmodel_autogen/conftest.py
@@ -13,20 +13,13 @@
 # limitations under the License.
 
 import json
-
 import pytest
-from autogen_agentchat.agents import AssistantAgent
-from autogen_agentchat.base import TaskResult
-from autogen_agentchat.teams import RoundRobinGroupChat
-from autogen_core import ComponentModel, FunctionCall, Image
+
+from autogen_core import FunctionCall
 from autogen_core.models import CreateResult, RequestUsage
-from autogen_core.models._model_client import ModelFamily
 from autogen_ext.models.replay import ReplayChatCompletionClient
-from pydantic import BaseModel, ValidationError
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
-
-from newrelic.common.object_names import callable_name
 
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slowdowns.
@@ -104,13 +97,13 @@ def multi_tool_model_client():
             ),
             CreateResult(
                 finish_reason="function_calls",
-                content=[FunctionCall(id="2", name="add_exclamation", arguments=json.dumps({"message": "Goodbye"}))],
+                content=[FunctionCall(id="3", name="compute_sum", arguments=json.dumps({"a": 5, "b": 3}))],
                 usage=RequestUsage(prompt_tokens=10, completion_tokens=5),
                 cached=False,
             ),
             CreateResult(
                 finish_reason="function_calls",
-                content=[FunctionCall(id="3", name="compute_sum", arguments=json.dumps({"a": 5, "b": 3}))],
+                content=[FunctionCall(id="2", name="add_exclamation", arguments=json.dumps({"message": "Goodbye"}))],
                 usage=RequestUsage(prompt_tokens=10, completion_tokens=5),
                 cached=False,
             ),

--- a/tests/mlmodel_openai/_mock_external_openai_server.py
+++ b/tests/mlmodel_openai/_mock_external_openai_server.py
@@ -744,7 +744,7 @@ def extract_shortened_prompt(openai_version):
 
 
 def get_openai_version():
-    # Import OpenAI so that get package version can catpure the version from the
+    # Import OpenAI so that get_package_version() can capture the version from the
     # system module. OpenAI does not have a package version in v0.
     import openai
 

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,8 @@ envlist =
     python-logger_logging-{py37,py38,py39,py310,py311,py312,py313,pypy310},
     python-logger_loguru-{py37,py38,py39,py310,py311,py312,py313,pypy310}-logurulatest,
     python-logger_structlog-{py37,py38,py39,py310,py311,py312,py313,pypy310}-structloglatest,
-    python-mlmodel_autogen-{py310,py311,py312,py313,pypy310},
+    python-mlmodel_autogen-{py310,py311,py312,py313,pypy310}-autogen061,
+    python-mlmodel_autogen-{py310,py311,py312,py313,pypy310}-autogenlatest,
     python-mlmodel_gemini-{py39,py310,py311,py312,py313},
     python-mlmodel_langchain-{py39,py310,py311,py312},
     ;; Package not ready for Python 3.13 (uses an older version of numpy)
@@ -408,9 +409,12 @@ deps =
     framework_tornado: pycurl
     framework_tornado-tornadolatest: tornado
     framework_tornado-tornadomaster: https://github.com/tornadoweb/tornado/archive/master.zip
-    mlmodel_autogen: autogen-agentchat
-    mlmodel_autogen: autogen-core
-    mlmodel_autogen: autogen-ext
+    mlmodel_autogen-autogen061: autogen-agentchat<0.6.2
+    mlmodel_autogen-autogen061: autogen-core<0.6.2
+    mlmodel_autogen-autogen061: autogen-ext<0.6.2
+    mlmodel_autogen-autogenlatest: autogen-core
+    mlmodel_autogen-autogenlatest: autogen-ext
+    mlmodel_autogen-autogenlatest: autogen-agentchat
     mlmodel_autogen: mcp
     mlmodel_gemini: google-genai
     mlmodel_openai-openai0: openai[datalib]<1.0


### PR DESCRIPTION
This PR adds new `LlmAgent` custom events to the existing `autogen` instrumentation. This addition supports trace filtering capabilities by agent name in NR1.
