### PR TITLE
Fix Tornado Tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -152,7 +152,7 @@ envlist =
     python-framework_strawberry-{py38,py39,py310,py311,py312}-strawberry02352,
     python-framework_strawberry-{py37,py38,py39,py310,py311,py312,py313}-strawberrylatest,
     python-framework_tornado-{py38,py39,py310,py311,py312,py313}-tornadolatest,
-    python-framework_tornado-{py39,py310,py311,py312,py313}-tornadomaster,
+    python-framework_tornado-{py310,py311,py312,py313}-tornadomaster,
     python-logger_logging-{py37,py38,py39,py310,py311,py312,py313,pypy310},
     python-logger_loguru-{py37,py38,py39,py310,py311,py312,py313,pypy310}-logurulatest,
     python-logger_structlog-{py37,py38,py39,py310,py311,py312,py313,pypy310}-structloglatest,


### PR DESCRIPTION
# Overview

* Fix tox matrix for `tornadomaster` by dropping unsupported py39 runtime.