### PR TITLE
More Specific Attestation List

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,7 +181,9 @@ jobs:
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # 2.4.0
         id: attest
         with:
-          subject-path: ./dist/*
+          subject-path: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
 
       - name: Wait for release to be available
         id: wait


### PR DESCRIPTION
# Overview

* Specify file extensions of artifacts to attest on deploy to remove attestations of attestations.
  * See [example](https://github.com/newrelic/newrelic-python-agent/attestations/9684065) where there are attestations for `.publish.attestation` files. These are attestations for PyPI and should not be included.