### PR TITLE
Remove instrumentation for options method on async ElasticSearch client.

### DIFF
--- a/newrelic/hooks/datastore_elasticsearch.py
+++ b/newrelic/hooks/datastore_elasticsearch.py
@@ -267,7 +267,6 @@ _elasticsearch_client_methods_v8 = (
     ("msearch_template", _extract_args_search_templates_index),
     ("mtermvectors", _extract_args_index),
     ("open_point_in_time", _extract_args_index),
-    ("options", None),
     ("ping", None),
     ("put_script", None),
     ("rank_eval", _extract_args_requests_index),

--- a/tests/datastore_elasticsearch/test_async_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_async_elasticsearch.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from conftest import ES_SETTINGS, IS_V8_OR_ABOVE
+from conftest import ES_SETTINGS, IS_V8_OR_ABOVE, RUN_IF_V8_OR_ABOVE
 from elasticsearch._async import client
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import override_application_settings
@@ -197,6 +197,7 @@ def test_async_elasticsearch_no_transaction(async_client, loop):
     loop.run_until_complete(_exercise_es(async_client))
 
 
+@RUN_IF_V8_OR_ABOVE
 @background_task()
 def test_async_elasticsearch_options_no_crash(async_client, loop):
     """Test that the options method on the async client doesn't cause a crash when run with the agent"""

--- a/tests/datastore_elasticsearch/test_async_elasticsearch.py
+++ b/tests/datastore_elasticsearch/test_async_elasticsearch.py
@@ -203,12 +203,12 @@ def test_async_elasticsearch_options_no_crash(async_client, loop):
     """Test that the options method on the async client doesn't cause a crash when run with the agent"""
 
     async def _test():
-        client_with_auth = async_client.options(basic_auth=('username', 'password'))
+        client_with_auth = async_client.options(basic_auth=("username", "password"))
         assert client_with_auth is not None
         assert client_with_auth != async_client
 
         # If options was instrumented, this would cause a crash since the first call would return an unexpected coroutine
-        client_chained = async_client.options(basic_auth=('user', 'pass')).options(request_timeout=60)
+        client_chained = async_client.options(basic_auth=("user", "pass")).options(request_timeout=60)
         assert client_chained is not None
 
     loop.run_until_complete(_test())

--- a/tests/datastore_elasticsearch/test_async_instrumented_methods.py
+++ b/tests/datastore_elasticsearch/test_async_instrumented_methods.py
@@ -75,7 +75,7 @@ def test_method_on_async_client_datastore_trace_inputs(
 
 def _test_methods_wrapped(_object, ignored_methods=None):
     if not ignored_methods:
-        ignored_methods = {"perform_request", "transport"}
+        ignored_methods = {"perform_request", "transport", "options"}
 
     def is_wrapped(m):
         return hasattr(getattr(_object, m), "__wrapped__")

--- a/tests/datastore_elasticsearch/test_instrumented_methods.py
+++ b/tests/datastore_elasticsearch/test_instrumented_methods.py
@@ -84,7 +84,7 @@ def test_method_on_client_datastore_trace_inputs(client, sub_module, method, arg
 
 def _test_methods_wrapped(_object, ignored_methods=None):
     if not ignored_methods:
-        ignored_methods = {"perform_request", "transport"}
+        ignored_methods = {"perform_request", "transport", "options"}
 
     def is_wrapped(m):
         return hasattr(getattr(_object, m), "__wrapped__")


### PR DESCRIPTION
This PR removes wrapping for the method `options` on the async ES client. This method does not need to be wrapped in a `DatastoreTrace` since it is focused on modifying the client with custom config rather than conducting any datastore operations/ requests. The previous instrumentation caused a crash because the wrapper was expecting all client methods to be async but `options` is actually a sync method. 
