### PR TITLE
Distributed CI Image Build

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -50,6 +50,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         pkg-config \
         python3-dev \
         python3-pip \
+        rustc \
         sudo \
         tzdata \
         unixodbc-dev \

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.ref || github.run_id }}
@@ -26,11 +27,17 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            cache_tag: linux-amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            cache_tag: linux-arm64
+            runner: ubuntu-24.04-arm
 
-    permissions:
-      contents: read
-      packages: write
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
@@ -42,11 +49,17 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # 3.11.1
 
+      # Lowercase image name and append -ci
+      - name: Generate Image Name
+        id: image-name
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}-ci" >>"${GITHUB_OUTPUT}"
+
       - name: Generate Docker Metadata (Tags and Labels)
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # 5.8.0
         with:
-          images: ghcr.io/${{ github.repository }}-ci
+          images: ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }}
           flavor: |
             prefix=
             suffix=
@@ -65,11 +78,84 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Publish Image
+      - name: Build and Push Image by Digest
+        id: build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # 6.18.0
         with:
-          push: ${{ github.event_name != 'pull_request' }}
           context: .github/containers
-          platforms: ${{ (format('refs/heads/{0}', github.event.repository.default_branch) == github.ref) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=build-${{ matrix.cache_tag }}
+          cache-to: type=gha,scope=build-${{ matrix.cache_tag }}
+
+      - name: Export Digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload Digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: digests-${{ matrix.cache_tag }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs:
+      - build
+
+    steps:
+      - name: Download Digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # 5.0.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # 3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # 3.11.1
+
+      # Lowercase image name and append -ci
+      - name: Generate Image Name
+        id: image-name
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}-ci" >>"${GITHUB_OUTPUT}"
+
+      - name: Generate Docker Metadata (Tags and Labels)
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # 5.8.0
+        with:
+          images: ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }}
+          flavor: |
+            prefix=
+            suffix=
+            latest=false
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=schedule,pattern={{date 'YYYY-MM-DD'}}
+            type=sha,format=short,prefix=sha-
+            type=sha,format=long,prefix=sha-
+
+      - name: Create Manifest List and Push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect Image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -16,6 +16,8 @@ name: Build CI Image
 
 on:
   workflow_dispatch: # Allow manual trigger
+  schedule:
+    - cron: "15 16 * * 0"  # At 16:15 UTC on Sunday
 
 permissions:
   contents: read


### PR DESCRIPTION
# Overview

* Upgrade CI image builds to be distributed, allowing them to be built without emulation.
* Add a weekly rebuild of the CI image to keep Python versions up to date.
* Add Rust to the toolchain to avoid slowdowns with building Rust wheels (like cryptography).