### PR TITLE
Fix Falcon Tests for master Branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,7 @@ envlist =
     python-framework_django-{py37,py38,py39,py310,py311,py312,py313}-Djangolatest,
     python-framework_django-{py39}-Django{0202,0300,0301,0302,0401},
     python-framework_falcon-{py37,py38,py39,py310,py311,py312,py313,pypy310}-falconlatest,
-    python-framework_falcon-{py38,py39,py310,py311,py312,py313,pypy310}-falconmaster,
+    python-framework_falcon-{py39,py310,py311,py312,py313,pypy310}-falconmaster,
     python-framework_fastapi-{py37,py38,py39,py310,py311,py312,py313},
     python-framework_flask-py37-flask020205,
     python-framework_flask-{py38,py39,py310,py311,py312,pypy310}-flask02,


### PR DESCRIPTION
# Overview

* Fix tests for Falcon by removing unsupported 3.8 version test on master branch.