### PR TITLE
Add response token count logic to Gemini instrumentation.

### DIFF
--- a/newrelic/hooks/mlmodel_gemini.py
+++ b/newrelic/hooks/mlmodel_gemini.py
@@ -175,20 +175,24 @@ def _record_embedding_success(transaction, embedding_id, linking_metadata, kwarg
         embedding_content = str(embedding_content)
         request_model = kwargs.get("model")
 
+        embedding_token_count = (
+            settings.ai_monitoring.llm_token_count_callback(request_model, embedding_content)
+            if settings.ai_monitoring.llm_token_count_callback
+            else None
+        )
+
         full_embedding_response_dict = {
             "id": embedding_id,
             "span_id": span_id,
             "trace_id": trace_id,
-            "token_count": (
-                settings.ai_monitoring.llm_token_count_callback(request_model, embedding_content)
-                if settings.ai_monitoring.llm_token_count_callback
-                else None
-            ),
             "request.model": request_model,
             "duration": ft.duration * 1000,
             "vendor": "gemini",
             "ingest_source": "Python",
         }
+        if embedding_token_count:
+            full_embedding_response_dict["response.usage.total_tokens"] = embedding_token_count
+
         if settings.ai_monitoring.record_content.enabled:
             full_embedding_response_dict["input"] = embedding_content
 
@@ -241,7 +245,7 @@ def wrap_generate_content_sync(wrapped, instance, args, kwargs):
 
     ft.__exit__(None, None, None)
 
-    _handle_generation_success(transaction, linking_metadata, completion_id, kwargs, ft, return_val)
+    _handle_generation_success(transaction, settings, linking_metadata, completion_id, kwargs, ft, return_val)
 
     return return_val
 
@@ -274,7 +278,7 @@ async def wrap_generate_content_async(wrapped, instance, args, kwargs):
 
     ft.__exit__(None, None, None)
 
-    _handle_generation_success(transaction, linking_metadata, completion_id, kwargs, ft, return_val)
+    _handle_generation_success(transaction, settings, linking_metadata, completion_id, kwargs, ft, return_val)
 
     return return_val
 
@@ -300,15 +304,13 @@ def _record_generation_error(transaction, linking_metadata, completion_id, kwarg
                 "Unable to parse input message to Gemini LLM. Message content and role will be omitted from "
                 "corresponding LlmChatCompletionMessage event. "
             )
+    # Extract the input message content and role from the input message if it exists
+    input_message_content, input_role = _parse_input_message(input_message) if input_message else (None, None)
 
-    generation_config = kwargs.get("config")
-    if generation_config:
-        request_temperature = getattr(generation_config, "temperature", None)
-        request_max_tokens = getattr(generation_config, "max_output_tokens", None)
-    else:
-        request_temperature = None
-        request_max_tokens = None
+    # Extract data from generation config object
+    request_temperature, request_max_tokens = _extract_generation_config(kwargs)
 
+    # Prepare error attributes
     notice_error_attributes = {
         "http.statusCode": getattr(exc, "code", None),
         "error.message": getattr(exc, "message", None),
@@ -348,21 +350,23 @@ def _record_generation_error(transaction, linking_metadata, completion_id, kwarg
 
         create_chat_completion_message_event(
             transaction,
-            input_message,
+            input_message_content,
+            input_role,
             completion_id,
             span_id,
             trace_id,
             # Passing the request model as the response model here since we do not have access to a response model
             request_model,
-            request_model,
             llm_metadata,
             output_message_list,
+            # We do not record token counts in error cases, so set all_token_counts to True so the pipeline tokenizer does not run
+            all_token_counts=True,
         )
     except Exception:
         _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, exc_info=True)
 
 
-def _handle_generation_success(transaction, linking_metadata, completion_id, kwargs, ft, return_val):
+def _handle_generation_success(transaction, settings, linking_metadata, completion_id, kwargs, ft, return_val):
     if not return_val:
         return
 
@@ -370,13 +374,13 @@ def _handle_generation_success(transaction, linking_metadata, completion_id, kwa
         # Response objects are pydantic models so this function call converts the response into a dict
         response = return_val.model_dump() if hasattr(return_val, "model_dump") else return_val
 
-        _record_generation_success(transaction, linking_metadata, completion_id, kwargs, ft, response)
+        _record_generation_success(transaction, settings, linking_metadata, completion_id, kwargs, ft, response)
 
     except Exception:
         _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, exc_info=True)
 
 
-def _record_generation_success(transaction, linking_metadata, completion_id, kwargs, ft, response):
+def _record_generation_success(transaction, settings, linking_metadata, completion_id, kwargs, ft, response):
     span_id = linking_metadata.get("span.id")
     trace_id = linking_metadata.get("trace.id")
     try:
@@ -385,12 +389,14 @@ def _record_generation_success(transaction, linking_metadata, completion_id, kwa
             # finish_reason is an enum, so grab just the stringified value from it to report
             finish_reason = response.get("candidates")[0].get("finish_reason").value
             output_message_list = [response.get("candidates")[0].get("content")]
+            token_usage = response.get("usage_metadata") or {}
         else:
             # Set all values to NoneTypes since we cannot access them through kwargs or another method that doesn't
             # require the response object
             response_model = None
             output_message_list = []
             finish_reason = None
+            token_usage = {}
 
         request_model = kwargs.get("model")
 
@@ -412,13 +418,49 @@ def _record_generation_success(transaction, linking_metadata, completion_id, kwa
                     "corresponding LlmChatCompletionMessage event. "
                 )
 
-        generation_config = kwargs.get("config")
-        if generation_config:
-            request_temperature = getattr(generation_config, "temperature", None)
-            request_max_tokens = getattr(generation_config, "max_output_tokens", None)
+        input_message_content, input_role = _parse_input_message(input_message) if input_message else (None, None)
+
+        # Parse output message content
+        # This list should have a length of 1 to represent the output message
+        # Parse the message text out to pass to any registered token counting callback
+        output_message_content = output_message_list[0].get("parts")[0].get("text") if output_message_list else None
+
+        # Extract token counts from response object
+        if token_usage:
+            response_prompt_tokens = token_usage.get("prompt_token_count")
+            response_completion_tokens = token_usage.get("candidates_token_count")
+            response_total_tokens = token_usage.get("total_token_count")
+            # Filter out the token usage object to only include the keys we want to report in the LLM event
+            filtered_token_usage = {
+                key: token_usage.get(key)
+                for key in ["prompt_token_count", "candidates_token_count", "total_token_count"]
+            }
+
         else:
-            request_temperature = None
-            request_max_tokens = None
+            response_prompt_tokens = None
+            response_completion_tokens = None
+            response_total_tokens = None
+
+        # Calculate token counts by checking if a callback is registered and if we have the necessary content to pass
+        # to it. If not, then we use the token counts provided in the response object
+        prompt_tokens = (
+            settings.ai_monitoring.llm_token_count_callback(request_model, input_message_content)
+            if settings.ai_monitoring.llm_token_count_callback and input_message_content
+            else response_prompt_tokens
+        )
+        completion_tokens = (
+            settings.ai_monitoring.llm_token_count_callback(response_model, output_message_content)
+            if settings.ai_monitoring.llm_token_count_callback and output_message_content
+            else response_completion_tokens
+        )
+        total_tokens = (
+            prompt_tokens + completion_tokens if all([prompt_tokens, completion_tokens]) else response_total_tokens
+        )
+
+        all_token_counts = bool(prompt_tokens and completion_tokens and total_tokens)
+
+        # Extract generation config
+        request_temperature, request_max_tokens = _extract_generation_config(kwargs)
 
         full_chat_completion_summary_dict = {
             "id": completion_id,
@@ -438,66 +480,78 @@ def _record_generation_success(transaction, linking_metadata, completion_id, kwa
             "response.number_of_messages": 1 + len(output_message_list),
         }
 
+        if all_token_counts:
+            full_chat_completion_summary_dict["response.usage.prompt_tokens"] = prompt_tokens
+            full_chat_completion_summary_dict["response.usage.completion_tokens"] = completion_tokens
+            full_chat_completion_summary_dict["response.usage.total_tokens"] = total_tokens
+
         llm_metadata = _get_llm_attributes(transaction)
         full_chat_completion_summary_dict.update(llm_metadata)
         transaction.record_custom_event("LlmChatCompletionSummary", full_chat_completion_summary_dict)
 
         create_chat_completion_message_event(
             transaction,
-            input_message,
+            input_message_content,
+            input_role,
             completion_id,
             span_id,
             trace_id,
             response_model,
-            request_model,
             llm_metadata,
             output_message_list,
+            all_token_counts,
         )
     except Exception:
         _logger.warning(RECORD_EVENTS_FAILURE_LOG_MESSAGE, exc_info=True)
 
 
+def _parse_input_message(input_message):
+    # The input_message will be a string if generate_content was called directly. In this case, we don't have
+    # access to the role, so we default to user since this was an input message
+    if isinstance(input_message, str):
+        return input_message, "user"
+    # The input_message will be a Google Content type if send_message was called, so we parse out the message
+    # text and role (which should be "user")
+    elif isinstance(input_message, google.genai.types.Content):
+        return input_message.parts[0].text, input_message.role
+    else:
+        return None, None
+
+
+def _extract_generation_config(kwargs):
+    generation_config = kwargs.get("config")
+    if generation_config:
+        request_temperature = getattr(generation_config, "temperature", None)
+        request_max_tokens = getattr(generation_config, "max_output_tokens", None)
+    else:
+        request_temperature = None
+        request_max_tokens = None
+
+    return request_temperature, request_max_tokens
+
+
 def create_chat_completion_message_event(
     transaction,
-    input_message,
+    input_message_content,
+    input_role,
     chat_completion_id,
     span_id,
     trace_id,
     response_model,
-    request_model,
     llm_metadata,
     output_message_list,
+    all_token_counts,
 ):
     try:
         settings = transaction.settings or global_settings()
 
-        if input_message:
-            # The input_message will be a string if generate_content was called directly. In this case, we don't have
-            # access to the role, so we default to user since this was an input message
-            if isinstance(input_message, str):
-                input_message_content = input_message
-                input_role = "user"
-            # The input_message will be a Google Content type if send_message was called, so we parse out the message
-            # text and role (which should be "user")
-            elif isinstance(input_message, google.genai.types.Content):
-                input_message_content = input_message.parts[0].text
-                input_role = input_message.role
-            # Set input data to NoneTypes to ensure token_count callback is not called
-            else:
-                input_message_content = None
-                input_role = None
-
+        if input_message_content:
             message_id = str(uuid.uuid4())
 
             chat_completion_input_message_dict = {
                 "id": message_id,
                 "span_id": span_id,
                 "trace_id": trace_id,
-                "token_count": (
-                    settings.ai_monitoring.llm_token_count_callback(request_model, input_message_content)
-                    if settings.ai_monitoring.llm_token_count_callback and input_message_content
-                    else None
-                ),
                 "role": input_role,
                 "completion_id": chat_completion_id,
                 # The input message will always be the first message in our request/ response sequence so this will
@@ -507,6 +561,8 @@ def create_chat_completion_message_event(
                 "vendor": "gemini",
                 "ingest_source": "Python",
             }
+            if all_token_counts:
+                chat_completion_input_message_dict["token_count"] = 0
 
             if settings.ai_monitoring.record_content.enabled:
                 chat_completion_input_message_dict["content"] = input_message_content
@@ -523,7 +579,7 @@ def create_chat_completion_message_event(
 
                 # Add one to the index to account for the single input message so our sequence value is accurate for
                 # the output message
-                if input_message:
+                if input_message_content:
                     index += 1
 
                 message_id = str(uuid.uuid4())
@@ -532,11 +588,6 @@ def create_chat_completion_message_event(
                     "id": message_id,
                     "span_id": span_id,
                     "trace_id": trace_id,
-                    "token_count": (
-                        settings.ai_monitoring.llm_token_count_callback(response_model, message_content)
-                        if settings.ai_monitoring.llm_token_count_callback
-                        else None
-                    ),
                     "role": message.get("role"),
                     "completion_id": chat_completion_id,
                     "sequence": index,
@@ -545,6 +596,9 @@ def create_chat_completion_message_event(
                     "ingest_source": "Python",
                     "is_response": True,
                 }
+
+                if all_token_counts:
+                    chat_completion_output_message_dict["token_count"] = 0
 
                 if settings.ai_monitoring.record_content.enabled:
                     chat_completion_output_message_dict["content"] = message_content

--- a/tests/mlmodel_gemini/test_embeddings.py
+++ b/tests/mlmodel_gemini/test_embeddings.py
@@ -15,7 +15,7 @@
 import google.genai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
-    add_token_count_to_events,
+    add_token_count_to_embedding_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_sans_content,
@@ -93,7 +93,7 @@ def test_gemini_embedding_sync_no_content(gemini_dev_client, set_trace_info):
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_count_to_events(embedding_recorded_events))
+@validate_custom_events(add_token_count_to_embedding_events(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_embeddings:test_gemini_embedding_sync_with_token_count",
@@ -177,7 +177,7 @@ def test_gemini_embedding_async_no_content(gemini_dev_client, loop, set_trace_in
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_count_to_events(embedding_recorded_events))
+@validate_custom_events(add_token_count_to_embedding_events(embedding_recorded_events))
 @validate_custom_event_count(count=1)
 @validate_transaction_metrics(
     name="test_embeddings:test_gemini_embedding_async_with_token_count",

--- a/tests/mlmodel_gemini/test_text_generation.py
+++ b/tests/mlmodel_gemini/test_text_generation.py
@@ -15,7 +15,7 @@
 import google.genai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
-    add_token_count_to_events,
+    add_token_counts_to_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_sans_content,
@@ -50,6 +50,9 @@ text_generation_recorded_events = [
             "vendor": "gemini",
             "ingest_source": "Python",
             "response.number_of_messages": 2,
+            "response.usage.prompt_tokens": 9,
+            "response.usage.completion_tokens": 13,
+            "response.usage.total_tokens": 22,
         },
     ),
     (
@@ -60,6 +63,7 @@ text_generation_recorded_events = [
             "llm.foo": "bar",
             "span_id": None,
             "trace_id": "trace-id",
+            "token_count": 0,
             "content": "How many letters are in the word Python?",
             "role": "user",
             "completion_id": None,
@@ -77,6 +81,7 @@ text_generation_recorded_events = [
             "llm.foo": "bar",
             "span_id": None,
             "trace_id": "trace-id",
+            "token_count": 0,
             "content": 'There are **6** letters in the word "Python".\n',
             "role": "model",
             "completion_id": None,
@@ -183,7 +188,7 @@ def test_gemini_text_generation_sync_no_content(gemini_dev_client, set_trace_inf
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_count_to_events(text_generation_recorded_events))
+@validate_custom_events(add_token_counts_to_events(text_generation_recorded_events))
 @validate_custom_event_count(count=3)
 @validate_transaction_metrics(
     name="test_text_generation:test_gemini_text_generation_sync_with_token_count",
@@ -324,7 +329,7 @@ def test_gemini_text_generation_async_no_content(gemini_dev_client, loop, set_tr
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_count_to_events(text_generation_recorded_events))
+@validate_custom_events(add_token_counts_to_events(text_generation_recorded_events))
 @validate_custom_event_count(count=3)
 @validate_transaction_metrics(
     name="test_text_generation:test_gemini_text_generation_async_with_token_count",

--- a/tests/mlmodel_gemini/test_text_generation.py
+++ b/tests/mlmodel_gemini/test_text_generation.py
@@ -15,7 +15,7 @@
 import google.genai
 from testing_support.fixtures import override_llm_token_callback_settings, reset_core_stats_engine, validate_attributes
 from testing_support.ml_testing_utils import (
-    add_token_counts_to_events,
+    add_token_counts_to_chat_events,
     disabled_ai_monitoring_record_content_settings,
     disabled_ai_monitoring_settings,
     events_sans_content,
@@ -188,7 +188,8 @@ def test_gemini_text_generation_sync_no_content(gemini_dev_client, set_trace_inf
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_counts_to_events(text_generation_recorded_events))
+# Ensure LLM callback is invoked and response token counts are overridden
+@validate_custom_events(add_token_counts_to_chat_events(text_generation_recorded_events))
 @validate_custom_event_count(count=3)
 @validate_transaction_metrics(
     name="test_text_generation:test_gemini_text_generation_sync_with_token_count",
@@ -329,7 +330,7 @@ def test_gemini_text_generation_async_no_content(gemini_dev_client, loop, set_tr
 
 @reset_core_stats_engine()
 @override_llm_token_callback_settings(llm_token_count_callback)
-@validate_custom_events(add_token_counts_to_events(text_generation_recorded_events))
+@validate_custom_events(add_token_counts_to_chat_events(text_generation_recorded_events))
 @validate_custom_event_count(count=3)
 @validate_transaction_metrics(
     name="test_text_generation:test_gemini_text_generation_async_with_token_count",

--- a/tests/testing_support/ml_testing_utils.py
+++ b/tests/testing_support/ml_testing_utils.py
@@ -29,11 +29,22 @@ def llm_token_count_callback(model, content):
     return 105
 
 
+# This will be removed once all LLM instrumentations have been converted to use new token count design
 def add_token_count_to_events(expected_events):
     events = copy.deepcopy(expected_events)
     for event in events:
         if event[0]["type"] != "LlmChatCompletionSummary":
-            event[1]["token_count"] = 105
+            event[1]["response.usage.total_tokens"] = 105
+    return events
+
+
+def add_token_counts_to_events(expected_events):
+    events = copy.deepcopy(expected_events)
+    for event in events:
+        if event[0]["type"] == "LlmChatCompletionSummary":
+            event[1]["response.usage.prompt_tokens"] = 105
+            event[1]["response.usage.completion_tokens"] = 105
+            event[1]["response.usage.total_tokens"] = 210
     return events
 
 

--- a/tests/testing_support/ml_testing_utils.py
+++ b/tests/testing_support/ml_testing_utils.py
@@ -34,11 +34,19 @@ def add_token_count_to_events(expected_events):
     events = copy.deepcopy(expected_events)
     for event in events:
         if event[0]["type"] != "LlmChatCompletionSummary":
+            event[1]["token_count"] = 105
+    return events
+
+
+def add_token_count_to_embedding_events(expected_events):
+    events = copy.deepcopy(expected_events)
+    for event in events:
+        if event[0]["type"] == "LlmEmbedding":
             event[1]["response.usage.total_tokens"] = 105
     return events
 
 
-def add_token_counts_to_events(expected_events):
+def add_token_counts_to_chat_events(expected_events):
     events = copy.deepcopy(expected_events)
     for event in events:
         if event[0]["type"] == "LlmChatCompletionSummary":


### PR DESCRIPTION
This PR updates Gemini instrumentation and tests to pull token counts directly from the response object. If a customer has an LLM token counting callback function registered, this will still take priority over the response token count values. 

It also removes token count calculations from error cases as the agent will consistently stop reporting token counts when a error was met during the creation of a text generation.


