### PR TITLE
Enable Coverage for Motor Instrumentation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,6 @@ ignore:
   - "newrelic/hooks/database_psycopg2ct.py"
   - "newrelic/hooks/datastore_aioredis.py"
   - "newrelic/hooks/datastore_aredis.py"
-  - "newrelic/hooks/datastore_motor.py"
   - "newrelic/hooks/datastore_pyelasticsearch.py"
   - "newrelic/hooks/external_dropbox.py"
   - "newrelic/hooks/external_facepy.py"


### PR DESCRIPTION
# Overview

* Enable motor instrumentation code coverage.
  * Previously, this was disabled when motor was not a full instrumentation package and the hooks were just a workaround for a crash.