### PR TITLE
Add deprecation warning for modules

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -20,8 +20,8 @@ import sys
 import threading
 import time
 import traceback
+from datetime import datetime, timezone
 from pathlib import Path
-from datetime import datetime
 
 import newrelic.api.application
 import newrelic.api.background_task
@@ -1108,9 +1108,7 @@ def _module_import_hook(target, module, function):
 
         # Deprecation warning for archived/unsupported modules
         library_name = target.__package__.split(".")[0]
-        deprecated_modules = {
-            "aioredis": datetime(2022, 2, 22, 0, 0)
-        }
+        deprecated_modules = {"aioredis": datetime(2022, 2, 22, 0, 0, tzinfo=timezone.utc)}
 
         if library_name in deprecated_modules:
             _logger.warning(
@@ -1118,10 +1116,7 @@ def _module_import_hook(target, module, function):
                 "and has not been supported since %(date)s. %(module)s "
                 "support will be removed from New Relic in a future "
                 "release.",
-                {
-                    "module": library_name,
-                    "date": deprecated_modules[library_name].strftime("%B %d, %Y")
-                }
+                {"module": library_name, "date": deprecated_modules[library_name].strftime("%B %d, %Y")},
             )
 
         try:

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -21,6 +21,7 @@ import threading
 import time
 import traceback
 from pathlib import Path
+from datetime import datetime
 
 import newrelic.api.application
 import newrelic.api.background_task
@@ -1104,6 +1105,24 @@ def module_import_hook_results():
 def _module_import_hook(target, module, function):
     def _instrument(target):
         _logger.debug("instrument module %s", ((target, module, function),))
+
+        # Deprecation warning for archived/unsupported modules
+        library_name = target.__package__.split(".")[0]
+        deprecated_modules = {
+            "aioredis": datetime(2022, 2, 22, 0, 0)
+        }
+
+        if library_name in deprecated_modules:
+            _logger.warning(
+                "%(module)s has been archived by the developers "
+                "and has not been supported since %(date)s. %(module)s "
+                "support will be removed from New Relic in a future "
+                "release.",
+                {
+                    "module": library_name,
+                    "date": deprecated_modules[library_name].strftime("%B %d, %Y")
+                }
+            )
 
         try:
             instrumented = target._nr_instrumented

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -55,6 +55,8 @@ __all__ = ["filter_app_factory", "initialize"]
 
 _logger = logging.getLogger(__name__)
 
+DEPRECATED_MODULES = {"aioredis": datetime(2022, 2, 22, 0, 0, tzinfo=timezone.utc)}
+
 
 def _map_aws_account_id(s):
     return newrelic.core.config._map_aws_account_id(s, _logger)
@@ -1108,15 +1110,14 @@ def _module_import_hook(target, module, function):
 
         # Deprecation warning for archived/unsupported modules
         library_name = target.__package__.split(".")[0]
-        deprecated_modules = {"aioredis": datetime(2022, 2, 22, 0, 0, tzinfo=timezone.utc)}
 
-        if library_name in deprecated_modules:
+        if library_name in DEPRECATED_MODULES:
             _logger.warning(
                 "%(module)s has been archived by the developers "
                 "and has not been supported since %(date)s. %(module)s "
                 "support will be removed from New Relic in a future "
                 "release.",
-                {"module": library_name, "date": deprecated_modules[library_name].strftime("%B %d, %Y")},
+                {"module": library_name, "date": DEPRECATED_MODULES[library_name].strftime("%B %d, %Y")},
             )
 
         try:


### PR DESCRIPTION
This PR adds a section to `newrelic/config.py` that issues a deprecation warning when a currently unsupported framework is still being used by the customer.