### PR TITLE
Drop CI Image Build Caching

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -89,8 +89,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ steps.image-name.outputs.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.cache_tag }}
-          cache-to: type=gha,scope=build-${{ matrix.cache_tag }}
 
       - name: Export Digest
         run: |


### PR DESCRIPTION
# Overview

Recently we added caching to CI image builds. Unfortunately, this makes every single build a no-op as there's nothing in the image definition to bust the cache. This prevents us from getting the intended behavior of regularly updating dependencies and Python versions.