### PR TITLE
Falcon sanic testing fix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -129,7 +129,8 @@ envlist =
     python-framework_cherrypy-{py37,py38,py39,py310,py311,py312,py313,pypy310}-CherryPylatest,
     python-framework_django-{py37,py38,py39,py310,py311,py312,py313}-Djangolatest,
     python-framework_django-{py39}-Django{0202,0300,0301,0302,0401},
-    python-framework_falcon-{py37,py38,py39,py310,py311,py312,py313,pypy310}-falconlatest,
+    python-framework_falcon-{py39,py310,py311,py312,py313,pypy310}-falconlatest,
+    python-framework_falcon-{py37,py38}-falcon0410,
     python-framework_falcon-{py39,py310,py311,py312,py313,pypy310}-falconmaster,
     python-framework_fastapi-{py37,py38,py39,py310,py311,py312,py313},
     python-framework_flask-py37-flask020205,
@@ -352,7 +353,7 @@ deps =
     framework_django-Django0401: Django<4.2
     framework_django-Djangolatest: Django
     framework_django-Djangomaster: https://github.com/django/django/archive/main.zip
-    framework_falcon-falcon0300: falcon<3.1
+    framework_falcon-falcon0410: falcon<4.2
     framework_falcon-falconlatest: falcon
     framework_falcon-falconmaster: https://github.com/falconry/falcon/archive/master.zip
     framework_fastapi: fastapi

--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ envlist =
     python-framework_pyramid-{py37,py38,py39,py310,py311,py312,py313,pypy310}-Pyramid0110-cornice,
     python-framework_sanic-{py37,py38}-sanic2406,
     python-framework_sanic-{py39,py310,py311,py312,py313,pypy310}-saniclatest,
-    python-framework_sanic-{py38,pypy310}-sanic{201207,2112,2290},
+    python-framework_sanic-{py38,pypy310}-sanic2290,
     python-framework_starlette-{py310,pypy310}-starlette{0014,0015,0019,0028},
     python-framework_starlette-{py37,py38,py39,py310,py311,py312,py313,pypy310}-starlettelatest,
     python-framework_starlette-{py37,py38}-starlette002001,
@@ -384,14 +384,12 @@ deps =
     framework_pyramid: routes
     framework_pyramid-cornice: cornice!=5.0.0
     framework_pyramid-Pyramidlatest: Pyramid
-    framework_sanic-sanic201207: sanic<20.12.8
-    framework_sanic-sanic2112: sanic<21.13
     framework_sanic-sanic2290: sanic<22.9.1
     framework_sanic-sanic2406: sanic<24.07
     framework_sanic-saniclatest: sanic
-    ; This is the last version of tracerite that supports Python 3.7
-    framework_sanic-sanic2406: tracerite<1.1.2
-    framework_sanic-sanic{201207,2112,2290}: websockets<11
+    ; This is the last version of tracerite that supports Python 3.8
+    framework_sanic-sanic{2290,2406}: tracerite<1.1.2
+    framework_sanic-sanic2290: websockets<11
     ; For test_exception_in_middleware test, anyio is used:
     ; https://github.com/encode/starlette/pull/1157
     ; but anyiolatest creates breaking changes to our tests


### PR DESCRIPTION
This PR changes the versions tested in Falcon and Sanic:

- Falcon's master branch has [dropped Python 3.8 support](https://github.com/falconry/falcon/pull/2528)
- Remove versions of Sanic from test suite that are older than 3 years.