### PR TITLE
Update deprecated urllib APIs

### DIFF
--- a/tests/external_httplib/test_urllib2.py
+++ b/tests/external_httplib/test_urllib2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import urllib.request as urllib2
 
 import pytest


### PR DESCRIPTION
Since Python 3.3, `urllib.URLopener()` has been deprecated in favor of `urllib.request.urlopen`.  In Python 3.14, `urllib.URLopener()` will be removed. `urllib.request.urlopen` corresponds to the old `urllib2.urlopen`

For more information: https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen