### PR TITLE
Format main with ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ share/python-wheels/
 *.egg
 MANIFEST
 version.txt
+version.py
+_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -4126,8 +4126,12 @@ def _process_module_builtin_defaults():
         "newrelic.hooks.framework_azurefunctions",
         "instrument_azure_functions_worker_dispatcher",
     )
-    _process_module_definition("pyzeebe.client.client", "newrelic.hooks.external_pyzeebe", "instrument_pyzeebe_client_client")
-    _process_module_definition("pyzeebe.worker.job_executor", "newrelic.hooks.external_pyzeebe", "instrument_pyzeebe_worker_job_executor")
+    _process_module_definition(
+        "pyzeebe.client.client", "newrelic.hooks.external_pyzeebe", "instrument_pyzeebe_client_client"
+    )
+    _process_module_definition(
+        "pyzeebe.worker.job_executor", "newrelic.hooks.external_pyzeebe", "instrument_pyzeebe_worker_job_executor"
+    )
 
 
 def _process_module_entry_points():

--- a/newrelic/hooks/external_pyzeebe.py
+++ b/newrelic/hooks/external_pyzeebe.py
@@ -16,9 +16,9 @@
 import logging
 
 from newrelic.api.application import application_instance
-from newrelic.api.web_transaction import WebTransaction
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.transaction import current_transaction
+from newrelic.api.web_transaction import WebTransaction
 from newrelic.common.object_wrapper import wrap_function_wrapper
 
 _logger = logging.getLogger(__name__)
@@ -28,7 +28,9 @@ CLIENT_ATTRIBUTES_DEPLOY_RESOURCE_LOG_MSG = "Exception occurred in PyZeebe instr
 
 # Adds client method params as txn or span attributes
 def _add_client_input_attributes(method_name, trace, args, kwargs):
-    bpmn_id = extract_agent_attribute_from_methods(args, kwargs, method_name, ("run_process", "run_process_with_result"), "bpmn_process_id", 0)
+    bpmn_id = extract_agent_attribute_from_methods(
+        args, kwargs, method_name, ("run_process", "run_process_with_result"), "bpmn_process_id", 0
+    )
     if bpmn_id:
         trace._add_agent_attribute("zeebe.client.bpmnProcessId", bpmn_id)
 
@@ -36,14 +38,16 @@ def _add_client_input_attributes(method_name, trace, args, kwargs):
     if msg_name:
         trace._add_agent_attribute("zeebe.client.messageName", msg_name)
 
-    correlation_key = extract_agent_attribute_from_methods(args, kwargs, method_name, ("publish_message"), "correlation_key", 1)
+    correlation_key = extract_agent_attribute_from_methods(
+        args, kwargs, method_name, ("publish_message"), "correlation_key", 1
+    )
     if correlation_key:
         trace._add_agent_attribute("zeebe.client.correlationKey", correlation_key)
-    
+
     message_id = extract_agent_attribute_from_methods(args, kwargs, method_name, ("publish_message"), "message_id", 4)
     if message_id:
         trace._add_agent_attribute("zeebe.client.messageId", message_id)
-    
+
     resource = extract_agent_attribute_from_methods(args, {}, method_name, ("deploy_resource"), None, 0)
     if resource:
         try:
@@ -61,7 +65,13 @@ def extract_agent_attribute_from_methods(args, kwargs, method_name, methods, par
                 value = args[index]
             return value
     except Exception:
-        _logger.warning("Exception occurred in PyZeebe instrumentation: failed to extract %s from %s. Report this issue to New Relic support.", param, method_name, exc_info=True)
+        _logger.warning(
+            "Exception occurred in PyZeebe instrumentation: failed to extract %s from %s. Report this issue to New Relic support.",
+            param,
+            method_name,
+            exc_info=True,
+        )
+
 
 # Async wrapper that instruments router/worker annotations`
 async def _nr_wrapper_execute_one_job(wrapped, instance, args, kwargs):

--- a/tests/external_pyzeebe/_mocks.py
+++ b/tests/external_pyzeebe/_mocks.py
@@ -31,7 +31,11 @@ DummyPublishMessageResponse = SimpleNamespace(key=99999, tenant_id=None)
 
 # Dummy RPC stub coroutines
 async def dummy_create_process_instance(
-    self, bpmn_process_id: str, variables: dict = None, version: int = -1, tenant_id: str = None # noqa: RUF013
+    self,
+    bpmn_process_id: str,
+    variables: dict = None,  # noqa: RUF013
+    version: int = -1,
+    tenant_id: str = None,  # noqa: RUF013
 ):
     """Simulate ZeebeAdapter.create_process_instance"""
     return DummyCreateProcessInstanceResponse
@@ -40,17 +44,17 @@ async def dummy_create_process_instance(
 async def dummy_create_process_instance_with_result(
     self,
     bpmn_process_id: str,
-    variables: dict = None, # noqa: RUF013
+    variables: dict = None,  # noqa: RUF013
     version: int = -1,
     timeout: int = 0,
     variables_to_fetch=None,
-    tenant_id: str = None, # noqa: RUF013
+    tenant_id: str = None,  # noqa: RUF013
 ):
     """Simulate ZeebeAdapter.create_process_instance_with_result"""
     return DummyCreateProcessInstanceWithResultResponse
 
 
-async def dummy_deploy_resource(*resource_file_path: str, tenant_id: str = None): # noqa: RUF013
+async def dummy_deploy_resource(*resource_file_path: str, tenant_id: str = None):  # noqa: RUF013
     """Simulate ZeebeAdapter.deploy_resource"""
     # Create dummy deployment metadata for each provided resource path
     deployments = [
@@ -73,10 +77,10 @@ async def dummy_publish_message(
     self,
     name: str,
     correlation_key: str,
-    variables: dict = None, # noqa: RUF013
+    variables: dict = None,  # noqa: RUF013
     time_to_live_in_milliseconds: int = 60000,
-    message_id: str = None, # noqa: RUF013
-    tenant_id: str = None, # noqa: RUF013
+    message_id: str = None,  # noqa: RUF013
+    tenant_id: str = None,  # noqa: RUF013
 ):
     """Simulate ZeebeAdapter.publish_message"""
     # Return the dummy response (contains message key)

--- a/tests/external_pyzeebe/test_client.py
+++ b/tests/external_pyzeebe/test_client.py
@@ -20,8 +20,8 @@ from _mocks import (
 )
 from pyzeebe import ZeebeClient, create_insecure_channel
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
-from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_custom_event import validate_custom_event_count
+from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
@@ -114,7 +114,14 @@ def test_deploy_resource_outside_txn(monkeypatch, loop):
 @validate_transaction_metrics(
     "test_zeebe_client:publish_message", rollup_metrics=[("ZeebeClient/publish_message", 1)], background_task=True
 )
-@validate_span_events(exact_agents={"zeebe.client.messageName": "test_message", "zeebe.client.correlationKey": "999999", "zeebe.client.messageId": "abc123"}, count=1)
+@validate_span_events(
+    exact_agents={
+        "zeebe.client.messageName": "test_message",
+        "zeebe.client.correlationKey": "999999",
+        "zeebe.client.messageId": "abc123",
+    },
+    count=1,
+)
 def test_publish_message(monkeypatch, loop):
     monkeypatch.setattr(ZeebeAdapter, "publish_message", dummy_publish_message)
 
@@ -124,6 +131,7 @@ def test_publish_message(monkeypatch, loop):
         assert result.key == 999999
 
     loop.run_until_complete(_test())
+
 
 @validate_custom_event_count(count=0)
 def test_publish_message_outside_txn(monkeypatch, loop):


### PR DESCRIPTION
# Overview

* Format main with ruff to fix linting issues.
* Add `version.py` and `_version.py` files to gitignore.