### PR TITLE
Remove PyPy From PyZeebe Tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -119,7 +119,8 @@ envlist =
     python-external_http-{py38,py39,py310,py311,py312,py313},
     python-external_httplib-{py38,py39,py310,py311,py312,py313,pypy310},
     python-external_httplib2-{py38,py39,py310,py311,py312,py313,pypy310},
-    python-external_pyzeebe-{py39,py310,py311,py312,pypy310},
+    # pyzeebe requires grpcio which does not support pypy
+    python-external_pyzeebe-{py39,py310,py311,py312},
     python-external_requests-{py38,py39,py310,py311,py312,py313,pypy310},
     python-external_urllib3-{py38,py39,py310,py311,py312,py313,pypy310}-urllib3latest,
     python-external_urllib3-{py312,py313,pypy310}-urllib30126,


### PR DESCRIPTION
# Overview

* Remove `pypy` testing for `pyzeebe` which depends on `grpcio`, which does not build `pypy` wheels. 
  * This causes a 18 minute compile time before running the tests.