### PR TITLE
Fix Merge Conflict Leftovers from Removing Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,9 @@ readme = "README.md"
 #     "LICENSE",
 #     "THIRD_PARTY_NOTICES.md",
 # ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"  # python_requires is also located in setup.py
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ if not with_setuptools:
 
     kwargs.update(
         {
-            "python_requires": ">=3.8",
+            "python_requires": ">=3.8",  # python_requires is also located in pyproject.toml
             "zip_safe": False,
             "packages": packages,
             "package_data": {


### PR DESCRIPTION
# Overview

* Removing Python 3.7 resulted in merge conflicts and differences between `setup.py` and `pyproject.toml` in the `python_requires` setting and the `classifiers`. Fix these to properly reflect the removal of Python 3.7