### PR TITLE
Fix CI Image

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -107,18 +107,20 @@ WORKDIR "${HOME}"
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="${HOME}/.local/bin:${PATH}"
 ENV UV_PYTHON_PREFERENCE="only-managed"
+ENV UV_LINK_MODE="copy"
 
-# Install Python
-ARG PYTHON_VERSIONS="3.13 3.12 3.11 3.10 3.9 3.8 pypy3.10"
-RUN bash -c "uv python install ${PYTHON_VERSIONS}" && \
-    uv python pin --global 3.13
+# Install PyPy versions and rename shims
+RUN uv python install -f pp3.11 pp3.10
+RUN mv "${HOME}/.local/bin/python3.11" "${HOME}/.local/bin/pypy3.11" && \
+    mv "${HOME}/.local/bin/python3.10" "${HOME}/.local/bin/pypy3.10"
 
-# Add shims for python and pip
-COPY --chmod=775 <<EOF "${HOME}/.local/bin/python"
-#!/bin/bash
-exec uv run --no-project python \$@
-EOF
+# Install CPython versions
+RUN uv python install -f cp3.14 cp3.13 cp3.12 cp3.11 cp3.10 cp3.9 cp3.8
 
+# Set default Python version to CPython 3.13
+RUN uv python install -f --default cp3.13
+
+# Add shim for pip to use 'uv pip'
 COPY --chmod=775 <<EOF "${HOME}/.local/bin/pip"
 #!/bin/bash
 exec uv pip \$@

--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -23,15 +23,33 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         bash \
         build-essential \
         curl \
+        default-libmysqlclient-dev \
+        expat \
         fish \
         fontconfig \
+        freetds-common \
+        freetds-dev \
         gcc \
         git \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        libffi-dev \
+        libgmp-dev \
+        libkrb5-dev \
+        liblzma-dev \
+        libmpfr-dev \
+        libncurses-dev \
+        libpq-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
         locales \
         make \
         odbc-postgresql \
         openssl \
         pkg-config \
+        python3-dev \
+        python3-pip \
         rustc \
         sudo \
         tzdata \
@@ -40,6 +58,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         vim \
         wget \
         zip \
+        zlib1g \
+        zlib1g-dev \
         zsh && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@
 [tox]
 setupdir = {toxinidir}
 uv_python_preference = only-managed
+uv_seed = true
 ; Fail tests when interpreters are missing.
 skip_missing_interpreters = false
 envlist =

--- a/tox.ini
+++ b/tox.ini
@@ -463,8 +463,6 @@ commands =
     framework_grpc:     --python_out={toxinidir}/tests/framework_grpc/sample_application \
     framework_grpc:     --grpc_python_out={toxinidir}/tests/framework_grpc/sample_application \
     framework_grpc:     /{toxinidir}/tests/framework_grpc/sample_application/sample_application.proto
-
-    framework_tornado: pip install --ignore-installed --config-settings="--build-option=--with-openssl" pycurl
     
     framework_azurefunctions: {toxinidir}/.github/scripts/install_azure_functions_worker.sh
 


### PR DESCRIPTION
# Overview

Various things were broken in the latest version of the CI image. The following changes have repaired it.

* Fix `PyPy` and `CPython` competing for `python3.10` binary by renaming the `PyPy` binary during install.
* Fix shims for default `Python` version by using `uv python install --default` to create multiple shims instead of just the `python3.13` shim.
* Set `UV_LINK_MODE=copy` to silence warnings around the cache being mounted in Docker.
* Replacing all the deleted development headers from Ubuntu.
  * We may want to remove any unused headers in a future version, but for now putting these back.
* Remove the custom `pycurl` reinstall command in `tornado` tests.
  * This is leftover from when we needed to build these from scratch and is now unnecessary.
* Fixed azure-functions install flow by adding `pip` to the created venvs through `uv_seed`.

# Testing

* [Example Test Run](https://github.com/TimPansino/newrelic-python-agent/actions/runs/18108599889/job/51529210805), this time verified to be using the changed CI image.
  * Coverage fails on the fork due to permissions but that can be ignored.