### PR TITLE
Put azurefunctions tests on separate worker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
     if: always() # Always run, even on cancellation or failure
     needs:
       - python
+      - azure
       - cassandra
       - elasticsearchserver07
       - elasticsearchserver08
@@ -218,6 +219,58 @@ jobs:
       - name: Test
         run: |
           tox -vv -e ${{ steps.get-envs.outputs.envs }}
+        env:
+          TOX_PARALLEL_NO_SPINNER: 1
+          FORCE_COLOR: "true"
+
+      - name: Upload Coverage Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
+        with:
+          name: coverage-${{ github.job }}-${{ strategy.job-index }}
+          path: ./**/.coverage.*
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
+  azure:
+    env:
+      TOTAL_GROUPS: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group-number: [1]
+
+    runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/newrelic/newrelic-python-agent-ci:latest
+      options: >-
+        --add-host=host.docker.internal:host-gateway
+    timeout-minutes: 30
+    
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
+
+      - name: Fetch git tags
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --tags origin
+
+      - name: Configure pip cache
+        run: |
+          mkdir -p /github/home/.cache/pip
+          chown -R "$(whoami)" /github/home/.cache/pip
+
+      - name: Get Environments
+        id: get-envs
+        run: |
+          echo "envs=$(tox -l | grep '^${{ github.job }}\-' | ./.github/workflows/get-envs.py)" >> "$GITHUB_OUTPUT"
+        env:
+          GROUP_NUMBER: ${{ matrix.group-number }}
+
+      - name: Test
+        run: |
+          tox -vv -e ${{ steps.get-envs.outputs.envs }} -p auto
         env:
           TOX_PARALLEL_NO_SPINNER: 1
           FORCE_COLOR: "true"

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ uv_seed = true
 ; Fail tests when interpreters are missing.
 skip_missing_interpreters = false
 envlist =
+    azure-framework_azurefunctions-{py39,py310,py311,py312},
     cassandra-datastore_cassandradriver-{py38,py39,py310,py311,py312,pypy310}-cassandralatest,
     elasticsearchserver07-datastore_elasticsearch-{py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch07,
     elasticsearchserver08-datastore_elasticsearch-{py38,py39,py310,py311,py312,py313,pypy310}-elasticsearch08,
@@ -128,7 +129,6 @@ envlist =
     python-external_urllib3-{py312,py313,pypy310}-urllib30126,
     python-framework_aiohttp-{py38,py39,py310,py311,py312,py313,pypy310}-aiohttp03,
     python-framework_ariadne-{py38,py39,py310,py311,py312,py313}-ariadnelatest,
-    python-framework_azurefunctions-{py39,py310,py311,py312},
     python-framework_bottle-{py38,py39,py310,py311,py312,py313,pypy310}-bottle0012,
     python-framework_cherrypy-{py38,py39,py310,py311,py312,py313,pypy310}-CherryPylatest,
     python-framework_django-{py38,py39,py310,py311,py312,py313}-Djangolatest,


### PR DESCRIPTION
# Overview

* Put azurefunctions tests on separate worker to provide speedup and isolate failures.