### PR TITLE
Guard against crashes from trace_cache.pop()

### DIFF
--- a/newrelic/core/context.py
+++ b/newrelic/core/context.py
@@ -75,7 +75,7 @@ class ContextOf:
                 self.trace_cache[self.thread_id] = self.restore
             else:
                 # Remove entry from cache
-                self.trace_cache.pop(self.thread_id)
+                self.trace_cache.pop(self.thread_id, None)
 
 
 def context_wrapper(func, trace=None, request=None, trace_cache_id=None, strict=True):


### PR DESCRIPTION
# Overview

* In the `ContextOf` class, there was an unsafe access of the `trace_cache` via `pop(key)` without a default value. This caused crashes when the `weakref` in the dictionary was already garbage collected.