### PR TITLE
Fix failing tests

### DIFF
--- a/newrelic/core/attribute.py
+++ b/newrelic/core/attribute.py
@@ -100,6 +100,7 @@ _TRANSACTION_EVENT_DEFAULT_ATTRIBUTES = {
     "response.headers.contentType",
     "response.status",
     "server.address",
+    "server.port",
     "zeebe.client.bpmnProcessId",
     "zeebe.client.messageName",
     "zeebe.client.correlationKey",

--- a/newrelic/core/database_node.py
+++ b/newrelic/core/database_node.py
@@ -279,7 +279,7 @@ class DatabaseNode(_DatabaseNode, DatastoreNodeMixin):
             start_time=start_time, end_time=end_time, name=name, params=params, children=children, label=None
         )
 
-    def span_event(self, *args, **kwargs):
+    def span_event(self, settings, base_attrs=None, parent_guid=None, attr_class=dict):
         sql = self.formatted
 
         if sql:
@@ -288,4 +288,4 @@ class DatabaseNode(_DatabaseNode, DatastoreNodeMixin):
 
         self.agent_attributes["db.statement"] = sql
 
-        return super().span_event(*args, **kwargs)
+        return super().span_event(settings, base_attrs=base_attrs, parent_guid=parent_guid, attr_class=attr_class)

--- a/newrelic/core/external_node.py
+++ b/newrelic/core/external_node.py
@@ -175,9 +175,9 @@ class ExternalNode(_ExternalNode, GenericNodeMixin):
         i_attrs = (base_attrs and base_attrs.copy()) or attr_class()
         i_attrs["category"] = "http"
         i_attrs["span.kind"] = "client"
-        i_attrs["component"] = self.library
+        _, i_attrs["component"] = attribute.process_user_attribute("component", self.library)
 
         if self.method:
-            i_attrs["http.method"] = self.method
+            _, i_attrs["http.method"] = attribute.process_user_attribute("http.method", self.method)
 
         return super().span_event(settings, base_attrs=i_attrs, parent_guid=parent_guid, attr_class=attr_class)

--- a/newrelic/core/node_mixin.py
+++ b/newrelic/core/node_mixin.py
@@ -117,14 +117,14 @@ class DatastoreNodeMixin(GenericNodeMixin):
         i_attrs["span.kind"] = "client"
 
         if self.product:
-            i_attrs["component"] = a_attrs["db.system"] = self.product
+            i_attrs["component"] = a_attrs["db.system"] = attribute.process_user_attribute("db.system", self.product)[1]
         if self.operation:
-            a_attrs["db.operation"] = self.operation
+            a_attrs["db.operation"] = attribute.process_user_attribute("db.operation", self.operation)[1]
         if self.target:
-            a_attrs["db.collection"] = self.target
+            a_attrs["db.collection"] = attribute.process_user_attribute("db.collection", self.target)[1]
 
         if self.instance_hostname:
-            peer_hostname = self.instance_hostname
+            peer_hostname = attribute.process_user_attribute("peer.hostname", self.instance_hostname)[1]
         else:
             peer_hostname = "Unknown"
 
@@ -132,7 +132,7 @@ class DatastoreNodeMixin(GenericNodeMixin):
 
         peer_address = f"{peer_hostname}:{self.port_path_or_id or 'Unknown'}"
 
-        a_attrs["peer.address"] = peer_address
+        a_attrs["peer.address"] = attribute.process_user_attribute("peer.address", peer_address)[1]
 
         # Attempt to treat port_path_or_id as an integer, fallback to not including it
         try:


### PR DESCRIPTION
# Overview
* The previous PR removed some calls to process_user_attribute that were needed to truncate agent and intrinsic attr lengths-this fixes that.
* Due to the re-ordering in inheritance calls, `server.port` was missing from the attributes list-this fixes that.
