### PR TITLE
Fix Error When shutdown_agent called from Within Harvest Thread

### DIFF
--- a/newrelic/core/agent.py
+++ b/newrelic/core/agent.py
@@ -746,7 +746,12 @@ class Agent:
             self._harvest_thread.start()
 
         if self._harvest_thread.is_alive():
-            self._harvest_thread.join(timeout)
+            try:
+                self._harvest_thread.join(timeout)
+            except RuntimeError:
+                # This can occur if the application is killed while in the harvest thread,
+                # causing shutdown_agent to be called from within the harvest thread.
+                pass
 
 
 def agent_instance():


### PR DESCRIPTION
# Overview

Add a guard to prevent crashes when calling `shutdown_agent` from within the harvest thread.

# Related Github Issue

Closes #1548 

# Testing

Not sure if this is possible to test, but seeing as it's a minuscule change that just adds a guard I think it's fine as is.
