### PR TITLE
Add Free Threaded Python to CI

### DIFF
--- a/.github/containers/Dockerfile
+++ b/.github/containers/Dockerfile
@@ -115,7 +115,7 @@ RUN mv "${HOME}/.local/bin/python3.11" "${HOME}/.local/bin/pypy3.11" && \
     mv "${HOME}/.local/bin/python3.10" "${HOME}/.local/bin/pypy3.10"
 
 # Install CPython versions
-RUN uv python install -f cp3.14 cp3.13 cp3.12 cp3.11 cp3.10 cp3.9 cp3.8
+RUN uv python install -f cp3.14 cp3.14t cp3.13 cp3.12 cp3.11 cp3.10 cp3.9 cp3.8
 
 # Set default Python version to CPython 3.13
 RUN uv python install -f --default cp3.13

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -283,9 +283,8 @@ jobs:
   windows:
     env:
       TOTAL_GROUPS: 1
-      UV_PYTHON: "3.13"
-      UV_PYTHON_DOWNLOADS: "never"
-      UV_PYTHON_PREFERENCE: "only-system"
+      UV_PYTHON_DOWNLOADS: "manual"
+      UV_PYTHON_PREFERENCE: "only-managed"
 
     strategy:
       fail-fast: false
@@ -301,15 +300,13 @@ jobs:
         run: |
           git fetch --tags origin
 
-      - name: Install Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # 6.0.0
-        with:
-          python-version: |
-            3.13
-            3.14
-
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
+
+      - name: Install Python
+        run: |
+          uv python install -f 3.13 3.14 3.14t
+          uv python install -f --default 3.13
 
       - name: Install Dependencies
         run: |
@@ -355,9 +352,8 @@ jobs:
   windows_arm64:
     env:
       TOTAL_GROUPS: 1
-      UV_PYTHON: "3.13"
-      UV_PYTHON_DOWNLOADS: "never"
-      UV_PYTHON_PREFERENCE: "only-system"
+      UV_PYTHON_DOWNLOADS: "manual"
+      UV_PYTHON_PREFERENCE: "only-managed"
 
     strategy:
       fail-fast: false
@@ -373,15 +369,13 @@ jobs:
         run: |
           git fetch --tags origin
 
-      - name: Install Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # 6.0.0
-        with:
-          python-version: |
-            3.13
-            3.14
-
       - name: Install uv
         uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
+
+      - name: Install Python
+        run: |
+          uv python install -f 3.13 3.14 3.14t
+          uv python install -f --default 3.13
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
# Overview

* Add free-threaded Python to CI image and to uv for windows runners.