### PR TITLE
Skip hypercorn tests for v0.18

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -176,7 +176,8 @@ envlist =
     python-framework_strawberry-{py38,py39,py310,py311,py312}-strawberry02352,
     python-framework_strawberry-{py38,py39,py310,py311,py312,py313,py314}-strawberrylatest,
     python-framework_tornado-{py38,py39,py310,py311,py312,py313,py314}-tornadolatest,
-    python-framework_tornado-{py310,py311,py312,py313,py314}-tornadomaster,
+    ; Remove `python-framework_tornado-py314-tornadomaster` temporarily
+    python-framework_tornado-{py310,py311,py312,py313}-tornadomaster,
     python-logger_logging-{py38,py39,py310,py311,py312,py313,py314,pypy311},
     python-logger_loguru-{py38,py39,py310,py311,py312,py313,py314,pypy311}-logurulatest,
     python-logger_structlog-{py38,py39,py310,py311,py312,py313,py314,pypy311}-structloglatest,


### PR DESCRIPTION
Pinning Hypercorn testing on latest to not pull from v0.18, due to [the latest changes](https://github.com/pgjones/hypercorn/compare/0.17.3...0.18.0#diff-e5404792659e82d70b27a7e78e31f7609a0fe0a96e0ce0933eecef47aa9ff8d1R107-R117).

This [issue](https://github.com/pgjones/hypercorn/issues/331) and analogous [PR](https://github.com/pgjones/hypercorn/pull/332) provide more context as well as proposed fixes.

Also temporarily remove tornadomaster testing for Python 3.14