### PR TITLE
Pin langchain & langchain_core

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -432,10 +432,10 @@ deps =
     mlmodel_openai-openailatest: openai[datalib]
     ; Required for openai testing
     mlmodel_openai: protobuf
-    ; Pinning to 0.1.16 while adding support for with_structured_output in chain tests
-    mlmodel_langchain: langchain
+    ; Pin to 1.1.0 temporarily
+    mlmodel_langchain: langchain<1.1.1
+    mlmodel_langchain: langchain-core<1.1.1
     mlmodel_langchain: langchain-community
-    mlmodel_langchain: langchain-core
     mlmodel_langchain: langchain-openai
     ; Required for langchain testing
     mlmodel_langchain: pypdf


### PR DESCRIPTION
Temporarily pin langchain and langchain_core tests to use v1.1.0