### PR TITLE
Temporarily pin scikit-learn to <v1.8.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -262,7 +262,8 @@ deps =
     mlmodel_sklearn: pandas
     mlmodel_sklearn: protobuf
     mlmodel_sklearn: numpy
-    mlmodel_sklearn-scikitlearnlatest: scikit-learn
+    ; Temporarily pin scikit-learn to below v1.8.0
+    mlmodel_sklearn-scikitlearnlatest: scikit-learn<1.8
     mlmodel_sklearn-scikitlearnlatest: scipy
     component_djangorestframework-djangorestframeworklatest: Django
     component_djangorestframework-djangorestframeworklatest: djangorestframework


### PR DESCRIPTION
Temporarily pin scikit-learn tests to use a version below v1.8.0