### PR TITLE
Guard Garbage Collection Metrics Against Re-Entrant Calls

### DIFF
--- a/newrelic/samplers/gc_data.py
+++ b/newrelic/samplers/gc_data.py
@@ -56,8 +56,9 @@ class _GCDataSource:
         if self.__recording:
             return
 
-        # __recording flag is used to prevent re-entrant calls to record_gc. This could theoretically result in missing
-        # some GC metrics, but would more likely result in infinite recursion that crashes the entire interpreter.
+        # The self.__recording flag is used to prevent re-entrant calls to record_gc. This could theoretically result
+        # in missing some GC metrics, but trying to record the metrics instead would likely result in infinite
+        # recursion that crashes the entire interpreter.
         self.__recording = True
         try:
             if not self.enabled:

--- a/newrelic/samplers/gc_data.py
+++ b/newrelic/samplers/gc_data.py
@@ -23,6 +23,8 @@ from newrelic.core.config import global_settings
 from newrelic.core.stats_engine import CustomMetrics
 from newrelic.samplers.decorators import data_source_factory
 
+IS_PYPY = platform.python_implementation() == "PyPy"
+
 
 @data_source_factory(name="Garbage Collector Metrics")
 class _GCDataSource:
@@ -34,11 +36,12 @@ class _GCDataSource:
 
     @property
     def enabled(self):
-        settings = global_settings()
-        if platform.python_implementation() == "PyPy" or not settings:
+        if IS_PYPY:
             return False
+
         # This might be inheriting from Settings instead of TopLevelSettings
-        elif settings and hasattr(settings, "gc_runtime_metrics"):
+        settings = global_settings()
+        if settings and hasattr(settings, "gc_runtime_metrics"):
             return settings.gc_runtime_metrics.enabled
         else:
             return False
@@ -66,7 +69,7 @@ class _GCDataSource:
                     self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/{gen}", 0)
 
     def start(self):
-        if hasattr(gc, "callbacks"):
+        if not IS_PYPY and hasattr(gc, "callbacks"):
             gc.callbacks.append(self.record_gc)
 
     def stop(self):

--- a/newrelic/samplers/gc_data.py
+++ b/newrelic/samplers/gc_data.py
@@ -33,6 +33,7 @@ class _GCDataSource:
         self.start_time = 0.0
         self.previous_stats = {}
         self.pid = os.getpid()
+        self.__recording = False
 
     @property
     def enabled(self):
@@ -52,21 +53,30 @@ class _GCDataSource:
         return settings.gc_runtime_metrics.top_object_count_limit
 
     def record_gc(self, phase, info):
-        if not self.enabled:
+        if self.__recording:
             return
 
-        current_generation = info["generation"]
+        # __recording flag is used to prevent re-entrant calls to record_gc. This could theoretically result in missing
+        # some GC metrics, but would more likely result in infinite recursion that crashes the entire interpreter.
+        self.__recording = True
+        try:
+            if not self.enabled:
+                return
 
-        if phase == "start":
-            self.start_time = time.time()
-        elif phase == "stop":
-            total_time = time.time() - self.start_time
-            self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/all", total_time)
-            for gen in range(0, 3):
-                if gen <= current_generation:
-                    self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/{gen}", total_time)
-                else:
-                    self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/{gen}", 0)
+            current_generation = info["generation"]
+
+            if phase == "start":
+                self.start_time = time.time()
+            elif phase == "stop":
+                total_time = time.time() - self.start_time
+                self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/all", total_time)
+                for gen in range(0, 3):
+                    if gen <= current_generation:
+                        self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/{gen}", total_time)
+                    else:
+                        self.gc_time_metrics.record_custom_metric(f"GC/time/{self.pid}/{gen}", 0)
+        finally:
+            self.__recording = False
 
     def start(self):
         if not IS_PYPY and hasattr(gc, "callbacks"):

--- a/tests/agent_unittests/test_sampler_metrics.py
+++ b/tests/agent_unittests/test_sampler_metrics.py
@@ -15,6 +15,7 @@
 import gc
 import os
 import platform
+import threading
 
 import pytest
 from testing_support.fixtures import override_generic_settings
@@ -102,6 +103,37 @@ def test_gc_metrics_collection(gc_data_source, top_object_count_limit):
         else:
             assert obj_metric_count == 4, metrics_table
 
+    _test()
+
+
+@pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="GC Metrics are always disabled on PyPy")
+def test_record_gc_safe_from_reentrant_gc(gc_data_source, monkeypatch):
+    @override_generic_settings(settings, {"gc_runtime_metrics.enabled": True})
+    def _test():
+        enabled_run = threading.Event()
+
+        @property
+        def enabled(*args, **kwargs):
+            # Calls a second time to record_gc(). Note that we can't call gc.collect() here
+            # as it would not actually start a new gc collection. Python stores a flag to
+            # prevent re-entrant gc collections (gcstate->collecting) and it isn't possible
+            # to directly invoke the gc here. However, the allocator can trigger a gc collection
+            # and bypass this flag. To simulate this, we can directly call record_gc() to
+            # verify that the callback is safe from re-entrant calls causing infinite recursion.
+            enabled_run.set()
+            gc_data_source.record_gc("start", {"generation": 0})  # Directly invoke callback
+            return True
+
+        # Patch the enabled property to trigger a re-entrant call to record_gc().
+        monkeypatch.setattr(gc_data_source.__class__, "enabled", enabled)
+
+        # Invoke the gc manually to start the test.
+        gc.collect()
+
+        # Ensure the new property is actually hit and the test is exercising correctly.
+        assert enabled_run.is_set(), "Test did not run correctly."
+
+    # If we exit without causing a RecursionError, the test is successful.
     _test()
 
 


### PR DESCRIPTION
# Overview

* Add flag to prevent re-entrant calls to `_GCDataSource.record_gc()` to prevent infinite recursion on Python 3.13+.
* Improve caching of IS_PYPY in `gc_data.py` for performance.
* Add regression test that bypasses garbage collection infrastructure and directly unit tests re-entrant calls to `_GCDataSource.record_gc()`.
  * If we can find a reliable way to trigger the original issue in testing, we could add a better regression test here as well.

# Related Github Issue

Closes #1706

# Testing

1. Revert the changes made to `gc_data.py`.
2. Run the `agent_unittests` suite. Observe the tests hanging forever when simulating re-entrant invocations of `record_gc`.
3. Restore the changes to `gc_data.py`.
4. Run the `agent_unittests` suite. Observe the tests passing due to the new guard in place preventing re-entrant calls.
