### PR TITLE
Pin OpenTelemetry MySQL instrumentation version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -424,7 +424,7 @@ deps =
     hybridagent_kafkapython: opentelemetry-instrumentation-kafka-python
     hybridagent_kafkapython: kafka-python<2.1
     hybridagent_mysql: opentelemetry-api
-    hybridagent_mysql: opentelemetry-instrumentation-mysql<0.62b0
+    hybridagent_mysql: opentelemetry-instrumentation-mysql==0.61b0
     hybridagent_mysql: mysql-connector-python
     hybridagent_mysql: protobuf<4
     hybridagent_opentelemetry: opentelemetry-api

--- a/tox.ini
+++ b/tox.ini
@@ -424,7 +424,7 @@ deps =
     hybridagent_kafkapython: opentelemetry-instrumentation-kafka-python
     hybridagent_kafkapython: kafka-python<2.1
     hybridagent_mysql: opentelemetry-api
-    hybridagent_mysql: opentelemetry-instrumentation-mysql
+    hybridagent_mysql: opentelemetry-instrumentation-mysql<v0.62b0
     hybridagent_mysql: mysql-connector-python
     hybridagent_mysql: protobuf<4
     hybridagent_opentelemetry: opentelemetry-api

--- a/tox.ini
+++ b/tox.ini
@@ -424,7 +424,7 @@ deps =
     hybridagent_kafkapython: opentelemetry-instrumentation-kafka-python
     hybridagent_kafkapython: kafka-python<2.1
     hybridagent_mysql: opentelemetry-api
-    hybridagent_mysql: opentelemetry-instrumentation-mysql<v0.62b0
+    hybridagent_mysql: opentelemetry-instrumentation-mysql<0.62b0
     hybridagent_mysql: mysql-connector-python
     hybridagent_mysql: protobuf<4
     hybridagent_opentelemetry: opentelemetry-api


### PR DESCRIPTION
Until [this PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4427) can be merged and released, the OpenTelemetry MySQL instrumentation needs to be pinned to the previous version for testing.

More information can be found in [this PR](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4427).