### PR TITLE
Add http.statusCode to transaction events

### DIFF
--- a/newrelic/api/web_transaction.py
+++ b/newrelic/api/web_transaction.py
@@ -358,6 +358,7 @@ class WebTransaction(Transaction):
             self._add_agent_attribute("response.headers.contentType", self._response_headers["content-type"])
         if self._response_code is not None:
             self._add_agent_attribute("response.status", str(self._response_code))
+            self._add_agent_attribute("http.statusCode", self._response_code)
 
         return super()._update_agent_attributes()
 

--- a/tests/agent_features/test_attribute.py
+++ b/tests/agent_features/test_attribute.py
@@ -71,6 +71,7 @@ _required_agent = [
     "request.method",
     "wsgi.output.seconds",
     "response.status",
+    "http.statusCode",
     "request.headers.host",
     "request.headers.accept",
     "request.uri",
@@ -417,6 +418,7 @@ agent_attributes = {
     "response.headers.contentLength": int,
     "response.headers.contentType": str,
     "response.status": str,
+    "http.statusCode": int
 }
 
 

--- a/tests/agent_features/test_attribute.py
+++ b/tests/agent_features/test_attribute.py
@@ -418,7 +418,7 @@ agent_attributes = {
     "response.headers.contentLength": int,
     "response.headers.contentType": str,
     "response.status": str,
-    "http.statusCode": int
+    "http.statusCode": int,
 }
 
 

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -545,7 +545,12 @@ def test_transaction_event_exclude_agent_attribute(normal_application):
 
 _override_settings = {"attributes.exclude": ["request.*"], "attributes.include": ["request.headers.*"]}
 
-_expected_agent_attributes = ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"]
+_expected_agent_attributes = [
+    "response.status",
+    "http.statusCode",
+    "request.headers.contentType",
+    "request.headers.contentLength",
+]
 
 _expected_absent_agent_attributes = ["request.method", "request.uri", *REQ_PARAMS]
 

--- a/tests/agent_features/test_attributes_in_action.py
+++ b/tests/agent_features/test_attributes_in_action.py
@@ -91,6 +91,7 @@ AGENT_KEYS_ALL = TRACE_ERROR_AGENT_KEYS + REQ_PARAMS
 TRANS_EVENT_INTRINSICS = ("name", "duration", "type", "timestamp", "totalTime", "error", "apdexPerfZone")
 TRANS_EVENT_AGENT_KEYS = [
     "response.status",
+    "http.statusCode",
     "request.method",
     "request.uri",
     "request.headers.contentType",
@@ -493,13 +494,13 @@ def test_browser_exclude_user_attribute(normal_application):
 _override_settings = {"attributes.exclude": ["request.*"], "attributes.include": ["request.headers.*"]}
 
 _expected_attributes = {
-    "agent": ["response.status", "request.headers.contentType", "request.headers.contentLength"],
+    "agent": ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"],
     "user": ERROR_USER_ATTRS,
     "intrinsic": ["guid"],
 }
 
 _expected_attributes_event = {
-    "agent": ["response.status", "request.headers.contentType", "request.headers.contentLength"],
+    "agent": ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"],
     "user": ERROR_USER_ATTRS,
     "intrinsic": ERROR_EVENT_INTRINSICS,
 }
@@ -515,7 +516,7 @@ def test_error_in_transaction_exclude_agent_attribute(normal_application):
 
 
 _expected_attributes = {
-    "agent": ["response.status", "request.headers.contentType", "request.headers.contentLength"],
+    "agent": ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"],
     "user": USER_ATTRS,
     "intrinsic": ["guid"],
 }
@@ -528,7 +529,7 @@ def test_transaction_trace_exclude_agent_attribute(normal_application):
 
 
 _expected_attributes = {
-    "agent": ["response.status", "request.headers.contentType", "request.headers.contentLength"],
+    "agent": ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"],
     "user": USER_ATTRS,
     "intrinsic": TRANS_EVENT_INTRINSICS,
 }
@@ -544,7 +545,7 @@ def test_transaction_event_exclude_agent_attribute(normal_application):
 
 _override_settings = {"attributes.exclude": ["request.*"], "attributes.include": ["request.headers.*"]}
 
-_expected_agent_attributes = ["response.status", "request.headers.contentType", "request.headers.contentLength"]
+_expected_agent_attributes = ["response.status", "http.statusCode", "request.headers.contentType", "request.headers.contentLength"]
 
 _expected_absent_agent_attributes = ["request.method", "request.uri", *REQ_PARAMS]
 

--- a/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
+++ b/tests/agent_features/test_transaction_event_data_and_some_browser_stuff_too.py
@@ -461,7 +461,7 @@ _expected_attributes = {"user": [], "agent": [], "intrinsic": ("name", "duration
 
 _expected_absent_attributes = {
     "user": ("foo", "drop-me"),
-    "agent": ("response.status", "request.method"),
+    "agent": ("response.status", "http.statusCode", "request.method"),
     "intrinsic": ("port"),
 }
 

--- a/tests/agent_features/test_web_transaction.py
+++ b/tests/agent_features/test_web_transaction.py
@@ -87,6 +87,7 @@ def test_double_wrapped_dispatcher_and_framework_metrics():
         "request.method",
         "request.uri",
         "response.status",
+        "http.statusCode",
         "response.headers.contentLength",
         "response.headers.contentType",
         "request.parameters.foo",

--- a/tests/component_graphenedjango/test_application.py
+++ b/tests/component_graphenedjango/test_application.py
@@ -141,6 +141,7 @@ def test_operation_metrics_and_attrs(wsgi_app):
     @validate_span_events(
         exact_agents={
             "response.status": "200",
+            "http.statusCode": 200,
             "response.headers.contentLength": 108,
             "response.headers.contentType": "application/json",
         }
@@ -179,6 +180,7 @@ def test_field_resolver_metrics_and_attrs(wsgi_app):
     @validate_span_events(
         exact_agents={
             "response.status": "200",
+            "http.statusCode": 200,
             "response.headers.contentLength": 108,
             "response.headers.contentType": "application/json",
         }

--- a/tests/framework_aiohttp/test_server.py
+++ b/tests/framework_aiohttp/test_server.py
@@ -73,7 +73,7 @@ def test_error_exception(method, uri, metric_name, error, status, nr_enabled, ai
         @validate_transaction_event_attributes(
             required_params={"agent": required_attrs, "user": [], "intrinsic": []},
             forgone_params={"agent": forgone_attrs, "user": [], "intrinsic": []},
-            exact_attrs={"agent": {"response.status": str(status)}, "user": {}, "intrinsic": {}},
+            exact_attrs={"agent": {"response.status": str(status), "http.statusCode": status}, "user": {}, "intrinsic": {}},
         )
         @validate_code_level_metrics(*metric_name.split(":"))
         @override_ignore_status_codes([404])
@@ -125,7 +125,7 @@ def test_simultaneous_requests(method, uri, metric_name, nr_enabled, aiohttp_app
 
     required_attrs.extend(extra_required)
 
-    required_attrs.extend(["response.status", "response.headers.contentType"])
+    required_attrs.extend(["response.status", "http.statusCode", "response.headers.contentType"])
 
     if nr_enabled:
         transactions = []

--- a/tests/framework_aiohttp/test_server.py
+++ b/tests/framework_aiohttp/test_server.py
@@ -73,7 +73,11 @@ def test_error_exception(method, uri, metric_name, error, status, nr_enabled, ai
         @validate_transaction_event_attributes(
             required_params={"agent": required_attrs, "user": [], "intrinsic": []},
             forgone_params={"agent": forgone_attrs, "user": [], "intrinsic": []},
-            exact_attrs={"agent": {"response.status": str(status), "http.statusCode": status}, "user": {}, "intrinsic": {}},
+            exact_attrs={
+                "agent": {"response.status": str(status), "http.statusCode": status},
+                "user": {},
+                "intrinsic": {},
+            },
         )
         @validate_code_level_metrics(*metric_name.split(":"))
         @override_ignore_status_codes([404])

--- a/tests/framework_grpc/test_server.py
+++ b/tests/framework_grpc/test_server.py
@@ -47,7 +47,7 @@ def test_simple(method_name, streaming_request, mock_grpc_server, stub):
     @override_application_settings({"attributes.include": ["request.*"]})
     @validate_transaction_event_attributes(
         required_params={
-            "agent": ["request.uri", "request.headers.userAgent", "response.status", "response.headers.contentType"],
+            "agent": ["request.uri", "request.headers.userAgent", "response.status", "http.statusCode", "response.headers.contentType"],
             "user": [],
             "intrinsic": ["port"],
         },
@@ -83,11 +83,11 @@ def test_raises_response_status(method_name, streaming_request, mock_grpc_server
     @override_application_settings({"attributes.include": ["request.*"]})
     @validate_transaction_event_attributes(
         required_params={
-            "agent": ["request.uri", "request.headers.userAgent", "response.status"],
+            "agent": ["request.uri", "request.headers.userAgent", "response.status", "http.statusCode"],
             "user": [],
             "intrinsic": ["port"],
         },
-        exact_attrs={"agent": {"response.status": status_code}, "user": {}, "intrinsic": {"port": port}},
+        exact_attrs={"agent": {"response.status": status_code, "http.statusCode": int(status_code)}, "user": {}, "intrinsic": {"port": port}},
     )
     @wait_for_transaction_completion
     def _doit():

--- a/tests/framework_grpc/test_server.py
+++ b/tests/framework_grpc/test_server.py
@@ -47,7 +47,13 @@ def test_simple(method_name, streaming_request, mock_grpc_server, stub):
     @override_application_settings({"attributes.include": ["request.*"]})
     @validate_transaction_event_attributes(
         required_params={
-            "agent": ["request.uri", "request.headers.userAgent", "response.status", "http.statusCode", "response.headers.contentType"],
+            "agent": [
+                "request.uri",
+                "request.headers.userAgent",
+                "response.status",
+                "http.statusCode",
+                "response.headers.contentType",
+            ],
             "user": [],
             "intrinsic": ["port"],
         },
@@ -87,7 +93,11 @@ def test_raises_response_status(method_name, streaming_request, mock_grpc_server
             "user": [],
             "intrinsic": ["port"],
         },
-        exact_attrs={"agent": {"response.status": status_code, "http.statusCode": int(status_code)}, "user": {}, "intrinsic": {"port": port}},
+        exact_attrs={
+            "agent": {"response.status": status_code, "http.statusCode": int(status_code)},
+            "user": {},
+            "intrinsic": {"port": port},
+        },
     )
     @wait_for_transaction_completion
     def _doit():

--- a/tests/framework_sanic/test_application.py
+++ b/tests/framework_sanic/test_application.py
@@ -43,7 +43,7 @@ BASE_METRICS = [
     ("Function/_target_application:request_middleware", 1 if sanic_v19_to_v22_12 else 2),
 ]
 FRAMEWORK_METRICS = [(f"Python/Framework/Sanic/{sanic.__version__}", 1)]
-BASE_ATTRS = ["response.status", "response.headers.contentType", "response.headers.contentLength"]
+BASE_ATTRS = ["response.status", "http.statusCode", "response.headers.contentType", "response.headers.contentLength"]
 
 validate_base_transaction_event_attr = validate_transaction_event_attributes(
     required_params={"agent": BASE_ATTRS, "user": [], "intrinsic": []}
@@ -160,7 +160,7 @@ def test_error_raised_in_error_handler(app):
     app.fetch("get", "/zero")
 
 
-STREAMING_ATTRS = ["response.status", "response.headers.contentType"]
+STREAMING_ATTRS = ["response.status", "http.statusCode", "response.headers.contentType"]
 STREAMING_METRICS = [("Function/_target_application:streaming", 1)]
 
 

--- a/tests/framework_sanic/test_distributed_trace.py
+++ b/tests/framework_sanic/test_distributed_trace.py
@@ -25,7 +25,7 @@ DT_METRICS = [
     ("Supportability/DistributedTrace/AcceptPayload/Success", None),
     ("Supportability/TraceContext/TraceParent/Accept/Success", 1),
 ]
-BASE_ATTRS = ["response.status", "response.headers.contentType", "response.headers.contentLength"]
+BASE_ATTRS = ["response.status", "http.statusCode", "response.headers.contentType", "response.headers.contentLength"]
 
 
 def raw_headers(response):

--- a/tests/framework_tornado/test_inbound_dt.py
+++ b/tests/framework_tornado/test_inbound_dt.py
@@ -23,7 +23,11 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
     required_params={"agent": (), "user": (), "intrinsic": ()},
     forgone_params={"agent": (), "user": (), "intrinsic": ()},
     exact_attrs={
-        "agent": {"response.status": "200", "http.statusCode": 200, "response.headers.contentType": "text/html; charset=UTF-8"},
+        "agent": {
+            "response.status": "200",
+            "http.statusCode": 200,
+            "response.headers.contentType": "text/html; charset=UTF-8",
+        },
         "user": {},
         "intrinsic": {},
     },

--- a/tests/framework_tornado/test_inbound_dt.py
+++ b/tests/framework_tornado/test_inbound_dt.py
@@ -23,7 +23,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
     required_params={"agent": (), "user": (), "intrinsic": ()},
     forgone_params={"agent": (), "user": (), "intrinsic": ()},
     exact_attrs={
-        "agent": {"response.status": "200", "response.headers.contentType": "text/html; charset=UTF-8"},
+        "agent": {"response.status": "200", "http.statusCode": 200, "response.headers.contentType": "text/html; charset=UTF-8"},
         "user": {},
         "intrinsic": {},
     },

--- a/tests/framework_tornado/test_server.py
+++ b/tests/framework_tornado/test_server.py
@@ -66,8 +66,7 @@ def test_server(app, uri, name, metrics, method_metric):
                 "request.method": "GET",
                 "request.uri": uri,
                 "response.status": "200",
-                "http.statusCode": 200
-
+                "http.statusCode": 200,
             },
             "user": {},
             "intrinsic": {"port": app.get_http_port()},

--- a/tests/framework_tornado/test_server.py
+++ b/tests/framework_tornado/test_server.py
@@ -66,6 +66,8 @@ def test_server(app, uri, name, metrics, method_metric):
                 "request.method": "GET",
                 "request.uri": uri,
                 "response.status": "200",
+                "http.statusCode": 200
+
             },
             "user": {},
             "intrinsic": {"port": app.get_http_port()},

--- a/tests/hybridagent_fastapi/test_otel_application.py
+++ b/tests/hybridagent_fastapi/test_otel_application.py
@@ -66,7 +66,7 @@ def test_application(caplog, app, endpoint):
                 "request.uri": endpoint,
                 "response.headers.contentLength": 2,
                 "response.status": "200",
-                "http.statusCode": 200
+                "http.statusCode": 200,
             },
             "intrinsic": {"name": f"WebTransaction/Uri/{transaction_name}"},
             "user": {},

--- a/tests/hybridagent_fastapi/test_otel_application.py
+++ b/tests/hybridagent_fastapi/test_otel_application.py
@@ -66,6 +66,7 @@ def test_application(caplog, app, endpoint):
                 "request.uri": endpoint,
                 "response.headers.contentLength": 2,
                 "response.status": "200",
+                "http.statusCode": 200
             },
             "intrinsic": {"name": f"WebTransaction/Uri/{transaction_name}"},
             "user": {},

--- a/tests/hybridagent_flask/test_application.py
+++ b/tests/hybridagent_flask/test_application.py
@@ -99,6 +99,7 @@ _test_application_rollup_metrics = [
             "request.uri": "/index",
             "response.headers.contentLength": 14,
             "response.status": "200",
+            "http.statusCode": 200
         },
         "intrinsic": {"name": "WebTransaction/Uri/index"},
         "user": {},

--- a/tests/hybridagent_flask/test_application.py
+++ b/tests/hybridagent_flask/test_application.py
@@ -99,7 +99,7 @@ _test_application_rollup_metrics = [
             "request.uri": "/index",
             "response.headers.contentLength": 14,
             "response.status": "200",
-            "http.statusCode": 200
+            "http.statusCode": 200,
         },
         "intrinsic": {"name": "WebTransaction/Uri/index"},
         "user": {},


### PR DESCRIPTION
The agent stores the http status code in the `response.status` attribute on transaction events. It needs to be stored in `http.statusCode` instead. `response.status` will be eventually be deprecated.