### PR TITLE
Repair RabbitMQ Testing

### DIFF
--- a/tests/hybridagent_pika/conftest.py
+++ b/tests/hybridagent_pika/conftest.py
@@ -64,8 +64,8 @@ def producer():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE, durable=False)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE, exchange=EXCHANGE)
 
         channel.basic_publish(
@@ -85,8 +85,8 @@ def producer_2():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE_2, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE_2, durable=False)
+        channel.queue_declare(queue=QUEUE_2, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE_2, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE_2, exchange=EXCHANGE_2)
 
         channel.basic_publish(
@@ -106,8 +106,8 @@ def produce_five():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE, durable=False)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE, exchange=EXCHANGE)
 
         for _ in range(5):

--- a/tests/hybridagent_pika/test_distributed_tracing.py
+++ b/tests/hybridagent_pika/test_distributed_tracing.py
@@ -112,7 +112,7 @@ def test_basic_consume_distributed_tracing_headers():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}
@@ -158,7 +158,7 @@ def test_basic_get_no_distributed_tracing_headers():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}
@@ -175,7 +175,7 @@ def test_distributed_tracing_sends_produce_id():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}

--- a/tests/hybridagent_pika/test_pika_produce.py
+++ b/tests/hybridagent_pika/test_pika_produce.py
@@ -14,6 +14,7 @@
 
 import pika
 import pytest
+from conftest import EXCHANGE, EXCHANGE_2, QUEUE
 from testing_support.db_settings import rabbitmq_settings
 from testing_support.fixtures import dt_enabled, override_application_settings, reset_core_stats_engine
 from testing_support.util import conditional_decorator
@@ -48,7 +49,6 @@ def cache_pika_headers(wrapped, instance, args, kwargs):
 
 
 DB_SETTINGS = rabbitmq_settings()[0]
-QUEUE = "test-pika-queue"
 CORRELATION_ID = "testingpika"
 REPLY_TO = "testing"
 HEADERS = {"MYHEADER": "pikatest"}
@@ -220,10 +220,10 @@ def test_blocking_connection_headers_reuse_properties():
 
 
 _test_blocking_connection_two_exchanges_metrics = [
-    ("MessageBroker/rabbitmq/Exchange/Produce/Named/exchange-1", 2),
-    ("MessageBroker/rabbitmq/Exchange/Produce/Named/exchange-2", 2),
-    ("MessageBroker/rabbitmq/Exchange/Consume/Named/exchange-1", None),
-    ("MessageBroker/rabbitmq/Exchange/Consume/Named/exchange-2", None),
+    (f"MessageBroker/rabbitmq/Exchange/Produce/Named/{EXCHANGE}", 2),
+    (f"MessageBroker/rabbitmq/Exchange/Produce/Named/{EXCHANGE_2}", 2),
+    (f"MessageBroker/rabbitmq/Exchange/Consume/Named/{EXCHANGE}", None),
+    (f"MessageBroker/rabbitmq/Exchange/Consume/Named/{EXCHANGE_2}", None),
 ]
 
 
@@ -246,17 +246,17 @@ _test_blocking_connection_two_exchanges_metrics = [
 def test_blocking_connection_two_exchanges():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
-        channel.queue_declare(queue=QUEUE)
-        channel.exchange_declare(exchange="exchange-1", durable=False, auto_delete=True)
-        channel.exchange_declare(exchange="exchange-2", durable=False, auto_delete=True)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE_2, durable=True, auto_delete=True)
 
-        channel.basic_publish(exchange="exchange-1", routing_key=QUEUE, body="test")
-        channel.basic_publish(exchange="exchange-2", routing_key=QUEUE, body="test")
+        channel.basic_publish(exchange=EXCHANGE, routing_key=QUEUE, body="test")
+        channel.basic_publish(exchange=EXCHANGE_2, routing_key=QUEUE, body="test")
 
 
 _test_select_connection_metrics = [
-    ("MessageBroker/rabbitmq/Exchange/Produce/Named/test-pika-queue", 1),
-    ("MessageBroker/rabbitmq/Exchange/Consume/Named/test-pika-queue", None),
+    (f"MessageBroker/rabbitmq/Exchange/Produce/Named/{QUEUE}", 1),
+    (f"MessageBroker/rabbitmq/Exchange/Consume/Named/{QUEUE}", None),
 ]
 
 
@@ -273,7 +273,7 @@ _test_select_connection_metrics = [
 )
 @validate_span_events(
     count=1,
-    exact_intrinsics={"name": "MessageBroker/rabbitmq/Exchange/Produce/Named/test-pika-queue"},
+    exact_intrinsics={"name": f"MessageBroker/rabbitmq/Exchange/Produce/Named/{QUEUE}"},
     exact_agents={"server.address": DB_SETTINGS["host"]},
 )
 @background_task()
@@ -302,8 +302,8 @@ def test_select_connection():
 
 
 _test_tornado_connection_metrics = [
-    ("MessageBroker/rabbitmq/Exchange/Produce/Named/test-pika-queue", 1),
-    ("MessageBroker/rabbitmq/Exchange/Consume/Named/test-pika-queue", None),
+    (f"MessageBroker/rabbitmq/Exchange/Produce/Named/{QUEUE}", 1),
+    (f"MessageBroker/rabbitmq/Exchange/Consume/Named/{QUEUE}", None),
 ]
 
 
@@ -320,7 +320,7 @@ _test_tornado_connection_metrics = [
 )
 @validate_span_events(
     count=1,
-    exact_intrinsics={"name": "MessageBroker/rabbitmq/Exchange/Produce/Named/test-pika-queue"},
+    exact_intrinsics={"name": f"MessageBroker/rabbitmq/Exchange/Produce/Named/{QUEUE}"},
     exact_agents={"server.address": DB_SETTINGS["host"]},
 )
 @background_task()

--- a/tests/messagebroker_kombu/conftest.py
+++ b/tests/messagebroker_kombu/conftest.py
@@ -146,7 +146,7 @@ def events():
 @pytest.fixture(scope="session")
 def exchange():
     exchange_uuid = str(uuid.uuid4())
-    return kombu.Exchange(f"exchange-{exchange_uuid}", "direct", durable=True)
+    return kombu.Exchange(f"exchange-{exchange_uuid}", "direct", durable=True, auto_delete=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/messagebroker_pika/conftest.py
+++ b/tests/messagebroker_pika/conftest.py
@@ -59,8 +59,8 @@ def producer():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE, durable=False)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE, exchange=EXCHANGE)
 
         channel.basic_publish(
@@ -80,8 +80,8 @@ def producer_2():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE_2, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE_2, durable=False)
+        channel.queue_declare(queue=QUEUE_2, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE_2, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE_2, exchange=EXCHANGE_2)
 
         channel.basic_publish(
@@ -101,8 +101,8 @@ def produce_five():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
 
-        channel.queue_declare(queue=QUEUE, durable=False)
-        channel.exchange_declare(exchange=EXCHANGE, durable=False)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
         channel.queue_bind(queue=QUEUE, exchange=EXCHANGE)
 
         for _ in range(5):

--- a/tests/messagebroker_pika/test_distributed_tracing.py
+++ b/tests/messagebroker_pika/test_distributed_tracing.py
@@ -98,7 +98,7 @@ def test_basic_consume_distributed_tracing_headers():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}
@@ -144,7 +144,7 @@ def test_basic_get_no_distributed_tracing_headers():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}
@@ -161,7 +161,7 @@ def test_distributed_tracing_sends_produce_id():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
         queue_name = f"TESTDT-{os.getpid()}"
-        channel.queue_declare(queue_name, durable=False)
+        channel.queue_declare(queue_name, durable=True, auto_delete=True)
 
         properties = pika.BasicProperties()
         properties.headers = {"Hello": "World"}

--- a/tests/messagebroker_pika/test_pika_blocking_connection_consume.py
+++ b/tests/messagebroker_pika/test_pika_blocking_connection_consume.py
@@ -86,7 +86,7 @@ def test_blocking_connection_basic_get_empty():
     QUEUE = f"test_blocking_empty-{os.getpid()}"
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
-        channel.queue_declare(queue=QUEUE)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
 
         try:
             method_frame, _, _ = channel.basic_get(QUEUE)
@@ -102,7 +102,7 @@ def test_blocking_connection_basic_get_outside_transaction(producer):
     def test_basic_get():
         with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
             channel = connection.channel()
-            channel.queue_declare(queue=QUEUE)
+            channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
 
             method_frame, _, _ = channel.basic_get(QUEUE)
             channel.basic_ack(method_frame.delivery_tag)

--- a/tests/messagebroker_pika/test_pika_produce.py
+++ b/tests/messagebroker_pika/test_pika_produce.py
@@ -14,6 +14,7 @@
 
 import pika
 import pytest
+from conftest import EXCHANGE, EXCHANGE_2, QUEUE
 from testing_support.db_settings import rabbitmq_settings
 from testing_support.fixtures import dt_enabled, override_application_settings
 from testing_support.validators.validate_messagebroker_headers import validate_messagebroker_headers
@@ -40,7 +41,6 @@ def cache_pika_headers(wrapped, instance, args, kwargs):
 
 
 DB_SETTINGS = rabbitmq_settings()[0]
-QUEUE = "test-pika-queue"
 CORRELATION_ID = "testingpika"
 REPLY_TO = "testing"
 HEADERS = {"MYHEADER": "pikatest"}
@@ -238,10 +238,10 @@ def test_blocking_connection_headers_reuse_properties(producer):
 
 
 _test_blocking_connection_two_exchanges_metrics = [
-    ("MessageBroker/RabbitMQ/Exchange/Produce/Named/exchange-1", 1),
-    ("MessageBroker/RabbitMQ/Exchange/Produce/Named/exchange-2", 1),
-    ("MessageBroker/RabbitMQ/Exchange/Consume/Named/exchange-1", None),
-    ("MessageBroker/RabbitMQ/Exchange/Consume/Named/exchange-2", None),
+    (f"MessageBroker/RabbitMQ/Exchange/Produce/Named/{EXCHANGE}", 1),
+    (f"MessageBroker/RabbitMQ/Exchange/Produce/Named/{EXCHANGE_2}", 1),
+    (f"MessageBroker/RabbitMQ/Exchange/Consume/Named/{EXCHANGE}", None),
+    (f"MessageBroker/RabbitMQ/Exchange/Consume/Named/{EXCHANGE_2}", None),
 ]
 
 
@@ -261,12 +261,12 @@ _test_blocking_connection_two_exchanges_metrics = [
 def test_blocking_connection_two_exchanges():
     with pika.BlockingConnection(pika.ConnectionParameters(DB_SETTINGS["host"])) as connection:
         channel = connection.channel()
-        channel.queue_declare(queue=QUEUE)
-        channel.exchange_declare(exchange="exchange-1", durable=False, auto_delete=True)
-        channel.exchange_declare(exchange="exchange-2", durable=False, auto_delete=True)
+        channel.queue_declare(queue=QUEUE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE, durable=True, auto_delete=True)
+        channel.exchange_declare(exchange=EXCHANGE_2, durable=True, auto_delete=True)
 
-        channel.basic_publish(exchange="exchange-1", routing_key=QUEUE, body="test")
-        channel.basic_publish(exchange="exchange-2", routing_key=QUEUE, body="test")
+        channel.basic_publish(exchange=EXCHANGE, routing_key=QUEUE, body="test")
+        channel.basic_publish(exchange=EXCHANGE_2, routing_key=QUEUE, body="test")
 
 
 _test_select_connection_metrics = [


### PR DESCRIPTION
# Overview

* Change all test instances of RabbitMQ to use `auto_delete` instead of transient queues (`durable=False`).