### PR TITLE
Starlette Context Propagation in StreamingResponse

### DIFF
--- a/newrelic/hooks/framework_starlette.py
+++ b/newrelic/hooks/framework_starlette.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 from newrelic.api.asgi_application import wrap_asgi_application
 from newrelic.api.background_task import BackgroundTaskWrapper
 from newrelic.api.function_trace import FunctionTraceWrapper
@@ -20,6 +22,7 @@ from newrelic.api.transaction import current_transaction
 from newrelic.common.coroutine import is_coroutine_function
 from newrelic.common.object_names import callable_name
 from newrelic.common.object_wrapper import FunctionWrapper, function_wrapper, wrap_function_wrapper
+from newrelic.common.signature import bind_args
 from newrelic.core.context import ContextOf, context_wrapper
 
 
@@ -208,6 +211,33 @@ async def wrap_run_in_threadpool(wrapped, instance, args, kwargs):
     return await wrapped(func, *args, **kwargs)
 
 
+async def wrap_iterate_in_threadpool(wrapped, instance, args, kwargs):
+    transaction = current_transaction()
+    trace = current_trace()
+
+    if not transaction or not trace:
+        async for item in wrapped(*args, **kwargs):
+            yield item
+
+    bound_args = bind_args(wrapped, args, kwargs)
+    bound_args["iterator"] = generator_wrapper(bound_args["iterator"], ContextOf(trace=trace))
+
+    async for item in wrapped(**bound_args):
+        yield item
+
+
+def generator_wrapper(wrapped, trace):
+    # This differs from the same API in async_wrapper.py in that it
+    # returns a generator object directly, instead of a generator function.
+    @functools.wraps(wrapped)
+    def wrapper(*args, **kwargs):
+        with trace:
+            result = yield from iter(wrapped)
+            return result
+
+    return wrapper()
+
+
 def instrument_starlette_applications(module):
     framework = framework_details()
     version_info = tuple(int(v) for v in framework[1].split(".", 3)[:3])
@@ -262,4 +292,7 @@ def instrument_starlette_background_task(module):
 
 
 def instrument_starlette_concurrency(module):
-    wrap_function_wrapper(module, "run_in_threadpool", wrap_run_in_threadpool)
+    if hasattr(module, "run_in_threadpool"):
+        wrap_function_wrapper(module, "run_in_threadpool", wrap_run_in_threadpool)
+    if hasattr(module, "iterate_in_threadpool"):
+        wrap_function_wrapper(module, "iterate_in_threadpool", wrap_iterate_in_threadpool)

--- a/tests/framework_starlette/_test_application.py
+++ b/tests/framework_starlette/_test_application.py
@@ -15,7 +15,7 @@
 from starlette.applications import Starlette
 from starlette.background import BackgroundTasks
 from starlette.exceptions import HTTPException
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, StreamingResponse
 from starlette.routing import Route
 from testing_support.asgi_testing import AsgiTest
 
@@ -41,7 +41,7 @@ async def index(request):
     return PlainTextResponse("Hello, world!")
 
 
-def non_async(request):
+def sync(request):
     assert current_transaction()
     return PlainTextResponse("Non async route")
 
@@ -78,6 +78,34 @@ def missing_route_handler(request, exc):
     return PlainTextResponse("Missing route handler", status_code=404)
 
 
+async def async_streaming_generator():
+    with FunctionTrace(name=callable_name(async_streaming_generator)):
+        for chunk in ("Async ", "streaming ", "response"):
+            yield chunk
+
+
+def sync_streaming_generator():
+    with FunctionTrace(name=callable_name(sync_streaming_generator)):
+        for chunk in ("Sync ", "streaming ", "response"):  # noqa: UP028
+            yield chunk
+
+
+async def async_handler_async_streaming_response(request):
+    return StreamingResponse(async_streaming_generator(), media_type="text/plain")
+
+
+async def async_handler_sync_streaming_response(request):
+    return StreamingResponse(sync_streaming_generator(), media_type="text/plain")
+
+
+def sync_handler_async_streaming_response(request):
+    return StreamingResponse(async_streaming_generator(), media_type="text/plain")
+
+
+def sync_handler_sync_streaming_response(request):
+    return StreamingResponse(sync_streaming_generator(), media_type="text/plain")
+
+
 class CustomRoute:
     def __init__(self, route):
         self.route = route
@@ -91,7 +119,7 @@ class CustomRoute:
 async def run_bg_task(request):
     tasks = BackgroundTasks()
     tasks.add_task(bg_task_async)
-    tasks.add_task(bg_task_non_async)
+    tasks.add_task(bg_task_sync)
     return PlainTextResponse("Hello, world!", background=tasks)
 
 
@@ -99,20 +127,24 @@ async def bg_task_async():
     pass
 
 
-def bg_task_non_async():
+def bg_task_sync():
     pass
 
 
 routes = [
     Route("/index", index),
     Route("/418", teapot),
-    Route("/non_async", non_async),
+    Route("/sync", sync),
     Route("/runtime_error", runtime_error),
     Route("/handled_error", handled_error),
     Route("/sync_handled_error", sync_handled_error),
     Route("/raw_runtime_error", CustomRoute(runtime_error)),
     Route("/raw_http_error", CustomRoute(teapot)),
     Route("/run_bg_task", run_bg_task),
+    Route("/async_handler_async_streaming_response", async_handler_async_streaming_response),
+    Route("/async_handler_sync_streaming_response", async_handler_sync_streaming_response),
+    Route("/sync_handler_async_streaming_response", sync_handler_async_streaming_response),
+    Route("/sync_handler_sync_streaming_response", sync_handler_sync_streaming_response),
 ]
 
 

--- a/tests/framework_starlette/_test_application.py
+++ b/tests/framework_starlette/_test_application.py
@@ -91,18 +91,26 @@ def sync_streaming_generator():
 
 
 async def async_handler_async_streaming_response(request):
+    with FunctionTrace(name="_test_application:async_handler_view"):
+        pass
     return StreamingResponse(async_streaming_generator(), media_type="text/plain")
 
 
 async def async_handler_sync_streaming_response(request):
+    with FunctionTrace(name="_test_application:async_handler_view"):
+        pass
     return StreamingResponse(sync_streaming_generator(), media_type="text/plain")
 
 
 def sync_handler_async_streaming_response(request):
+    with FunctionTrace(name="_test_application:sync_handler_view"):
+        pass
     return StreamingResponse(async_streaming_generator(), media_type="text/plain")
 
 
 def sync_handler_sync_streaming_response(request):
+    with FunctionTrace(name="_test_application:sync_handler_view"):
+        pass
     return StreamingResponse(sync_streaming_generator(), media_type="text/plain")
 
 

--- a/tests/framework_starlette/test_application.py
+++ b/tests/framework_starlette/test_application.py
@@ -66,15 +66,79 @@ def test_application_index(target_application, app_name):
 
 @pytest.mark.parametrize("app_name", ("no_error_handler",))
 @validate_transaction_metrics(
-    "_test_application:non_async",
-    scoped_metrics=[*MIDDLEWARE_METRICS, ("Function/_test_application:non_async", 1)],
+    "_test_application:async_handler_async_streaming_response",
+    scoped_metrics=[
+        *MIDDLEWARE_METRICS,
+        ("Function/_test_application:async_handler_async_streaming_response", 1),
+        ("Function/_test_application:async_streaming_generator", 1),
+    ],
     rollup_metrics=[FRAMEWORK_METRIC],
 )
-@validate_code_level_metrics("_test_application", "non_async")
-@validate_code_level_metrics("_test_application.middleware_factory.<locals>", "middleware", count=2)
-def test_application_non_async(target_application, app_name):
+def test_application_async_handler_async_streaming_response(target_application, app_name):
     app = target_application[app_name]
-    response = app.get("/non_async")
+    response = app.get("/async_handler_async_streaming_response")
+    assert response.status == 200
+
+
+@pytest.mark.parametrize("app_name", ("no_error_handler",))
+@validate_transaction_metrics(
+    "_test_application:async_handler_sync_streaming_response",
+    scoped_metrics=[
+        *MIDDLEWARE_METRICS,
+        ("Function/_test_application:async_handler_sync_streaming_response", 1),
+        ("Function/_test_application:sync_streaming_generator", 1),
+    ],
+    rollup_metrics=[FRAMEWORK_METRIC],
+)
+def test_application_async_handler_sync_streaming_response(target_application, app_name):
+    app = target_application[app_name]
+    response = app.get("/async_handler_sync_streaming_response")
+    assert response.status == 200
+
+
+@pytest.mark.parametrize("app_name", ("no_error_handler",))
+@validate_transaction_metrics(
+    "_test_application:sync_handler_async_streaming_response",
+    scoped_metrics=[
+        *MIDDLEWARE_METRICS,
+        ("Function/_test_application:sync_handler_async_streaming_response", 1),
+        ("Function/_test_application:async_streaming_generator", 1),
+    ],
+    rollup_metrics=[FRAMEWORK_METRIC],
+)
+def test_application_sync_handler_async_streaming_response(target_application, app_name):
+    app = target_application[app_name]
+    response = app.get("/sync_handler_async_streaming_response")
+    assert response.status == 200
+
+
+@pytest.mark.parametrize("app_name", ("no_error_handler",))
+@validate_transaction_metrics(
+    "_test_application:sync_handler_sync_streaming_response",
+    scoped_metrics=[
+        *MIDDLEWARE_METRICS,
+        ("Function/_test_application:sync_handler_sync_streaming_response", 1),
+        ("Function/_test_application:sync_streaming_generator", 1),
+    ],
+    rollup_metrics=[FRAMEWORK_METRIC],
+)
+def test_application_sync_handler_sync_streaming_response(target_application, app_name):
+    app = target_application[app_name]
+    response = app.get("/sync_handler_sync_streaming_response")
+    assert response.status == 200
+
+
+@pytest.mark.parametrize("app_name", ("no_error_handler",))
+@validate_transaction_metrics(
+    "_test_application:sync",
+    scoped_metrics=[*MIDDLEWARE_METRICS, ("Function/_test_application:sync", 1)],
+    rollup_metrics=[FRAMEWORK_METRIC],
+)
+@validate_code_level_metrics("_test_application", "sync")
+@validate_code_level_metrics("_test_application.middleware_factory.<locals>", "middleware", count=2)
+def test_application_sync(target_application, app_name):
+    app = target_application[app_name]
+    response = app.get("/sync")
     assert response.status == 200
 
 

--- a/tests/framework_starlette/test_application.py
+++ b/tests/framework_starlette/test_application.py
@@ -71,6 +71,7 @@ def test_application_index(target_application, app_name):
         *MIDDLEWARE_METRICS,
         ("Function/_test_application:async_handler_async_streaming_response", 1),
         ("Function/_test_application:async_streaming_generator", 1),
+        ("Function/_test_application:async_handler_view", 1),
     ],
     rollup_metrics=[FRAMEWORK_METRIC],
 )
@@ -87,6 +88,7 @@ def test_application_async_handler_async_streaming_response(target_application, 
         *MIDDLEWARE_METRICS,
         ("Function/_test_application:async_handler_sync_streaming_response", 1),
         ("Function/_test_application:sync_streaming_generator", 1),
+        ("Function/_test_application:async_handler_view", 1),
     ],
     rollup_metrics=[FRAMEWORK_METRIC],
 )
@@ -103,6 +105,7 @@ def test_application_async_handler_sync_streaming_response(target_application, a
         *MIDDLEWARE_METRICS,
         ("Function/_test_application:sync_handler_async_streaming_response", 1),
         ("Function/_test_application:async_streaming_generator", 1),
+        ("Function/_test_application:sync_handler_view", 1),
     ],
     rollup_metrics=[FRAMEWORK_METRIC],
 )
@@ -119,6 +122,7 @@ def test_application_sync_handler_async_streaming_response(target_application, a
         *MIDDLEWARE_METRICS,
         ("Function/_test_application:sync_handler_sync_streaming_response", 1),
         ("Function/_test_application:sync_streaming_generator", 1),
+        ("Function/_test_application:sync_handler_view", 1),
     ],
     rollup_metrics=[FRAMEWORK_METRIC],
 )


### PR DESCRIPTION
# Overview

* Add trace context propagation to Starlette StreamingResponse for both synchronous and asynchronous generators.