### PR TITLE
Re-initialize the plugins generator

### DIFF
--- a/newrelic/core/application.py
+++ b/newrelic/core/application.py
@@ -1778,6 +1778,7 @@ class Application:
         if restart:
             self._agent_restart += 1
             self.activate_session()
+            self.plugins = plugins()  # re-initialize the generator
 
         else:
             self._agent_shutdown = True


### PR DESCRIPTION
This PR adds a line to re-initialize the plugins generator in order to re-send the module information upon reconnection of the agent.