### PR TITLE
Pin pyOpenSSL for Daphne Tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -224,6 +224,8 @@ deps =
     adapter_cheroot: cheroot
     adapter_daphne-daphnelatest: daphne
     adapter_daphne-daphnelatest: Twisted[tls,http2]
+    # Pin pyOpenSSL to avoid compatibility issues with Twisted
+    adapter_daphne-daphnelatest: pyOpenSSL<26.2.0
     adapter_daphne: niquests
     adapter_gevent: WSGIProxy2
     adapter_gevent: gevent

--- a/tox.ini
+++ b/tox.ini
@@ -432,7 +432,8 @@ deps =
     hybridagent_opentelemetry: opentelemetry-api
     hybridagent_pika: opentelemetry-api
     hybridagent_pika: opentelemetry-instrumentation-pika
-    hybridagent_pika: pika
+    # TODO: Pinned for a crash in our tests' callbacks on 1.4.0
+    hybridagent_pika: pika!=1.4.0
     hybridagent_pika: tornado<5
     hybridagent_psycopg2: opentelemetry-api
     hybridagent_psycopg2: psycopg2-binary
@@ -474,7 +475,8 @@ deps =
     mlmodel_strands: strands-agents-tools
     logger_loguru-logurulatest: loguru
     logger_structlog-structloglatest: structlog
-    messagebroker_pika-pikalatest: pika
+    # TODO: Pinned for a crash in our tests' callbacks on 1.4.0
+    messagebroker_pika-pikalatest: pika!=1.4.0
     messagebroker_pika: tornado<5
     messagebroker_confluentkafka-confluentkafkalatest: confluent-kafka
     messagebroker_kafkapython-kafkapythonnglatest: kafka-python-ng


### PR DESCRIPTION
# Overview

* Daphne uses Twisted as a dependency, which is now incompatible with pyOpenSSL's latest release. Pin this to unblock the tests.
* Pin pika tests to older versions due to a new crash in callbacks.