### PR TITLE
Unpin OpenTelemetry MySQL instrumenation version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -424,7 +424,7 @@ deps =
     hybridagent_kafkapython: opentelemetry-instrumentation-kafka-python
     hybridagent_kafkapython: kafka-python<2.1
     hybridagent_mysql: opentelemetry-api
-    hybridagent_mysql: opentelemetry-instrumentation-mysql==0.61b0
+    hybridagent_mysql: opentelemetry-instrumentation-mysql
     hybridagent_mysql: mysql-connector-python
     hybridagent_mysql: protobuf<4
     hybridagent_opentelemetry: opentelemetry-api


### PR DESCRIPTION
Pinning the OpenTelemetry MySQL instrumentation version is no longer necessary, so we are removing this so that it can continue to pull from the latest main branch.  More information can be [found here](https://github.com/newrelic/newrelic-python-agent/pull/1710#issue-4264113659).