### PR TITLE
Clean Up Custom CI Images

### DIFF
--- a/.github/containers/firestore/docker-compose.yml
+++ b/.github/containers/firestore/docker-compose.yml
@@ -1,0 +1,26 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  firestore:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:437.0.1-emulators
+    command: ["/bin/bash", "-c", "gcloud emulators firestore start --host-port=0.0.0.0:8080"]
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/ || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s

--- a/.github/containers/firestore/docker-compose.yml
+++ b/.github/containers/firestore/docker-compose.yml
@@ -15,7 +15,12 @@
 services:
   firestore:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:437.0.1-emulators
-    command: ["/bin/bash", "-c", "gcloud emulators firestore start --host-port=0.0.0.0:8080"]
+    command:
+      [
+        "/bin/bash",
+        "-c",
+        "gcloud emulators firestore start --host-port=0.0.0.0:8080",
+      ]
     ports:
       - 8080:8080
     healthcheck:

--- a/.github/containers/rediscluster/Dockerfile
+++ b/.github/containers/rediscluster/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.4
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM redis:7.0.12
+
+COPY <<"EOF" /etc/redis.conf
+cluster-announce-hostname 'host.docker.internal'
+bind 0.0.0.0
+port 6379
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes
+EOF
+
+CMD ["redis-server", "/etc/redis.conf"]

--- a/.github/containers/rediscluster/Dockerfile
+++ b/.github/containers/rediscluster/Dockerfile
@@ -16,13 +16,15 @@
 FROM redis:7.0.12
 
 COPY <<"EOF" /etc/redis.conf
-cluster-announce-hostname 'host.docker.internal'
 bind 0.0.0.0
-port 6379
 cluster-enabled yes
 cluster-config-file nodes.conf
 cluster-node-timeout 5000
+cluster-preferred-endpoint-type hostname
 appendonly yes
 EOF
 
-CMD ["redis-server", "/etc/redis.conf"]
+ENV REDIS_PORT=6379 \
+    REDIS_ANNOUNCE_HOSTNAME=localhost
+
+CMD ["sh", "-c", "exec redis-server /etc/redis.conf --port \"$REDIS_PORT\" --cluster-announce-hostname \"$REDIS_ANNOUNCE_HOSTNAME\" --cluster-announce-port \"$REDIS_PORT\""]

--- a/.github/containers/rediscluster/docker-compose.yml
+++ b/.github/containers/rediscluster/docker-compose.yml
@@ -1,0 +1,85 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+x-redis-node: &redis-node
+  build: .
+  image: redis-cluster-node:local
+  healthcheck:
+    test: ["CMD", "redis-cli", "ping"]
+    interval: 2s
+    timeout: 3s
+    retries: 15
+
+services:
+  redis1:
+    <<: *redis-node
+    ports:
+      - 6379:6379
+      - 16379:16379
+
+  redis2:
+    <<: *redis-node
+    ports:
+      - 6380:6379
+      - 16380:16379
+
+  redis3:
+    <<: *redis-node
+    ports:
+      - 6381:6379
+      - 16381:16379
+
+  redis4:
+    <<: *redis-node
+    ports:
+      - 6382:6379
+      - 16382:16379
+
+  redis5:
+    <<: *redis-node
+    ports:
+      - 6383:6379
+      - 16383:16379
+
+  redis6:
+    <<: *redis-node
+    ports:
+      - 6384:6379
+      - 16384:16379
+
+  cluster-setup:
+    image: redis-cluster-node:local
+    restart: "no"
+    command:
+      - bash
+      - -c
+      - >-
+        redis-cli --cluster create
+        redis1:6379 redis2:6379 redis3:6379 redis4:6379 redis5:6379 redis6:6379
+        --cluster-replicas 1
+        --cluster-yes &&
+        exec sleep infinity
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -h redis1 cluster info | grep -q cluster_state:ok"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
+    depends_on:
+      redis1: {condition: service_healthy}
+      redis2: {condition: service_healthy}
+      redis3: {condition: service_healthy}
+      redis4: {condition: service_healthy}
+      redis5: {condition: service_healthy}
+      redis6: {condition: service_healthy}

--- a/.github/containers/rediscluster/docker-compose.yml
+++ b/.github/containers/rediscluster/docker-compose.yml
@@ -71,15 +71,19 @@ services:
         --cluster-yes &&
         exec sleep infinity
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -h redis1 cluster info | grep -q cluster_state:ok"]
+      test:
+        [
+          "CMD-SHELL",
+          "redis-cli -h redis1 cluster info | grep -q cluster_state:ok",
+        ]
       interval: 2s
       timeout: 3s
       retries: 30
       start_period: 30s
     depends_on:
-      redis1: {condition: service_healthy}
-      redis2: {condition: service_healthy}
-      redis3: {condition: service_healthy}
-      redis4: {condition: service_healthy}
-      redis5: {condition: service_healthy}
-      redis6: {condition: service_healthy}
+      redis1: { condition: service_healthy }
+      redis2: { condition: service_healthy }
+      redis3: { condition: service_healthy }
+      redis4: { condition: service_healthy }
+      redis5: { condition: service_healthy }
+      redis6: { condition: service_healthy }

--- a/.github/containers/rediscluster/docker-compose.yml
+++ b/.github/containers/rediscluster/docker-compose.yml
@@ -15,8 +15,10 @@
 x-redis-node: &redis-node
   build: .
   image: redis-cluster-node:local
+  tmpfs:
+    - /data
   healthcheck:
-    test: ["CMD", "redis-cli", "ping"]
+    test: ["CMD-SHELL", "redis-cli -p $$REDIS_PORT ping"]
     interval: 2s
     timeout: 3s
     retries: 15
@@ -24,39 +26,51 @@ x-redis-node: &redis-node
 services:
   redis1:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6379"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
       - 6379:6379
-      - 16379:16379
 
   redis2:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6380"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
-      - 6380:6379
-      - 16380:16379
+      - 6380:6380
 
   redis3:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6381"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
-      - 6381:6379
-      - 16381:16379
+      - 6381:6381
 
   redis4:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6382"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
-      - 6382:6379
-      - 16382:16379
+      - 6382:6382
 
   redis5:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6383"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
-      - 6383:6379
-      - 16383:16379
+      - 6383:6383
 
   redis6:
     <<: *redis-node
+    environment:
+      REDIS_PORT: "6384"
+      REDIS_ANNOUNCE_HOSTNAME: ${REDIS_ANNOUNCE_HOSTNAME:-localhost}
     ports:
-      - 6384:6379
-      - 16384:16379
+      - 6384:6384
 
   cluster-setup:
     image: redis-cluster-node:local
@@ -66,7 +80,7 @@ services:
       - -c
       - >-
         redis-cli --cluster create
-        redis1:6379 redis2:6379 redis3:6379 redis4:6379 redis5:6379 redis6:6379
+        redis1:6379 redis2:6380 redis3:6381 redis4:6382 redis5:6383 redis6:6384
         --cluster-replicas 1
         --cluster-yes &&
         exec sleep infinity

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1885,6 +1885,8 @@ jobs:
           chown -R "$(whoami)" /github/home/.cache/pip
 
       - name: Start rediscluster
+        env:
+          REDIS_ANNOUNCE_HOSTNAME: host.docker.internal
         run: |
           # Build only the redis1 image to prevent fighting, then start the entire cluster
           docker compose \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1871,60 +1871,6 @@ jobs:
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
-    services:
-      redis1:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6379:6379
-          - 16379:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      redis2:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6380:6379
-          - 16380:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      redis3:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6381:6379
-          - 16381:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      redis4:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6382:6379
-          - 16382:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      redis5:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6383:6379
-          - 16383:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      redis6:
-        image: hmstepanek/redis-cluster-node:1.0.0
-        ports:
-          - 6384:6379
-          - 16384:16379
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
-      cluster-setup:
-        image: hmstepanek/redis-cluster:1.0.0
-        options: >-
-          --add-host=host.docker.internal:host-gateway
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
@@ -1937,6 +1883,23 @@ jobs:
         run: |
           mkdir -p /github/home/.cache/pip
           chown -R "$(whoami)" /github/home/.cache/pip
+
+      - name: Start rediscluster
+        run: |
+          # Build only the redis1 image to prevent fighting, then start the entire cluster
+          docker compose \
+            -f .github/containers/rediscluster/docker-compose.yml \
+            build \
+            redis1 && \
+          docker compose \
+            -f .github/containers/rediscluster/docker-compose.yml \
+            up -d \
+            --wait \
+            --wait-timeout 120 \
+            && exit 0
+          echo "rediscluster did not become healthy in time"
+          docker compose -f .github/containers/rediscluster/docker-compose.yml logs
+          exit 1
 
       - name: Get Environments
         id: get-envs
@@ -1974,6 +1937,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
+
+      - name: Stop rediscluster
+        if: always()
+        run: |
+          docker compose -f .github/containers/rediscluster/docker-compose.yml down
 
   solr:
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -751,26 +751,6 @@ jobs:
       options: >-
         --add-host=host.docker.internal:host-gateway
     timeout-minutes: 30
-    services:
-      firestore:
-        # Image set here MUST be repeated down below in options. See comment below.
-        image: gcr.io/google.com/cloudsdktool/google-cloud-cli:437.0.1-emulators
-        ports:
-          - 8080:8080
-        # Set health checks to wait until container has started
-        options: >-
-          --health-cmd "echo success"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --health-start-period 5s
-          gcr.io/google.com/cloudsdktool/google-cloud-cli:437.0.1-emulators /bin/bash -c "gcloud emulators firestore start --host-port=0.0.0.0:8080" ||
-        # This is a very hacky solution. GitHub Actions doesn't provide APIs for setting commands on services, but allows adding arbitrary options.
-        # --entrypoint won't work as it only accepts an executable and not the [] syntax.
-        # Instead, we specify the image again the command afterwards like a call to docker create. The result is a few environment variables
-        # and the original command being appended to our hijacked docker create command. We can avoid any issues by adding || to prevent that
-        # from every being executed as bash commands.
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
@@ -783,6 +763,18 @@ jobs:
         run: |
           mkdir -p /github/home/.cache/pip
           chown -R "$(whoami)" /github/home/.cache/pip
+
+      - name: Start firestore
+        run: |
+          docker compose \
+            -f .github/containers/firestore/docker-compose.yml \
+            up -d \
+            --wait \
+            --wait-timeout 60 \
+            && exit 0
+          echo "firestore did not become healthy in time"
+          docker compose -f .github/containers/firestore/docker-compose.yml logs
+          exit 1
 
       - name: Get Environments
         id: get-envs
@@ -820,6 +812,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
+
+      - name: Stop firestore
+        if: always()
+        run: |
+          docker compose -f .github/containers/firestore/docker-compose.yml down
 
   grpc:
     env:


### PR DESCRIPTION
# Overview

Remove the need for all custom CI images published to docker hub by building them at runtime from within the CI container. 