### PR TITLE
feat(kafka): add MessageBroker/Kafka/Cluster/{id}/Produce/{topic} and Consume/{topic} metrics

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -3103,6 +3103,9 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "kafka.cluster", "newrelic.hooks.messagebroker_kafkapython", "instrument_kafka_cluster"
+    )
+    _process_module_definition(
         "kafka.consumer.group", "newrelic.hooks.messagebroker_kafkapython", "instrument_kafka_consumer_group"
     )
     _process_module_definition(

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -164,6 +164,10 @@ class GCRuntimeMetricsSettings(Settings):
     enabled = False
 
 
+class KafkaSettings(Settings):
+    cluster_metrics_enabled = False
+
+
 class MemoryRuntimeMetricsSettings(Settings):
     pass
 
@@ -660,6 +664,7 @@ _settings.event_harvest_config = EventHarvestConfigSettings()
 _settings.event_harvest_config.harvest_limits = EventHarvestConfigHarvestLimitSettings()
 _settings.event_loop_visibility = EventLoopVisibilitySettings()
 _settings.gc_runtime_metrics = GCRuntimeMetricsSettings()
+_settings.kafka = KafkaSettings()
 _settings.memory_runtime_pid_metrics = MemoryRuntimeMetricsSettings()
 _settings.heroku = HerokuSettings()
 _settings.infinite_tracing = InfiniteTracingSettings()
@@ -990,6 +995,8 @@ _settings.thread_profiler.enabled = True
 
 _settings.gc_runtime_metrics.enabled = _environ_as_bool("NEW_RELIC_GC_RUNTIME_METRICS_ENABLED", default=False)
 _settings.gc_runtime_metrics.top_object_count_limit = 5
+
+_settings.kafka.cluster_metrics_enabled = _environ_as_bool("NEW_RELIC_KAFKA_CLUSTER_METRICS_ENABLED", default=False)
 
 _settings.memory_runtime_pid_metrics.enabled = _environ_as_bool(
     "NEW_RELIC_MEMORY_RUNTIME_PID_METRICS_ENABLED", default=True

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import logging
 import sys
+import threading
+import weakref
 
 from newrelic.api.application import application_instance
 from newrelic.api.error_trace import wrap_error_trace
@@ -32,6 +34,57 @@ HEARTBEAT_FAIL = "MessageBroker/Kafka/Heartbeat/Fail"
 HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
+
+KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
+KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
+
+
+_nr_cluster_id_cache = {}
+_nr_cluster_id_cache_lock = threading.Lock()
+
+
+def _fetch_cluster_id(instance):
+    servers = getattr(instance, "_nr_bootstrap_servers", None)
+    # Sort so that equivalent broker sets with different orderings share the same key.
+    cache_key = ",".join(sorted(servers)) if servers else None
+
+    if cache_key:
+        with _nr_cluster_id_cache_lock:
+            cached = _nr_cluster_id_cache.get(cache_key)
+            if cached:
+                instance._nr_cluster_id = cached
+                return
+            if cached is not None:
+                return
+            _nr_cluster_id_cache[cache_key] = ""
+
+    # Hold only a weak reference so the thread closure does not extend the
+    # lifetime of a Producer/Consumer that the caller has already abandoned.
+    instance_ref = weakref.ref(instance)
+
+    def _run():
+        inst = instance_ref()
+        if inst is None:
+            # Instance was GC'd before the thread ran; clean up sentinel and exit.
+            if cache_key:
+                with _nr_cluster_id_cache_lock:
+                    _nr_cluster_id_cache.pop(cache_key, None)
+            return
+        try:
+            meta = inst.list_topics(timeout=5)
+            cluster_id = getattr(meta, "cluster_id", None)
+            if cluster_id:
+                inst._nr_cluster_id = cluster_id
+                if cache_key:
+                    with _nr_cluster_id_cache_lock:
+                        _nr_cluster_id_cache[cache_key] = cluster_id
+        except Exception as e:
+            _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
+            if cache_key:
+                with _nr_cluster_id_cache_lock:
+                    _nr_cluster_id_cache.pop(cache_key, None)
+
+    threading.Thread(target=_run, daemon=True, name="NR-Kafka-ClusterId").start()
 
 
 def wrap_Producer_produce(wrapped, instance, args, kwargs):
@@ -62,6 +115,17 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
     if hasattr(instance, "_nr_bootstrap_servers"):
         for server_name in instance._nr_bootstrap_servers:
             transaction.record_custom_metric(f"MessageBroker/Kafka/Nodes/{server_name}/Produce/{topic}", 1)
+
+    cluster_id = getattr(instance, "_nr_cluster_id", None)
+    if not cluster_id and hasattr(instance, "_nr_bootstrap_servers"):
+        _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
+        cluster_id = _nr_cluster_id_cache.get(_cache_key) or None
+        if cluster_id:
+            instance._nr_cluster_id = cluster_id  # cache on instance for future calls
+    if cluster_id:
+        transaction.record_custom_metric(
+            KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
+        )
 
     with MessageTrace(
         library="Kafka", operation="Produce", destination_type="Topic", destination_name=topic, source=wrapped
@@ -171,6 +235,16 @@ def wrap_Consumer_poll(wrapped, instance, args, kwargs):
                     transaction.record_custom_metric(
                         f"MessageBroker/Kafka/Nodes/{server_name}/Consume/{destination_name}", 1
                     )
+            cluster_id = getattr(instance, "_nr_cluster_id", None)
+            if not cluster_id and hasattr(instance, "_nr_bootstrap_servers"):
+                _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
+                cluster_id = _nr_cluster_id_cache.get(_cache_key) or None
+                if cluster_id:
+                    instance._nr_cluster_id = cluster_id
+            if cluster_id:
+                transaction.record_custom_metric(
+                    KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1
+                )
             transaction.add_messagebroker_info("Confluent-Kafka", get_package_version("confluent-kafka"))
 
     return record
@@ -213,6 +287,16 @@ def wrap_SerializingProducer_init(wrapped, instance, args, kwargs):
     if hasattr(instance, "_value_serializer") and callable(instance._value_serializer):
         instance._value_serializer = wrap_serializer("Serialization/Value", "MessageBroker")(instance._value_serializer)
 
+    try:
+        conf = kwargs.get("conf") or (args[0] if args else {})
+        servers = conf.get("bootstrap.servers") if isinstance(conf, dict) else None
+        if servers:
+            instance._nr_bootstrap_servers = servers.split(",")
+    except Exception:
+        pass
+
+    _fetch_cluster_id(instance)
+
 
 def wrap_DeserializingConsumer_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
@@ -222,6 +306,16 @@ def wrap_DeserializingConsumer_init(wrapped, instance, args, kwargs):
 
     if hasattr(instance, "_value_deserializer") and callable(instance._value_deserializer):
         instance._value_deserializer = wrap_serializer("Deserialization/Value", "Message")(instance._value_deserializer)
+
+    try:
+        conf = kwargs.get("conf") or (args[0] if args else {})
+        servers = conf.get("bootstrap.servers") if isinstance(conf, dict) else None
+        if servers:
+            instance._nr_bootstrap_servers = servers.split(",")
+    except Exception:
+        pass
+
+    _fetch_cluster_id(instance)
 
 
 def wrap_Producer_init(wrapped, instance, args, kwargs):
@@ -236,6 +330,8 @@ def wrap_Producer_init(wrapped, instance, args, kwargs):
     except Exception:
         pass
 
+    _fetch_cluster_id(instance)
+
 
 def wrap_Consumer_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
@@ -248,6 +344,8 @@ def wrap_Consumer_init(wrapped, instance, args, kwargs):
             instance._nr_bootstrap_servers = servers.split(",")
     except Exception:
         pass
+
+    _fetch_cluster_id(instance)
 
 
 def wrap_immutable_class(module, class_name):

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -14,6 +14,7 @@
 import logging
 import sys
 import threading
+import time
 import weakref
 
 from newrelic.api.application import application_instance
@@ -39,6 +40,8 @@ KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produc
 KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
 
 
+_CLUSTER_ID_TTL_SECONDS = 60 * 60
+
 _nr_cluster_id_cache = {}
 _nr_cluster_id_cache_lock = threading.Lock()
 
@@ -51,10 +54,15 @@ def _fetch_cluster_id(instance):
     if cache_key:
         with _nr_cluster_id_cache_lock:
             cached = _nr_cluster_id_cache.get(cache_key)
-            if cached:
-                instance._nr_cluster_id = cached
-                return
-            if cached is not None:
+            if isinstance(cached, tuple):
+                cluster_id, ts = cached
+                if time.monotonic() - ts <= _CLUSTER_ID_TTL_SECONDS:
+                    instance._nr_cluster_id = cluster_id
+                    instance._nr_cluster_id_fetched_at = ts
+                    return
+                # Expired — fall through to start a new fetch.
+            elif cached is not None:
+                # "" sentinel — fetch already in progress.
                 return
             _nr_cluster_id_cache[cache_key] = ""
 
@@ -74,11 +82,13 @@ def _fetch_cluster_id(instance):
             meta = inst.list_topics(timeout=5)
             cluster_id = getattr(meta, "cluster_id", None)
             if cluster_id:
+                now = time.monotonic()
                 inst._nr_cluster_id = cluster_id
+                inst._nr_cluster_id_fetched_at = now
                 if cache_key:
                     with _nr_cluster_id_cache_lock:
-                        _nr_cluster_id_cache[cache_key] = cluster_id
-        except Exception as e:
+                        _nr_cluster_id_cache[cache_key] = (cluster_id, now)
+        except Exception:
             _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
             if cache_key:
                 with _nr_cluster_id_cache_lock:
@@ -117,11 +127,18 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
             transaction.record_custom_metric(f"MessageBroker/Kafka/Nodes/{server_name}/Produce/{topic}", 1)
 
     cluster_id = getattr(instance, "_nr_cluster_id", None)
-    if not cluster_id and hasattr(instance, "_nr_bootstrap_servers"):
+    if cluster_id:
+        if time.monotonic() - getattr(instance, "_nr_cluster_id_fetched_at", 0.0) > _CLUSTER_ID_TTL_SECONDS:
+            _fetch_cluster_id(instance)  # background re-fetch; use stale value below
+    elif hasattr(instance, "_nr_bootstrap_servers"):
         _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
-        cluster_id = _nr_cluster_id_cache.get(_cache_key) or None
-        if cluster_id:
-            instance._nr_cluster_id = cluster_id  # cache on instance for future calls
+        _cached = _nr_cluster_id_cache.get(_cache_key)
+        if isinstance(_cached, tuple):
+            cluster_id, _ts = _cached
+            instance._nr_cluster_id = cluster_id
+            instance._nr_cluster_id_fetched_at = _ts
+            if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
+                _fetch_cluster_id(instance)  # background re-fetch
     if cluster_id:
         transaction.record_custom_metric(
             KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
@@ -236,11 +253,18 @@ def wrap_Consumer_poll(wrapped, instance, args, kwargs):
                         f"MessageBroker/Kafka/Nodes/{server_name}/Consume/{destination_name}", 1
                     )
             cluster_id = getattr(instance, "_nr_cluster_id", None)
-            if not cluster_id and hasattr(instance, "_nr_bootstrap_servers"):
+            if cluster_id:
+                if time.monotonic() - getattr(instance, "_nr_cluster_id_fetched_at", 0.0) > _CLUSTER_ID_TTL_SECONDS:
+                    _fetch_cluster_id(instance)  # background re-fetch; use stale value below
+            elif hasattr(instance, "_nr_bootstrap_servers"):
                 _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
-                cluster_id = _nr_cluster_id_cache.get(_cache_key) or None
-                if cluster_id:
+                _cached = _nr_cluster_id_cache.get(_cache_key)
+                if isinstance(_cached, tuple):
+                    cluster_id, _ts = _cached
                     instance._nr_cluster_id = cluster_id
+                    instance._nr_cluster_id_fetched_at = _ts
+                    if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
+                        _fetch_cluster_id(instance)  # background re-fetch
             if cluster_id:
                 transaction.record_custom_metric(
                     KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -26,6 +26,7 @@ from newrelic.api.time_trace import notice_error
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import function_wrapper, wrap_function_wrapper
 from newrelic.common.package_version_utils import get_package_version
+from newrelic.core.config import global_settings
 
 _logger = logging.getLogger(__name__)
 
@@ -47,6 +48,9 @@ _nr_cluster_id_cache_lock = threading.Lock()
 
 
 def _fetch_cluster_id(instance):
+    settings = global_settings()
+    if not getattr(getattr(settings, "kafka", None), "cluster_metrics_enabled", False):
+        return
     servers = getattr(instance, "_nr_bootstrap_servers", None)
     # Sort so that equivalent broker sets with different orderings share the same key.
     cache_key = ",".join(sorted(servers)) if servers else None

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 import logging
 import sys
-import threading
-import time
-import weakref
 
 from newrelic.api.application import application_instance
 from newrelic.api.error_trace import wrap_error_trace
@@ -41,64 +38,52 @@ KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produc
 KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
 
 
-_CLUSTER_ID_TTL_SECONDS = 60 * 60
+# Populated only by Producers (see _resolve_producer_cluster_id) and read by
+# Consumers on the same broker set (see _resolve_consumer_cluster_id). No TTL:
+# a cluster id is a stable identifier for the lifetime of a broker cluster, and
+# a new Producer/Consumer naturally refreshes it on its own first call.
+_nr_cluster_id_by_bootstrap = {}
 
-_nr_cluster_id_cache = {}
-_nr_cluster_id_cache_lock = threading.Lock()
 
-
-def _fetch_cluster_id(instance):
+def _cluster_metrics_enabled():
     settings = global_settings()
-    if not getattr(getattr(settings, "kafka", None), "cluster_metrics_enabled", False):
-        return
-    servers = getattr(instance, "_nr_bootstrap_servers", None)
+    return bool(getattr(getattr(settings, "kafka", None), "cluster_metrics_enabled", False))
+
+
+def _bootstrap_key(instance):
     # Sort so that equivalent broker sets with different orderings share the same key.
-    cache_key = ",".join(sorted(servers)) if servers else None
+    servers = getattr(instance, "_nr_bootstrap_servers", None)
+    return ",".join(sorted(servers)) if servers else None
 
-    if cache_key:
-        with _nr_cluster_id_cache_lock:
-            cached = _nr_cluster_id_cache.get(cache_key)
-            if isinstance(cached, tuple):
-                cluster_id, ts = cached
-                if time.monotonic() - ts <= _CLUSTER_ID_TTL_SECONDS:
-                    instance._nr_cluster_id = cluster_id
-                    instance._nr_cluster_id_fetched_at = ts
-                    return
-                # Expired — fall through to start a new fetch.
-            elif cached is not None:
-                # "" sentinel — fetch already in progress.
-                return
-            _nr_cluster_id_cache[cache_key] = ""
 
-    # Hold only a weak reference so the thread closure does not extend the
-    # lifetime of a Producer/Consumer that the caller has already abandoned.
-    instance_ref = weakref.ref(instance)
+def _resolve_producer_cluster_id(instance):
+    # timeout=0 returns whatever metadata librdkafka already has cached for this
+    # already-connected client (or nothing) without blocking — no separate
+    # AdminClient connection, no network round trip on our part.
+    if not _cluster_metrics_enabled():
+        return None
+    try:
+        meta = instance.list_topics(timeout=0)
+        cluster_id = getattr(meta, "cluster_id", None)
+    except Exception:
+        _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
+        cluster_id = None
+    if cluster_id:
+        key = _bootstrap_key(instance)
+        if key:
+            _nr_cluster_id_by_bootstrap[key] = cluster_id
+    return cluster_id
 
-    def _run():
-        inst = instance_ref()
-        if inst is None:
-            # Instance was GC'd before the thread ran; clean up sentinel and exit.
-            if cache_key:
-                with _nr_cluster_id_cache_lock:
-                    _nr_cluster_id_cache.pop(cache_key, None)
-            return
-        try:
-            meta = inst.list_topics(timeout=5)
-            cluster_id = getattr(meta, "cluster_id", None)
-            if cluster_id:
-                now = time.monotonic()
-                inst._nr_cluster_id = cluster_id
-                inst._nr_cluster_id_fetched_at = now
-                if cache_key:
-                    with _nr_cluster_id_cache_lock:
-                        _nr_cluster_id_cache[cache_key] = (cluster_id, now)
-        except Exception:
-            _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
-            if cache_key:
-                with _nr_cluster_id_cache_lock:
-                    _nr_cluster_id_cache.pop(cache_key, None)
 
-    threading.Thread(target=_run, daemon=True, name="NR-Kafka-ClusterId").start()
+def _resolve_consumer_cluster_id(instance):
+    # Consumers deliberately never call list_topics() themselves: librdkafka has
+    # a known use-after-free (rdkafka#4214) when topic metadata is fetched on a
+    # Consumer while a partition rebalance is in progress. Instead, read a value
+    # a Producer on the same bootstrap-servers has already resolved.
+    if not _cluster_metrics_enabled():
+        return None
+    key = _bootstrap_key(instance)
+    return _nr_cluster_id_by_bootstrap.get(key) if key else None
 
 
 def wrap_Producer_produce(wrapped, instance, args, kwargs):
@@ -130,19 +115,7 @@ def wrap_Producer_produce(wrapped, instance, args, kwargs):
         for server_name in instance._nr_bootstrap_servers:
             transaction.record_custom_metric(f"MessageBroker/Kafka/Nodes/{server_name}/Produce/{topic}", 1)
 
-    cluster_id = getattr(instance, "_nr_cluster_id", None)
-    if cluster_id:
-        if time.monotonic() - getattr(instance, "_nr_cluster_id_fetched_at", 0.0) > _CLUSTER_ID_TTL_SECONDS:
-            _fetch_cluster_id(instance)  # background re-fetch; use stale value below
-    elif hasattr(instance, "_nr_bootstrap_servers"):
-        _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
-        _cached = _nr_cluster_id_cache.get(_cache_key)
-        if isinstance(_cached, tuple):
-            cluster_id, _ts = _cached
-            instance._nr_cluster_id = cluster_id
-            instance._nr_cluster_id_fetched_at = _ts
-            if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
-                _fetch_cluster_id(instance)  # background re-fetch
+    cluster_id = _resolve_producer_cluster_id(instance)
     if cluster_id:
         transaction.record_custom_metric(
             KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
@@ -256,19 +229,7 @@ def wrap_Consumer_poll(wrapped, instance, args, kwargs):
                     transaction.record_custom_metric(
                         f"MessageBroker/Kafka/Nodes/{server_name}/Consume/{destination_name}", 1
                     )
-            cluster_id = getattr(instance, "_nr_cluster_id", None)
-            if cluster_id:
-                if time.monotonic() - getattr(instance, "_nr_cluster_id_fetched_at", 0.0) > _CLUSTER_ID_TTL_SECONDS:
-                    _fetch_cluster_id(instance)  # background re-fetch; use stale value below
-            elif hasattr(instance, "_nr_bootstrap_servers"):
-                _cache_key = ",".join(sorted(instance._nr_bootstrap_servers))
-                _cached = _nr_cluster_id_cache.get(_cache_key)
-                if isinstance(_cached, tuple):
-                    cluster_id, _ts = _cached
-                    instance._nr_cluster_id = cluster_id
-                    instance._nr_cluster_id_fetched_at = _ts
-                    if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
-                        _fetch_cluster_id(instance)  # background re-fetch
+            cluster_id = _resolve_consumer_cluster_id(instance)
             if cluster_id:
                 transaction.record_custom_metric(
                     KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1
@@ -323,8 +284,6 @@ def wrap_SerializingProducer_init(wrapped, instance, args, kwargs):
     except Exception:
         pass
 
-    _fetch_cluster_id(instance)
-
 
 def wrap_DeserializingConsumer_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
@@ -343,8 +302,6 @@ def wrap_DeserializingConsumer_init(wrapped, instance, args, kwargs):
     except Exception:
         pass
 
-    _fetch_cluster_id(instance)
-
 
 def wrap_Producer_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
@@ -358,8 +315,6 @@ def wrap_Producer_init(wrapped, instance, args, kwargs):
     except Exception:
         pass
 
-    _fetch_cluster_id(instance)
-
 
 def wrap_Consumer_init(wrapped, instance, args, kwargs):
     wrapped(*args, **kwargs)
@@ -372,8 +327,6 @@ def wrap_Consumer_init(wrapped, instance, args, kwargs):
             instance._nr_bootstrap_servers = servers.split(",")
     except Exception:
         pass
-
-    _fetch_cluster_id(instance)
 
 
 def wrap_immutable_class(module, class_name):

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import sys
+import threading
 
 from newrelic.api.application import application_instance
 from newrelic.api.error_trace import wrap_error_trace
@@ -44,6 +45,11 @@ KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consum
 # a new Producer/Consumer naturally refreshes it on its own first call.
 _nr_cluster_id_by_bootstrap = {}
 
+# Bootstrap-key (or, lacking one, instance id) for producers with a resolution
+# thread currently running, so concurrent produce() calls don't each spawn one.
+_nr_cluster_id_resolution_in_flight = set()
+_nr_cluster_id_resolution_lock = threading.Lock()
+
 
 def _cluster_metrics_enabled():
     settings = global_settings()
@@ -51,28 +57,57 @@ def _cluster_metrics_enabled():
 
 
 def _bootstrap_key(instance):
-    # Sort so that equivalent broker sets with different orderings share the same key.
+    # Sort so that equivalent broker sets with different orderings share the same key;
+    # strip whitespace so "a:9092, b:9092" and "a:9092,b:9092" also share it.
     servers = getattr(instance, "_nr_bootstrap_servers", None)
-    return ",".join(sorted(servers)) if servers else None
+    return ",".join(sorted(server.strip() for server in servers)) if servers else None
 
 
 def _resolve_producer_cluster_id(instance):
-    # timeout=0 returns whatever metadata librdkafka already has cached for this
-    # already-connected client (or nothing) without blocking — no separate
-    # AdminClient connection, no network round trip on our part.
+    # Resolved at most once per producer instance: the cluster id is stable for
+    # the producer's lifetime. list_topics() genuinely blocks (it waits for
+    # librdkafka's metadata refresh), so resolution runs on a background daemon
+    # thread rather than the calling produce() thread — otherwise every produce()
+    # call would re-block for the full timeout for as long as resolution keeps
+    # failing (e.g. during a broker outage), which is worst exactly when fast
+    # failure matters most.
     if not _cluster_metrics_enabled():
         return None
-    try:
-        meta = instance.list_topics(timeout=0)
-        cluster_id = getattr(meta, "cluster_id", None)
-    except Exception:
-        _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
-        cluster_id = None
+    cluster_id = getattr(instance, "_nr_cluster_id", None)
     if cluster_id:
-        key = _bootstrap_key(instance)
-        if key:
-            _nr_cluster_id_by_bootstrap[key] = cluster_id
-    return cluster_id
+        return cluster_id
+    key = _bootstrap_key(instance)
+    if key:
+        cluster_id = _nr_cluster_id_by_bootstrap.get(key)
+        if cluster_id:
+            instance._nr_cluster_id = cluster_id
+            return cluster_id
+    _schedule_cluster_id_resolution(instance, key)
+    return None
+
+
+def _schedule_cluster_id_resolution(instance, key):
+    guard_key = key if key else id(instance)
+    with _nr_cluster_id_resolution_lock:
+        if guard_key in _nr_cluster_id_resolution_in_flight:
+            return
+        _nr_cluster_id_resolution_in_flight.add(guard_key)
+
+    def _resolve():
+        try:
+            meta = instance.list_topics(timeout=5)
+            cluster_id = getattr(meta, "cluster_id", None)
+        except Exception:
+            _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
+            cluster_id = None
+        if cluster_id:
+            instance._nr_cluster_id = cluster_id
+            if key:
+                _nr_cluster_id_by_bootstrap[key] = cluster_id
+        with _nr_cluster_id_resolution_lock:
+            _nr_cluster_id_resolution_in_flight.discard(guard_key)
+
+    threading.Thread(target=_resolve, daemon=True).start()
 
 
 def _resolve_consumer_cluster_id(instance):

--- a/newrelic/hooks/messagebroker_confluentkafka.py
+++ b/newrelic/hooks/messagebroker_confluentkafka.py
@@ -35,8 +35,8 @@ HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 
-KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
-KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
+KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Produce/{1}"
+KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Consume/{1}"
 
 
 # Populated only by Producers (see _resolve_producer_cluster_id) and read by

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import sys
+import threading
 
 from kafka.serializer import Serializer
 
@@ -30,6 +32,20 @@ HEARTBEAT_FAIL = "MessageBroker/Kafka/Heartbeat/Fail"
 HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
+
+KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
+KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
+
+_kafka_cluster_id_cache = {}
+_nr_cluster_id_cache_lock = threading.Lock()
+_logger = logging.getLogger(__name__)
+
+
+def _bootstrap_cache_key(bootstrap_servers):
+    """Normalize bootstrap_servers (str or iterable) to the cluster-ID cache key."""
+    if isinstance(bootstrap_servers, str):
+        bootstrap_servers = [bootstrap_servers]
+    return ",".join(sorted(str(s) for s in bootstrap_servers))
 
 
 def _bind_send(topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
@@ -66,6 +82,17 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
         if hasattr(instance, "config"):
             for server_name in instance.config.get("bootstrap_servers", []):
                 transaction.record_custom_metric(f"MessageBroker/Kafka/Nodes/{server_name}/Produce/{topic}", 1)
+
+        servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
+        cluster_id = None
+        if servers:
+            _cache_key = _bootstrap_cache_key(servers)
+            cluster_id = _kafka_cluster_id_cache.get(_cache_key) or None
+        if cluster_id:
+            transaction.record_custom_metric(
+                KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
+            )
+
         try:
             return wrapped(
                 topic, value=value, key=key, headers=dt_headers, partition=partition, timestamp_ms=timestamp_ms
@@ -82,39 +109,14 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
     try:
         record = wrapped(*args, **kwargs)
     except Exception as e:
-        # StopIteration is an expected error, indicating the end of an iterable,
-        # that should not be captured.
         if not isinstance(e, StopIteration):
             if current_transaction():
-                # Report error on existing transaction if there is one
                 notice_error()
             else:
-                # Report error on application
                 notice_error(application=application_instance(activate=False))
         raise
 
     if record:
-        # This iterator can be called either outside of a transaction, or
-        # within the context of an existing transaction.  There are 3
-        # possibilities we need to handle: (Note that this is similar to
-        # our Pika and Celery instrumentation)
-        #
-        #   1. In an inactive transaction
-        #
-        #      If the end_of_transaction() or ignore_transaction() API
-        #      calls have been invoked, this iterator may be called in the
-        #      context of an inactive transaction. In this case, don't wrap
-        #      the iterator in any way. Just run the original iterator.
-        #
-        #   2. In an active transaction
-        #
-        #      Do nothing.
-        #
-        #   3. Outside of a transaction
-        #
-        #      Since it's not running inside of an existing transaction, we
-        #      want to create a new background transaction for it.
-
         library = "Kafka"
         destination_type = "Topic"
         destination_name = record.topic
@@ -137,7 +139,6 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             instance._nr_transaction = transaction
             transaction.__enter__()
 
-            # Obtain consumer client_id to send up as agent attribute
             if hasattr(instance, "config") and "client_id" in instance.config:
                 client_id = instance.config["client_id"]
                 transaction._add_agent_attribute("kafka.consume.client_id", client_id)
@@ -145,11 +146,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             transaction._add_agent_attribute("kafka.consume.byteCount", received_bytes)
 
         transaction = current_transaction()
-        if transaction:  # If there is an active transaction now.
-            # Add metrics whether or not a transaction was already active, or one was just started.
-            # Don't add metrics if there was an inactive transaction.
-            # Name the metrics using the same format as the transaction, but in case the active transaction
-            # was an existing one and not a message transaction, reproduce the naming logic here.
+        if transaction:
             group = f"Message/{library}/{destination_type}"
             name = f"Named/{destination_name}"
             transaction.record_custom_metric(f"{group}/{name}/Received/Bytes", received_bytes)
@@ -159,11 +156,84 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
                     transaction.record_custom_metric(
                         f"MessageBroker/Kafka/Nodes/{server_name}/Consume/{destination_name}", 1
                     )
+
+            servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
+            cluster_id = None
+            if servers:
+                _cache_key = _bootstrap_cache_key(servers)
+                cached = _kafka_cluster_id_cache.get(_cache_key)
+                cluster_id = cached if cached else None
+            if cluster_id:
+                transaction.record_custom_metric(
+                    KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1
+                )
             transaction.add_messagebroker_info(
                 "Kafka-Python", get_package_version("kafka-python") or get_package_version("kafka-python-ng")
             )
 
     return record
+
+
+_SECURITY_CONFIG_KEYS = (
+    "security_protocol", "ssl_context", "ssl_cafile", "ssl_certfile",
+    "ssl_keyfile", "ssl_password", "ssl_crlfile", "ssl_ciphers",
+    "sasl_mechanism", "sasl_plain_username", "sasl_plain_password",
+    "sasl_kerberos_service_name", "sasl_kerberos_domain_name",
+    "sasl_oauth_token_provider",
+)
+
+
+def _fetch_cluster_id_kafka_python(bootstrap_servers, instance_config=None):
+    cache_key = _bootstrap_cache_key(bootstrap_servers)
+    with _nr_cluster_id_cache_lock:
+        if _kafka_cluster_id_cache.get(cache_key) is not None:
+            return
+        _kafka_cluster_id_cache[cache_key] = ""  # sentinel to prevent duplicate fetches
+
+    try:
+        from kafka.admin import KafkaAdminClient as _KafkaAdminClient
+        if not hasattr(_KafkaAdminClient, "describe_cluster"):
+            return
+    except ImportError:
+        return
+
+    def _run():
+        admin = None
+        cluster_id = None
+        try:
+            from kafka.admin import KafkaAdminClient
+            extra = {k: instance_config[k] for k in _SECURITY_CONFIG_KEYS if instance_config and k in instance_config and instance_config[k] is not None}
+            admin = KafkaAdminClient(
+                bootstrap_servers=bootstrap_servers,
+                client_id="newrelic-cluster-id-probe",
+                api_version_auto_timeout_ms=5000,
+                **extra,
+            )
+            meta = admin._client.cluster
+            admin._client.poll(timeout_ms=3000)
+            try:
+                result = admin.describe_cluster()
+                cluster_id = getattr(result, "cluster_id", None) or getattr(result, "clusterId", None)
+            except Exception:
+                _logger.debug("NR Kafka describe_cluster failed", exc_info=True)
+            if not cluster_id:
+                cluster_id = getattr(meta, "cluster_id", None) or getattr(meta, "_cluster_id", None)
+        except Exception:
+            _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
+        finally:
+            try:
+                if admin is not None:
+                    admin.close()
+            except Exception:
+                pass
+        if cluster_id:
+            with _nr_cluster_id_cache_lock:
+                _kafka_cluster_id_cache[cache_key] = cluster_id
+        else:
+            with _nr_cluster_id_cache_lock:
+                _kafka_cluster_id_cache.pop(cache_key, None)
+
+    threading.Thread(target=_run, daemon=True, name="NR-KafkaPython-ClusterId").start()
 
 
 def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
@@ -176,7 +246,13 @@ def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
         instance, "Serialization/Value", "MessageBroker", get_config_key("value_serializer")
     )
 
-    return wrapped(*args, **kwargs)
+    result = wrapped(*args, **kwargs)
+
+    servers = instance.config.get("bootstrap_servers", [])
+    if servers:
+        _fetch_cluster_id_kafka_python(servers, instance.config)
+
+    return result
 
 
 class NewRelicSerializerWrapper(ObjectProxy):
@@ -211,7 +287,6 @@ def wrap_serializer(client, serializer_name, group_prefix, serializer):
         if isinstance(transaction, MessageTransaction):
             topic = transaction.destination_name
         else:
-            # Find parent message trace to retrieve topic
             message_trace = current_trace()
             while message_trace is not None and not isinstance(message_trace, MessageTrace):
                 message_trace = message_trace.parent
@@ -224,17 +299,14 @@ def wrap_serializer(client, serializer_name, group_prefix, serializer):
         return FunctionTraceWrapper(wrapped, name=name, group=group)(*args, **kwargs)
 
     try:
-        # Apply wrapper to serializer
         if serializer is None:
-            # Do nothing
             return serializer
         elif isinstance(serializer, Serializer):
             return NewRelicSerializerWrapper(serializer, group_prefix=group_prefix, serializer_name=serializer_name)
         else:
-            # Wrap callable in wrapper
             return _wrap_serializer(serializer)
     except Exception:
-        return serializer  # Avoid crashes from immutable serializers
+        return serializer
 
 
 def metric_wrapper(metric_name, check_result=False):
@@ -244,8 +316,6 @@ def metric_wrapper(metric_name, check_result=False):
         application = application_instance(activate=False)
         if application:
             if not check_result or (check_result and result):
-                # If the result does not need validated, send metric.
-                # If the result does need validated, ensure it is True.
                 application.record_custom_metric(metric_name, 1)
 
         return result
@@ -259,8 +329,17 @@ def instrument_kafka_producer(module):
         wrap_function_wrapper(module, "KafkaProducer.send", wrap_KafkaProducer_send)
 
 
+def _wrap_KafkaConsumer_init(wrapped, instance, args, kwargs):
+    result = wrapped(*args, **kwargs)
+    servers = instance.config.get("bootstrap_servers", [])
+    if servers:
+        _fetch_cluster_id_kafka_python(servers, instance.config)
+    return result
+
+
 def instrument_kafka_consumer_group(module):
     if hasattr(module, "KafkaConsumer"):
+        wrap_function_wrapper(module, "KafkaConsumer.__init__", _wrap_KafkaConsumer_init)
         wrap_function_wrapper(module, "KafkaConsumer.__next__", wrap_kafkaconsumer_next)
 
 

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -14,6 +14,7 @@
 import logging
 import sys
 import threading
+import time
 
 from kafka.serializer import Serializer
 
@@ -36,6 +37,8 @@ HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
 KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
 
+_CLUSTER_ID_TTL_SECONDS = 60 * 60
+
 _kafka_cluster_id_cache = {}
 _nr_cluster_id_cache_lock = threading.Lock()
 _logger = logging.getLogger(__name__)
@@ -56,6 +59,20 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
     transaction = current_transaction()
 
     if transaction is None:
+        topic, *_ = _bind_send(*args, **kwargs)
+        topic = topic or "Default"
+        servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
+        if servers:
+            _cache_key = _bootstrap_cache_key(servers)
+            _cached = _kafka_cluster_id_cache.get(_cache_key)
+            if isinstance(_cached, tuple):
+                cluster_id, _ts = _cached
+                if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
+                    _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
+                if cluster_id:
+                    app = application_instance(activate=False)
+                    if app:
+                        app.record_custom_metric(KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1)
         return wrapped(*args, **kwargs)
 
     topic, value, key, headers, partition, timestamp_ms = _bind_send(*args, **kwargs)
@@ -87,7 +104,11 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
         cluster_id = None
         if servers:
             _cache_key = _bootstrap_cache_key(servers)
-            cluster_id = _kafka_cluster_id_cache.get(_cache_key) or None
+            _cached = _kafka_cluster_id_cache.get(_cache_key)
+            if isinstance(_cached, tuple):
+                cluster_id, _ts = _cached
+                if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
+                    _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
         if cluster_id:
             transaction.record_custom_metric(
                 KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
@@ -109,6 +130,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
     try:
         record = wrapped(*args, **kwargs)
     except Exception as e:
+        # StopIteration ends iteration normally — do not capture.
         if not isinstance(e, StopIteration):
             if current_transaction():
                 notice_error()
@@ -161,8 +183,11 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             cluster_id = None
             if servers:
                 _cache_key = _bootstrap_cache_key(servers)
-                cached = _kafka_cluster_id_cache.get(_cache_key)
-                cluster_id = cached if cached else None
+                _cached = _kafka_cluster_id_cache.get(_cache_key)
+                if isinstance(_cached, tuple):
+                    cluster_id, _ts = _cached
+                    if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
+                        _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
             if cluster_id:
                 transaction.record_custom_metric(
                     KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1
@@ -186,8 +211,13 @@ _SECURITY_CONFIG_KEYS = (
 def _fetch_cluster_id_kafka_python(bootstrap_servers, instance_config=None):
     cache_key = _bootstrap_cache_key(bootstrap_servers)
     with _nr_cluster_id_cache_lock:
-        if _kafka_cluster_id_cache.get(cache_key) is not None:
-            return
+        cached = _kafka_cluster_id_cache.get(cache_key)
+        if isinstance(cached, tuple):
+            if time.monotonic() - cached[1] <= _CLUSTER_ID_TTL_SECONDS:
+                return  # still fresh
+            # Expired — fall through to start a new fetch.
+        elif cached is not None:
+            return  # "" sentinel — fetch already in progress.
         _kafka_cluster_id_cache[cache_key] = ""  # sentinel to prevent duplicate fetches
 
     try:
@@ -213,7 +243,10 @@ def _fetch_cluster_id_kafka_python(bootstrap_servers, instance_config=None):
             admin._client.poll(timeout_ms=3000)
             try:
                 result = admin.describe_cluster()
-                cluster_id = getattr(result, "cluster_id", None) or getattr(result, "clusterId", None)
+                if isinstance(result, dict):
+                    cluster_id = result.get("cluster_id") or result.get("clusterId")
+                else:
+                    cluster_id = getattr(result, "cluster_id", None) or getattr(result, "clusterId", None)
             except Exception:
                 _logger.debug("NR Kafka describe_cluster failed", exc_info=True)
             if not cluster_id:
@@ -228,7 +261,7 @@ def _fetch_cluster_id_kafka_python(bootstrap_servers, instance_config=None):
                 pass
         if cluster_id:
             with _nr_cluster_id_cache_lock:
-                _kafka_cluster_id_cache[cache_key] = cluster_id
+                _kafka_cluster_id_cache[cache_key] = (cluster_id, time.monotonic())
         else:
             with _nr_cluster_id_cache_lock:
                 _kafka_cluster_id_cache.pop(cache_key, None)

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -33,8 +33,8 @@ HEARTBEAT_RECEIVE = "MessageBroker/Kafka/Heartbeat/Receive"
 HEARTBEAT_SESSION_TIMEOUT = "MessageBroker/Kafka/Heartbeat/SessionTimeout"
 HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 
-KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
-KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
+KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Produce/{1}"
+KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Consume/{1}"
 
 _logger = logging.getLogger(__name__)
 

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 import logging
 import sys
-import threading
-import time
 
 from kafka.serializer import Serializer
 
@@ -26,6 +24,7 @@ from newrelic.api.time_trace import current_trace, notice_error
 from newrelic.api.transaction import current_transaction
 from newrelic.common.object_wrapper import ObjectProxy, function_wrapper, wrap_function_wrapper
 from newrelic.common.package_version_utils import get_package_version
+from newrelic.core.config import global_settings
 
 HEARTBEAT_POLL = "MessageBroker/Kafka/Heartbeat/Poll"
 HEARTBEAT_SENT = "MessageBroker/Kafka/Heartbeat/Sent"
@@ -37,18 +36,27 @@ HEARTBEAT_POLL_TIMEOUT = "MessageBroker/Kafka/Heartbeat/PollTimeout"
 KAFKA_CLUSTER_METRIC_PRODUCE = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Produce"
 KAFKA_CLUSTER_METRIC_CONSUME = "MessageBroker/Kafka/Cluster/{0}/Topic/{1}/Consume"
 
-_CLUSTER_ID_TTL_SECONDS = 60 * 60
-
-_kafka_cluster_id_cache = {}
-_nr_cluster_id_cache_lock = threading.Lock()
 _logger = logging.getLogger(__name__)
 
 
-def _bootstrap_cache_key(bootstrap_servers):
-    """Normalize bootstrap_servers (str or iterable) to the cluster-ID cache key."""
-    if isinstance(bootstrap_servers, str):
-        bootstrap_servers = [bootstrap_servers]
-    return ",".join(sorted(str(s) for s in bootstrap_servers))
+def _cluster_metrics_enabled():
+    settings = global_settings()
+    return bool(getattr(getattr(settings, "kafka", None), "cluster_metrics_enabled", False))
+
+
+def _read_cluster_id(instance):
+    # kafka-python's own ClusterMetadata already tracks the cluster id as a
+    # passive side effect of the client's normal bootstrap/refresh traffic —
+    # this is a synchronous, in-memory attribute read, no admin client, no
+    # extra connection. KafkaProducer and KafkaConsumer expose it via
+    # different attribute paths.
+    if not _cluster_metrics_enabled():
+        return None
+    metadata = getattr(instance, "_metadata", None)  # KafkaProducer
+    if metadata is None:
+        client = getattr(instance, "_client", None)  # KafkaConsumer
+        metadata = getattr(client, "cluster", None) if client else None
+    return getattr(metadata, "cluster_id", None) if metadata else None
 
 
 def _bind_send(topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
@@ -61,18 +69,11 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
     if transaction is None:
         topic, *_ = _bind_send(*args, **kwargs)
         topic = topic or "Default"
-        servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
-        if servers:
-            _cache_key = _bootstrap_cache_key(servers)
-            _cached = _kafka_cluster_id_cache.get(_cache_key)
-            if isinstance(_cached, tuple):
-                cluster_id, _ts = _cached
-                if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
-                    _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
-                if cluster_id:
-                    app = application_instance(activate=False)
-                    if app:
-                        app.record_custom_metric(KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1)
+        cluster_id = _read_cluster_id(instance)
+        if cluster_id:
+            app = application_instance(activate=False)
+            if app:
+                app.record_custom_metric(KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1)
         return wrapped(*args, **kwargs)
 
     topic, value, key, headers, partition, timestamp_ms = _bind_send(*args, **kwargs)
@@ -100,15 +101,7 @@ def wrap_KafkaProducer_send(wrapped, instance, args, kwargs):
             for server_name in instance.config.get("bootstrap_servers", []):
                 transaction.record_custom_metric(f"MessageBroker/Kafka/Nodes/{server_name}/Produce/{topic}", 1)
 
-        servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
-        cluster_id = None
-        if servers:
-            _cache_key = _bootstrap_cache_key(servers)
-            _cached = _kafka_cluster_id_cache.get(_cache_key)
-            if isinstance(_cached, tuple):
-                cluster_id, _ts = _cached
-                if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
-                    _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
+        cluster_id = _read_cluster_id(instance)
         if cluster_id:
             transaction.record_custom_metric(
                 KAFKA_CLUSTER_METRIC_PRODUCE.format(cluster_id, topic), 1
@@ -179,15 +172,7 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
                         f"MessageBroker/Kafka/Nodes/{server_name}/Consume/{destination_name}", 1
                     )
 
-            servers = instance.config.get("bootstrap_servers", []) if hasattr(instance, "config") else []
-            cluster_id = None
-            if servers:
-                _cache_key = _bootstrap_cache_key(servers)
-                _cached = _kafka_cluster_id_cache.get(_cache_key)
-                if isinstance(_cached, tuple):
-                    cluster_id, _ts = _cached
-                    if time.monotonic() - _ts > _CLUSTER_ID_TTL_SECONDS:
-                        _fetch_cluster_id_kafka_python(servers, instance.config if hasattr(instance, "config") else None)
+            cluster_id = _read_cluster_id(instance)
             if cluster_id:
                 transaction.record_custom_metric(
                     KAFKA_CLUSTER_METRIC_CONSUME.format(cluster_id, destination_name), 1
@@ -197,76 +182,6 @@ def wrap_kafkaconsumer_next(wrapped, instance, args, kwargs):
             )
 
     return record
-
-
-_SECURITY_CONFIG_KEYS = (
-    "security_protocol", "ssl_context", "ssl_cafile", "ssl_certfile",
-    "ssl_keyfile", "ssl_password", "ssl_crlfile", "ssl_ciphers",
-    "sasl_mechanism", "sasl_plain_username", "sasl_plain_password",
-    "sasl_kerberos_service_name", "sasl_kerberos_domain_name",
-    "sasl_oauth_token_provider",
-)
-
-
-def _fetch_cluster_id_kafka_python(bootstrap_servers, instance_config=None):
-    cache_key = _bootstrap_cache_key(bootstrap_servers)
-    with _nr_cluster_id_cache_lock:
-        cached = _kafka_cluster_id_cache.get(cache_key)
-        if isinstance(cached, tuple):
-            if time.monotonic() - cached[1] <= _CLUSTER_ID_TTL_SECONDS:
-                return  # still fresh
-            # Expired — fall through to start a new fetch.
-        elif cached is not None:
-            return  # "" sentinel — fetch already in progress.
-        _kafka_cluster_id_cache[cache_key] = ""  # sentinel to prevent duplicate fetches
-
-    try:
-        from kafka.admin import KafkaAdminClient as _KafkaAdminClient
-        if not hasattr(_KafkaAdminClient, "describe_cluster"):
-            return
-    except ImportError:
-        return
-
-    def _run():
-        admin = None
-        cluster_id = None
-        try:
-            from kafka.admin import KafkaAdminClient
-            extra = {k: instance_config[k] for k in _SECURITY_CONFIG_KEYS if instance_config and k in instance_config and instance_config[k] is not None}
-            admin = KafkaAdminClient(
-                bootstrap_servers=bootstrap_servers,
-                client_id="newrelic-cluster-id-probe",
-                api_version_auto_timeout_ms=5000,
-                **extra,
-            )
-            meta = admin._client.cluster
-            admin._client.poll(timeout_ms=3000)
-            try:
-                result = admin.describe_cluster()
-                if isinstance(result, dict):
-                    cluster_id = result.get("cluster_id") or result.get("clusterId")
-                else:
-                    cluster_id = getattr(result, "cluster_id", None) or getattr(result, "clusterId", None)
-            except Exception:
-                _logger.debug("NR Kafka describe_cluster failed", exc_info=True)
-            if not cluster_id:
-                cluster_id = getattr(meta, "cluster_id", None) or getattr(meta, "_cluster_id", None)
-        except Exception:
-            _logger.debug("NR Kafka cluster ID fetch failed", exc_info=True)
-        finally:
-            try:
-                if admin is not None:
-                    admin.close()
-            except Exception:
-                pass
-        if cluster_id:
-            with _nr_cluster_id_cache_lock:
-                _kafka_cluster_id_cache[cache_key] = (cluster_id, time.monotonic())
-        else:
-            with _nr_cluster_id_cache_lock:
-                _kafka_cluster_id_cache.pop(cache_key, None)
-
-    threading.Thread(target=_run, daemon=True, name="NR-KafkaPython-ClusterId").start()
 
 
 def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
@@ -279,13 +194,7 @@ def wrap_KafkaProducer_init(wrapped, instance, args, kwargs):
         instance, "Serialization/Value", "MessageBroker", get_config_key("value_serializer")
     )
 
-    result = wrapped(*args, **kwargs)
-
-    servers = instance.config.get("bootstrap_servers", [])
-    if servers:
-        _fetch_cluster_id_kafka_python(servers, instance.config)
-
-    return result
+    return wrapped(*args, **kwargs)
 
 
 class NewRelicSerializerWrapper(ObjectProxy):
@@ -362,17 +271,8 @@ def instrument_kafka_producer(module):
         wrap_function_wrapper(module, "KafkaProducer.send", wrap_KafkaProducer_send)
 
 
-def _wrap_KafkaConsumer_init(wrapped, instance, args, kwargs):
-    result = wrapped(*args, **kwargs)
-    servers = instance.config.get("bootstrap_servers", [])
-    if servers:
-        _fetch_cluster_id_kafka_python(servers, instance.config)
-    return result
-
-
 def instrument_kafka_consumer_group(module):
     if hasattr(module, "KafkaConsumer"):
-        wrap_function_wrapper(module, "KafkaConsumer.__init__", _wrap_KafkaConsumer_init)
         wrap_function_wrapper(module, "KafkaConsumer.__next__", wrap_kafkaconsumer_next)
 
 

--- a/newrelic/hooks/messagebroker_kafkapython.py
+++ b/newrelic/hooks/messagebroker_kafkapython.py
@@ -45,18 +45,35 @@ def _cluster_metrics_enabled():
 
 
 def _read_cluster_id(instance):
-    # kafka-python's own ClusterMetadata already tracks the cluster id as a
-    # passive side effect of the client's normal bootstrap/refresh traffic —
-    # this is a synchronous, in-memory attribute read, no admin client, no
-    # extra connection. KafkaProducer and KafkaConsumer expose it via
-    # different attribute paths.
+    # ClusterMetadata.update_metadata() receives the cluster id on every real
+    # metadata refresh (it's a field on the raw MetadataResponse) but discards it —
+    # it only copies brokers/topics/controller_id onto self. wrap_ClusterMetadata_update_metadata
+    # captures it into _nr_cluster_id as a passive side effect of that same refresh,
+    # so this read stays a synchronous, in-memory attribute lookup: no admin client,
+    # no extra connection. KafkaProducer and KafkaConsumer expose the ClusterMetadata
+    # object via different attribute paths.
     if not _cluster_metrics_enabled():
         return None
     metadata = getattr(instance, "_metadata", None)  # KafkaProducer
     if metadata is None:
         client = getattr(instance, "_client", None)  # KafkaConsumer
         metadata = getattr(client, "cluster", None) if client else None
-    return getattr(metadata, "cluster_id", None) if metadata else None
+    return getattr(metadata, "_nr_cluster_id", None) if metadata else None
+
+
+def _bind_update_metadata(metadata_response):
+    return metadata_response
+
+
+def wrap_ClusterMetadata_update_metadata(wrapped, instance, args, kwargs):
+    try:
+        metadata_response = _bind_update_metadata(*args, **kwargs)
+        cluster_id = getattr(metadata_response, "cluster_id", None)
+        if cluster_id:
+            instance._nr_cluster_id = cluster_id
+    except Exception:
+        _logger.debug("NR Kafka cluster ID capture failed", exc_info=True)
+    return wrapped(*args, **kwargs)
 
 
 def _bind_send(topic, value=None, key=None, headers=None, partition=None, timestamp_ms=None):
@@ -263,6 +280,11 @@ def metric_wrapper(metric_name, check_result=False):
         return result
 
     return _metric_wrapper
+
+
+def instrument_kafka_cluster(module):
+    if hasattr(module, "ClusterMetadata") and hasattr(module.ClusterMetadata, "update_metadata"):
+        wrap_function_wrapper(module, "ClusterMetadata.update_metadata", wrap_ClusterMetadata_update_metadata)
 
 
 def instrument_kafka_producer(module):

--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -182,3 +182,34 @@ def expected_broker_metrics(broker, topic):
 @pytest.fixture
 def expected_missing_broker_metrics(broker, topic):
     return [(f"MessageBroker/Kafka/Nodes/{server}/Consume/{topic}", None) for server in broker.split(",")]
+
+
+# ---------------------------------------------------------------------------
+# Cluster-ID metric and attribute tests (confluent-kafka)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def consumer_with_cluster_id(consumer, broker):
+    """Set _nr_cluster_id directly on the consumer instance for deterministic tests."""
+    test_cluster_id = "confluent-consumer-cluster-test"
+    consumer._nr_cluster_id = test_cluster_id
+    if not hasattr(consumer, "_nr_bootstrap_servers"):
+        consumer._nr_bootstrap_servers = broker.split(",")
+    yield consumer, test_cluster_id
+
+
+def test_cluster_consume_metric(topic, get_consumer_record, consumer_with_cluster_id, client_type):
+    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Consume appears after poll()."""
+    _, cluster_id = consumer_with_cluster_id
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Consume"
+
+    @validate_transaction_metrics(
+        f"Named/{topic}",
+        group="Message/Kafka/Topic",
+        custom_metrics=[(cluster_metric, 1)],
+        background_task=True,
+    )
+    def _test():
+        get_consumer_record()
+
+    _test()

--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -210,9 +210,9 @@ def consumer_with_cluster_id(consumer, broker, monkeypatch):
 
 
 def test_cluster_consume_metric(topic, get_consumer_record, consumer_with_cluster_id, client_type):
-    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Consume appears after poll()."""
+    """MessageBroker/Kafka/Cluster/{id}/Consume/{topic} appears after poll()."""
     _, cluster_id = consumer_with_cluster_id
-    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Consume"
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Consume/{topic}"
 
     @validate_transaction_metrics(
         f"Named/{topic}",

--- a/tests/messagebroker_confluentkafka/test_consumer.py
+++ b/tests/messagebroker_confluentkafka/test_consumer.py
@@ -26,6 +26,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import end_of_transaction
 from newrelic.common.object_names import callable_name
+from newrelic.core.config import global_settings
 
 
 def test_custom_metrics(get_consumer_record, topic, expected_broker_metrics):
@@ -189,13 +190,23 @@ def expected_missing_broker_metrics(broker, topic):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def consumer_with_cluster_id(consumer, broker):
-    """Set _nr_cluster_id directly on the consumer instance for deterministic tests."""
+def consumer_with_cluster_id(consumer, broker, monkeypatch):
+    """Enable cluster metrics and pre-populate the shared bootstrap-servers ->
+    cluster-id cache, as a Producer on the same broker set would — Consumers
+    never call list_topics() themselves (see _resolve_consumer_cluster_id)."""
+    from newrelic.hooks.messagebroker_confluentkafka import _bootstrap_key, _nr_cluster_id_by_bootstrap
+
     test_cluster_id = "confluent-consumer-cluster-test"
-    consumer._nr_cluster_id = test_cluster_id
+    settings = global_settings()
+    monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
     if not hasattr(consumer, "_nr_bootstrap_servers"):
         consumer._nr_bootstrap_servers = broker.split(",")
-    yield consumer, test_cluster_id
+    key = _bootstrap_key(consumer)
+    _nr_cluster_id_by_bootstrap[key] = test_cluster_id
+    try:
+        yield consumer, test_cluster_id
+    finally:
+        _nr_cluster_id_by_bootstrap.pop(key, None)
 
 
 def test_cluster_consume_metric(topic, get_consumer_record, consumer_with_cluster_id, client_type):

--- a/tests/messagebroker_confluentkafka/test_producer.py
+++ b/tests/messagebroker_confluentkafka/test_producer.py
@@ -152,3 +152,36 @@ def test_producer_errors(topic, producer, monkeypatch):
 @pytest.fixture
 def expected_broker_metrics(broker, topic):
     return [(f"MessageBroker/Kafka/Nodes/{server}/Produce/{topic}", 1) for server in broker.split(",")]
+
+
+# ---------------------------------------------------------------------------
+# Cluster-ID metric tests (confluent-kafka)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def producer_with_cluster_id(producer, broker):
+    """Set _nr_cluster_id directly on the producer instance, bypassing the
+    async daemon-thread fetch so metric tests are deterministic and fast."""
+    test_cluster_id = "confluent-cluster-test-999"
+    producer._nr_cluster_id = test_cluster_id
+    # Also need bootstrap servers so the Nodes metrics fire correctly
+    if not hasattr(producer, "_nr_bootstrap_servers"):
+        producer._nr_bootstrap_servers = broker.split(",")
+    yield producer, test_cluster_id
+
+
+def test_cluster_produce_metric(topic, producer_with_cluster_id, send_producer_message, client_type):
+    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Produce appears after produce()."""
+    _, cluster_id = producer_with_cluster_id
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce"
+
+    @validate_transaction_metrics(
+        "test_producer:test_cluster_produce_metric.<locals>.test",
+        custom_metrics=[(cluster_metric, 1)],
+        background_task=True,
+    )
+    @background_task()
+    def test():
+        send_producer_message()
+
+    test()

--- a/tests/messagebroker_confluentkafka/test_producer.py
+++ b/tests/messagebroker_confluentkafka/test_producer.py
@@ -161,10 +161,17 @@ def expected_broker_metrics(broker, topic):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def producer_with_cluster_id(producer, broker, monkeypatch):
+def producer_with_cluster_id(producer, broker, monkeypatch, send_producer_message):
     """Enable cluster metrics and stub list_topics() so the producer's
     cluster-id read (see _resolve_producer_cluster_id) is deterministic and
-    doesn't depend on a real broker round trip."""
+    doesn't depend on a real broker round trip.
+
+    Resolution runs on a background thread (see _schedule_cluster_id_resolution),
+    so it's never available on the very first produce() call that triggers it —
+    same as real usage. Send one warm-up message here and wait for that thread
+    to finish, so the metric assertion in the actual test can rely on the id
+    already being cached on the instance.
+    """
     test_cluster_id = "confluent-cluster-test-999"
     settings = global_settings()
     monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
@@ -172,6 +179,17 @@ def producer_with_cluster_id(producer, broker, monkeypatch):
     # Also need bootstrap servers so the Nodes metrics fire correctly
     if not hasattr(producer, "_nr_bootstrap_servers"):
         producer._nr_bootstrap_servers = broker.split(",")
+
+    @background_task()
+    def _warm_up():
+        send_producer_message()
+
+    _warm_up()  # triggers resolution; id isn't cached on the instance yet
+    deadline = time.time() + 2
+    while getattr(producer, "_nr_cluster_id", None) is None and time.time() < deadline:
+        time.sleep(0.01)
+    assert producer._nr_cluster_id == test_cluster_id, "background cluster-id resolution did not complete"
+
     return producer, test_cluster_id
 
 

--- a/tests/messagebroker_confluentkafka/test_producer.py
+++ b/tests/messagebroker_confluentkafka/test_producer.py
@@ -14,6 +14,7 @@
 
 import threading
 import time
+from types import SimpleNamespace
 
 import pytest
 from conftest import cache_kafka_producer_headers
@@ -24,6 +25,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.common.object_names import callable_name
+from newrelic.core.config import global_settings
 
 
 @pytest.mark.parametrize(
@@ -159,15 +161,18 @@ def expected_broker_metrics(broker, topic):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def producer_with_cluster_id(producer, broker):
-    """Set _nr_cluster_id directly on the producer instance, bypassing the
-    async daemon-thread fetch so metric tests are deterministic and fast."""
+def producer_with_cluster_id(producer, broker, monkeypatch):
+    """Enable cluster metrics and stub list_topics() so the producer's
+    cluster-id read (see _resolve_producer_cluster_id) is deterministic and
+    doesn't depend on a real broker round trip."""
     test_cluster_id = "confluent-cluster-test-999"
-    producer._nr_cluster_id = test_cluster_id
+    settings = global_settings()
+    monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
+    monkeypatch.setattr(producer, "list_topics", lambda timeout=0: SimpleNamespace(cluster_id=test_cluster_id))
     # Also need bootstrap servers so the Nodes metrics fire correctly
     if not hasattr(producer, "_nr_bootstrap_servers"):
         producer._nr_bootstrap_servers = broker.split(",")
-    yield producer, test_cluster_id
+    return producer, test_cluster_id
 
 
 def test_cluster_produce_metric(topic, producer_with_cluster_id, send_producer_message, client_type):

--- a/tests/messagebroker_confluentkafka/test_producer.py
+++ b/tests/messagebroker_confluentkafka/test_producer.py
@@ -194,9 +194,9 @@ def producer_with_cluster_id(producer, broker, monkeypatch, send_producer_messag
 
 
 def test_cluster_produce_metric(topic, producer_with_cluster_id, send_producer_message, client_type):
-    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Produce appears after produce()."""
+    """MessageBroker/Kafka/Cluster/{id}/Produce/{topic} appears after produce()."""
     _, cluster_id = producer_with_cluster_id
-    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce"
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Produce/{topic}"
 
     @validate_transaction_metrics(
         "test_producer:test_cluster_produce_metric.<locals>.test",

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -54,7 +54,7 @@ class TestProducerSendKeyPreservation:
         """Key must not be replaced by broker address string when cluster ID cached."""
         cluster_id = "test-cluster-uuid"
         cache_key = "broker1:9092,broker2:9092"
-        _kafka_cluster_id_cache[cache_key] = cluster_id
+        _kafka_cluster_id_cache[cache_key] = (cluster_id, time.monotonic())
 
         wrapped = MagicMock(return_value=MagicMock())
         instance = self._make_producer_instance()
@@ -146,7 +146,8 @@ class TestFetchClusterIdKafkaPython:
             time.sleep(0.5)
 
         try:
-            assert _kafka_cluster_id_cache.get(cache_key) == "fetched-uuid"
+            cached = _kafka_cluster_id_cache.get(cache_key)
+            assert isinstance(cached, tuple) and cached[0] == "fetched-uuid"
         finally:
             _kafka_cluster_id_cache.pop(cache_key, None)
 
@@ -166,7 +167,7 @@ class TestFetchClusterIdKafkaPython:
         """A fully-resolved cache entry (non-empty) skips the fetch and returns immediately."""
         servers = ["broker-resolved:9092"]
         cache_key = self._cache_key(servers)
-        _kafka_cluster_id_cache[cache_key] = "already-resolved-uuid"
+        _kafka_cluster_id_cache[cache_key] = ("already-resolved-uuid", time.monotonic())
 
         with patch("newrelic.hooks.messagebroker_kafkapython.threading.Thread") as mock_thread:
             _fetch_cluster_id_kafka_python(servers)

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -147,7 +147,8 @@ class TestFetchClusterIdKafkaPython:
 
         try:
             cached = _kafka_cluster_id_cache.get(cache_key)
-            assert isinstance(cached, tuple) and cached[0] == "fetched-uuid"
+            assert isinstance(cached, tuple)
+            assert cached[0] == "fetched-uuid"
         finally:
             _kafka_cluster_id_cache.pop(cache_key, None)
 

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -1,0 +1,190 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for cluster-ID additions in messagebroker_kafkapython.
+
+These tests exercise the wrapper functions directly with mocks — no real Kafka
+broker required. They verify correctness of arguments passed to the underlying
+`wrapped` callable without any network I/O.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from newrelic.hooks.messagebroker_kafkapython import (
+    _bootstrap_cache_key,
+    _fetch_cluster_id_kafka_python,
+    _kafka_cluster_id_cache,
+    wrap_KafkaProducer_send,
+)
+
+
+# ---------------------------------------------------------------------------
+# PY-1 regression: wrap_KafkaProducer_send must not overwrite the Kafka
+# message routing key with the broker address string.
+# ---------------------------------------------------------------------------
+
+class TestProducerSendKeyPreservation:
+    """The Kafka message routing key must survive the wrap_KafkaProducer_send
+    instrumentation unchanged, regardless of whether cluster ID is cached."""
+
+    def _make_producer_instance(self, bootstrap_servers=None):
+        instance = MagicMock()
+        instance.config = {
+            "bootstrap_servers": bootstrap_servers or ["broker1:9092", "broker2:9092"],
+        }
+        return instance
+
+    def _bind_send_args(self, topic, value=None, key=None, headers=None):
+        """Return positional args as wrap_KafkaProducer_send receives them."""
+        return (topic,), {"value": value, "key": key, "headers": headers or []}
+
+    def test_message_key_not_overwritten_with_cluster_id_in_cache(self):
+        """Key must not be replaced by broker address string when cluster ID cached."""
+        cluster_id = "test-cluster-uuid"
+        cache_key = "broker1:9092,broker2:9092"
+        _kafka_cluster_id_cache[cache_key] = cluster_id
+
+        wrapped = MagicMock(return_value=MagicMock())
+        instance = self._make_producer_instance()
+        args, kwargs = self._bind_send_args("my-topic", value=b"v", key=b"original-key")
+
+        try:
+            with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
+                mock_txn.return_value = MagicMock()  # active transaction
+                wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
+        finally:
+            _kafka_cluster_id_cache.pop(cache_key, None)
+
+        # The wrapped callable must have been called with key=b"original-key",
+        # not key="broker1:9092,broker2:9092" or any other broker-derived string.
+        assert wrapped.called, "wrapped() was never called"
+        call_kwargs = wrapped.call_args[1]
+        assert call_kwargs["key"] == b"original-key", (
+            f"Message key was corrupted: got {call_kwargs['key']!r}, "
+            f"expected b'original-key'. Likely cause: cache lookup variable "
+            f"reused the name 'key', overwriting the Kafka routing key."
+        )
+
+    def test_message_key_not_overwritten_when_no_cluster_id_cached(self):
+        """Key must not be replaced even when cluster ID is not yet in the cache."""
+        wrapped = MagicMock(return_value=MagicMock())
+        instance = self._make_producer_instance(bootstrap_servers=["broker-no-cache:9092"])
+        args, kwargs = self._bind_send_args("topic", key="string-key-123")
+
+        with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
+            mock_txn.return_value = MagicMock()
+            wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
+
+        assert wrapped.called
+        assert wrapped.call_args[1]["key"] == "string-key-123", (
+            "Message key corrupted even when cluster ID was not in cache."
+        )
+
+    def test_none_key_preserved(self):
+        """A None routing key must remain None (common case for unkeyed messages)."""
+        wrapped = MagicMock(return_value=MagicMock())
+        instance = self._make_producer_instance()
+        args, kwargs = self._bind_send_args("topic", key=None)
+
+        with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
+            mock_txn.return_value = MagicMock()
+            wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
+
+        assert wrapped.call_args[1]["key"] is None, "None key was corrupted."
+
+    def test_no_transaction_bypasses_instrumentation(self):
+        """Without an active NR transaction, wrapped() is called with original args."""
+        wrapped = MagicMock(return_value=MagicMock())
+        instance = self._make_producer_instance()
+        args = ("topic",)
+        kwargs = {"value": b"v", "key": b"my-key"}
+
+        with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
+            mock_txn.return_value = None  # no active transaction
+            wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
+
+        # wrapped() called directly with original args — no instrumentation applied
+        assert wrapped.called
+        wrapped.assert_called_once_with(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Cluster ID is fetched via KafkaAdminClient.describe_cluster() in a
+# background daemon thread — no passive MetadataResponse interception.
+# ---------------------------------------------------------------------------
+
+class TestFetchClusterIdKafkaPython:
+    """_fetch_cluster_id_kafka_python populates the cache via KafkaAdminClient."""
+
+    def _cache_key(self, servers):
+        return _bootstrap_cache_key(servers)
+
+    def test_cluster_id_written_to_cache_on_success(self):
+        """A successful describe_cluster() stores the cluster UUID in the module cache."""
+        servers = ["broker-fetch1:9092"]
+        cache_key = self._cache_key(servers)
+        _kafka_cluster_id_cache.pop(cache_key, None)
+
+        mock_admin = MagicMock()
+        mock_admin.describe_cluster.return_value = {"cluster_id": "fetched-uuid", "brokers": []}
+
+        with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
+            _fetch_cluster_id_kafka_python(servers)
+            # Allow the daemon thread to finish
+            import time; time.sleep(0.5)
+
+        try:
+            assert _kafka_cluster_id_cache.get(cache_key) == "fetched-uuid"
+        finally:
+            _kafka_cluster_id_cache.pop(cache_key, None)
+
+    def test_sentinel_prevents_duplicate_fetches(self):
+        """While a fetch is in-flight (sentinel ''), a second call does not spawn a thread."""
+        servers = ["broker-sentinel:9092"]
+        cache_key = self._cache_key(servers)
+        _kafka_cluster_id_cache[cache_key] = ""  # pre-set sentinel
+
+        with patch("newrelic.hooks.messagebroker_kafkapython.threading.Thread") as mock_thread:
+            _fetch_cluster_id_kafka_python(servers)
+            mock_thread.assert_not_called()
+
+        _kafka_cluster_id_cache.pop(cache_key, None)
+
+    def test_existing_resolved_entry_not_refetched(self):
+        """A fully-resolved cache entry (non-empty) skips the fetch and returns immediately."""
+        servers = ["broker-resolved:9092"]
+        cache_key = self._cache_key(servers)
+        _kafka_cluster_id_cache[cache_key] = "already-resolved-uuid"
+
+        with patch("newrelic.hooks.messagebroker_kafkapython.threading.Thread") as mock_thread:
+            _fetch_cluster_id_kafka_python(servers)
+            mock_thread.assert_not_called()
+
+        _kafka_cluster_id_cache.pop(cache_key, None)
+
+    def test_sentinel_removed_on_failure(self):
+        """If KafkaAdminClient raises, the sentinel is removed so future instances can retry."""
+        servers = ["broker-fail:9092"]
+        cache_key = self._cache_key(servers)
+        _kafka_cluster_id_cache.pop(cache_key, None)
+
+        # Raise at construction time — this hits the outer except in _run() which
+        # removes the sentinel. Raising only on connect() wouldn't work because
+        # MagicMock.describe_cluster() auto-creates a truthy return value, causing
+        # the cache to be populated with a MagicMock instead of being cleared.
+        with patch("kafka.admin.KafkaAdminClient", side_effect=Exception("connection refused")):
+            _fetch_cluster_id_kafka_python(servers)
+            import time; time.sleep(0.3)
+
+        assert _kafka_cluster_id_cache.get(cache_key) is None

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -19,6 +19,7 @@ broker required. They verify correctness of arguments passed to the underlying
 `wrapped` callable without any network I/O.
 """
 
+import time
 from unittest.mock import MagicMock, patch
 
 from newrelic.hooks.messagebroker_kafkapython import (
@@ -142,7 +143,7 @@ class TestFetchClusterIdKafkaPython:
         with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
             _fetch_cluster_id_kafka_python(servers)
             # Allow the daemon thread to finish
-            import time; time.sleep(0.5)
+            time.sleep(0.5)
 
         try:
             assert _kafka_cluster_id_cache.get(cache_key) == "fetched-uuid"
@@ -185,6 +186,6 @@ class TestFetchClusterIdKafkaPython:
         # the cache to be populated with a MagicMock instead of being cleared.
         with patch("kafka.admin.KafkaAdminClient", side_effect=Exception("connection refused")):
             _fetch_cluster_id_kafka_python(servers)
-            import time; time.sleep(0.3)
+            time.sleep(0.3)
 
         assert _kafka_cluster_id_cache.get(cache_key) is None

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -45,7 +45,7 @@ class TestProducerSendKeyPreservation:
         instance.config = {
             "bootstrap_servers": bootstrap_servers or ["broker1:9092", "broker2:9092"],
         }
-        instance._metadata = SimpleNamespace(cluster_id=cluster_id)
+        instance._metadata = SimpleNamespace(_nr_cluster_id=cluster_id)
         return instance
 
     def _bind_send_args(self, topic, value=None, key=None, headers=None):
@@ -120,33 +120,88 @@ class TestProducerSendKeyPreservation:
 # ---------------------------------------------------------------------------
 # Cluster ID is a passive, synchronous read off kafka-python's own
 # ClusterMetadata object — no AdminClient, no background thread, no cache.
+#
+# Real ClusterMetadata never stores the wire protocol's cluster_id field on
+# itself (update_metadata() discards it), so these tests target the attribute
+# wrap_ClusterMetadata_update_metadata actually populates (_nr_cluster_id), not
+# the native (always-empty) one. See TestUpdateMetadataCapture below for a test
+# against the real kafka-python protocol response type, not a stub.
 # ---------------------------------------------------------------------------
 
 class TestReadClusterId:
     def test_returns_none_when_cluster_metrics_disabled(self):
         instance = MagicMock()
-        instance._metadata = SimpleNamespace(cluster_id="some-id")
+        instance._metadata = SimpleNamespace(_nr_cluster_id="some-id")
         assert _read_cluster_id(instance) is None
 
     def test_reads_from_producer_metadata_attribute(self, monkeypatch):
         _enable_cluster_metrics(monkeypatch)
         instance = MagicMock(spec=["_metadata"])
-        instance._metadata = SimpleNamespace(cluster_id="producer-cluster-id")
+        instance._metadata = SimpleNamespace(_nr_cluster_id="producer-cluster-id")
         assert _read_cluster_id(instance) == "producer-cluster-id"
 
     def test_reads_from_consumer_client_cluster_attribute(self, monkeypatch):
         _enable_cluster_metrics(monkeypatch)
         instance = MagicMock(spec=["_client"])
-        instance._client = SimpleNamespace(cluster=SimpleNamespace(cluster_id="consumer-cluster-id"))
+        instance._client = SimpleNamespace(cluster=SimpleNamespace(_nr_cluster_id="consumer-cluster-id"))
         assert _read_cluster_id(instance) == "consumer-cluster-id"
 
     def test_returns_none_when_metadata_not_yet_populated(self, monkeypatch):
         _enable_cluster_metrics(monkeypatch)
         instance = MagicMock(spec=["_metadata"])
-        instance._metadata = SimpleNamespace(cluster_id=None)
+        instance._metadata = SimpleNamespace(_nr_cluster_id=None)
         assert _read_cluster_id(instance) is None
 
     def test_returns_none_when_no_metadata_or_client_attribute(self, monkeypatch):
         _enable_cluster_metrics(monkeypatch)
         instance = MagicMock(spec=[])
         assert _read_cluster_id(instance) is None
+
+
+# ---------------------------------------------------------------------------
+# wrap_ClusterMetadata_update_metadata against the real kafka-python protocol
+# response type (not a stub) — this is the regression test for the bug where
+# ClusterMetadata never actually stored a real cluster id anywhere.
+# ---------------------------------------------------------------------------
+
+class TestUpdateMetadataCapture:
+    def _real_response(self, cluster_id):
+        from kafka.protocol.metadata import MetadataResponse_v2
+
+        return MetadataResponse_v2(brokers=[], cluster_id=cluster_id, controller_id=-1, topics=[])
+
+    def test_captures_cluster_id_from_real_response_type(self):
+        from newrelic.hooks.messagebroker_kafkapython import wrap_ClusterMetadata_update_metadata
+
+        instance = MagicMock(spec=["_nr_cluster_id"])
+        wrapped = MagicMock()
+        response = self._real_response("real-cluster-uuid")
+
+        wrap_ClusterMetadata_update_metadata(wrapped, instance, (response,), {})
+
+        assert instance._nr_cluster_id == "real-cluster-uuid"
+        wrapped.assert_called_once_with(response)
+
+    def test_wrapped_still_called_when_capture_fails(self):
+        """A malformed response must not prevent the real update_metadata from running."""
+        from newrelic.hooks.messagebroker_kafkapython import wrap_ClusterMetadata_update_metadata
+
+        instance = MagicMock(spec_set=[])  # setting any attribute raises AttributeError
+        wrapped = MagicMock()
+        response = self._real_response("real-cluster-uuid")
+
+        wrap_ClusterMetadata_update_metadata(wrapped, instance, (response,), {})
+
+        wrapped.assert_called_once_with(response)
+
+    def test_no_cluster_id_on_response_does_not_set_attribute(self):
+        from newrelic.hooks.messagebroker_kafkapython import wrap_ClusterMetadata_update_metadata
+
+        instance = object()  # plain object -- no attribute unless we actually set one
+        wrapped = MagicMock()
+        response = self._real_response(None)
+
+        wrap_ClusterMetadata_update_metadata(wrapped, instance, (response,), {})
+
+        assert not hasattr(instance, "_nr_cluster_id")
+        wrapped.assert_called_once_with(response)

--- a/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
+++ b/tests/messagebroker_kafkapython/test_cluster_metrics_unit.py
@@ -19,15 +19,16 @@ broker required. They verify correctness of arguments passed to the underlying
 `wrapped` callable without any network I/O.
 """
 
-import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from newrelic.hooks.messagebroker_kafkapython import (
-    _bootstrap_cache_key,
-    _fetch_cluster_id_kafka_python,
-    _kafka_cluster_id_cache,
-    wrap_KafkaProducer_send,
-)
+from newrelic.core.config import global_settings
+from newrelic.hooks.messagebroker_kafkapython import _read_cluster_id, wrap_KafkaProducer_send
+
+
+def _enable_cluster_metrics(monkeypatch):
+    settings = global_settings()
+    monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
 
 
 # ---------------------------------------------------------------------------
@@ -37,50 +38,44 @@ from newrelic.hooks.messagebroker_kafkapython import (
 
 class TestProducerSendKeyPreservation:
     """The Kafka message routing key must survive the wrap_KafkaProducer_send
-    instrumentation unchanged, regardless of whether cluster ID is cached."""
+    instrumentation unchanged, regardless of whether a cluster ID is resolved."""
 
-    def _make_producer_instance(self, bootstrap_servers=None):
+    def _make_producer_instance(self, bootstrap_servers=None, cluster_id=None):
         instance = MagicMock()
         instance.config = {
             "bootstrap_servers": bootstrap_servers or ["broker1:9092", "broker2:9092"],
         }
+        instance._metadata = SimpleNamespace(cluster_id=cluster_id)
         return instance
 
     def _bind_send_args(self, topic, value=None, key=None, headers=None):
         """Return positional args as wrap_KafkaProducer_send receives them."""
         return (topic,), {"value": value, "key": key, "headers": headers or []}
 
-    def test_message_key_not_overwritten_with_cluster_id_in_cache(self):
-        """Key must not be replaced by broker address string when cluster ID cached."""
-        cluster_id = "test-cluster-uuid"
-        cache_key = "broker1:9092,broker2:9092"
-        _kafka_cluster_id_cache[cache_key] = (cluster_id, time.monotonic())
-
+    def test_message_key_not_overwritten_with_cluster_id_resolved(self, monkeypatch):
+        """Key must not be replaced by broker address string when a cluster ID is resolved."""
+        _enable_cluster_metrics(monkeypatch)
         wrapped = MagicMock(return_value=MagicMock())
-        instance = self._make_producer_instance()
+        instance = self._make_producer_instance(cluster_id="test-cluster-uuid")
         args, kwargs = self._bind_send_args("my-topic", value=b"v", key=b"original-key")
 
-        try:
-            with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
-                mock_txn.return_value = MagicMock()  # active transaction
-                wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
-        finally:
-            _kafka_cluster_id_cache.pop(cache_key, None)
+        with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
+            mock_txn.return_value = MagicMock()  # active transaction
+            wrap_KafkaProducer_send(wrapped, instance, args, kwargs)
 
         # The wrapped callable must have been called with key=b"original-key",
         # not key="broker1:9092,broker2:9092" or any other broker-derived string.
         assert wrapped.called, "wrapped() was never called"
         call_kwargs = wrapped.call_args[1]
         assert call_kwargs["key"] == b"original-key", (
-            f"Message key was corrupted: got {call_kwargs['key']!r}, "
-            f"expected b'original-key'. Likely cause: cache lookup variable "
-            f"reused the name 'key', overwriting the Kafka routing key."
+            f"Message key was corrupted: got {call_kwargs['key']!r}, expected b'original-key'."
         )
 
-    def test_message_key_not_overwritten_when_no_cluster_id_cached(self):
-        """Key must not be replaced even when cluster ID is not yet in the cache."""
+    def test_message_key_not_overwritten_when_no_cluster_id_resolved(self, monkeypatch):
+        """Key must not be replaced even when no cluster ID is resolved."""
+        _enable_cluster_metrics(monkeypatch)
         wrapped = MagicMock(return_value=MagicMock())
-        instance = self._make_producer_instance(bootstrap_servers=["broker-no-cache:9092"])
+        instance = self._make_producer_instance(bootstrap_servers=["broker-no-cluster:9092"], cluster_id=None)
         args, kwargs = self._bind_send_args("topic", key="string-key-123")
 
         with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
@@ -89,13 +84,14 @@ class TestProducerSendKeyPreservation:
 
         assert wrapped.called
         assert wrapped.call_args[1]["key"] == "string-key-123", (
-            "Message key corrupted even when cluster ID was not in cache."
+            "Message key corrupted even when no cluster ID was resolved."
         )
 
-    def test_none_key_preserved(self):
+    def test_none_key_preserved(self, monkeypatch):
         """A None routing key must remain None (common case for unkeyed messages)."""
+        _enable_cluster_metrics(monkeypatch)
         wrapped = MagicMock(return_value=MagicMock())
-        instance = self._make_producer_instance()
+        instance = self._make_producer_instance(cluster_id="test-cluster-uuid")
         args, kwargs = self._bind_send_args("topic", key=None)
 
         with patch("newrelic.hooks.messagebroker_kafkapython.current_transaction") as mock_txn:
@@ -104,10 +100,11 @@ class TestProducerSendKeyPreservation:
 
         assert wrapped.call_args[1]["key"] is None, "None key was corrupted."
 
-    def test_no_transaction_bypasses_instrumentation(self):
+    def test_no_transaction_bypasses_instrumentation(self, monkeypatch):
         """Without an active NR transaction, wrapped() is called with original args."""
+        _enable_cluster_metrics(monkeypatch)
         wrapped = MagicMock(return_value=MagicMock())
-        instance = self._make_producer_instance()
+        instance = self._make_producer_instance(cluster_id="test-cluster-uuid")
         args = ("topic",)
         kwargs = {"value": b"v", "key": b"my-key"}
 
@@ -121,73 +118,35 @@ class TestProducerSendKeyPreservation:
 
 
 # ---------------------------------------------------------------------------
-# Cluster ID is fetched via KafkaAdminClient.describe_cluster() in a
-# background daemon thread — no passive MetadataResponse interception.
+# Cluster ID is a passive, synchronous read off kafka-python's own
+# ClusterMetadata object — no AdminClient, no background thread, no cache.
 # ---------------------------------------------------------------------------
 
-class TestFetchClusterIdKafkaPython:
-    """_fetch_cluster_id_kafka_python populates the cache via KafkaAdminClient."""
+class TestReadClusterId:
+    def test_returns_none_when_cluster_metrics_disabled(self):
+        instance = MagicMock()
+        instance._metadata = SimpleNamespace(cluster_id="some-id")
+        assert _read_cluster_id(instance) is None
 
-    def _cache_key(self, servers):
-        return _bootstrap_cache_key(servers)
+    def test_reads_from_producer_metadata_attribute(self, monkeypatch):
+        _enable_cluster_metrics(monkeypatch)
+        instance = MagicMock(spec=["_metadata"])
+        instance._metadata = SimpleNamespace(cluster_id="producer-cluster-id")
+        assert _read_cluster_id(instance) == "producer-cluster-id"
 
-    def test_cluster_id_written_to_cache_on_success(self):
-        """A successful describe_cluster() stores the cluster UUID in the module cache."""
-        servers = ["broker-fetch1:9092"]
-        cache_key = self._cache_key(servers)
-        _kafka_cluster_id_cache.pop(cache_key, None)
+    def test_reads_from_consumer_client_cluster_attribute(self, monkeypatch):
+        _enable_cluster_metrics(monkeypatch)
+        instance = MagicMock(spec=["_client"])
+        instance._client = SimpleNamespace(cluster=SimpleNamespace(cluster_id="consumer-cluster-id"))
+        assert _read_cluster_id(instance) == "consumer-cluster-id"
 
-        mock_admin = MagicMock()
-        mock_admin.describe_cluster.return_value = {"cluster_id": "fetched-uuid", "brokers": []}
+    def test_returns_none_when_metadata_not_yet_populated(self, monkeypatch):
+        _enable_cluster_metrics(monkeypatch)
+        instance = MagicMock(spec=["_metadata"])
+        instance._metadata = SimpleNamespace(cluster_id=None)
+        assert _read_cluster_id(instance) is None
 
-        with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
-            _fetch_cluster_id_kafka_python(servers)
-            # Allow the daemon thread to finish
-            time.sleep(0.5)
-
-        try:
-            cached = _kafka_cluster_id_cache.get(cache_key)
-            assert isinstance(cached, tuple)
-            assert cached[0] == "fetched-uuid"
-        finally:
-            _kafka_cluster_id_cache.pop(cache_key, None)
-
-    def test_sentinel_prevents_duplicate_fetches(self):
-        """While a fetch is in-flight (sentinel ''), a second call does not spawn a thread."""
-        servers = ["broker-sentinel:9092"]
-        cache_key = self._cache_key(servers)
-        _kafka_cluster_id_cache[cache_key] = ""  # pre-set sentinel
-
-        with patch("newrelic.hooks.messagebroker_kafkapython.threading.Thread") as mock_thread:
-            _fetch_cluster_id_kafka_python(servers)
-            mock_thread.assert_not_called()
-
-        _kafka_cluster_id_cache.pop(cache_key, None)
-
-    def test_existing_resolved_entry_not_refetched(self):
-        """A fully-resolved cache entry (non-empty) skips the fetch and returns immediately."""
-        servers = ["broker-resolved:9092"]
-        cache_key = self._cache_key(servers)
-        _kafka_cluster_id_cache[cache_key] = ("already-resolved-uuid", time.monotonic())
-
-        with patch("newrelic.hooks.messagebroker_kafkapython.threading.Thread") as mock_thread:
-            _fetch_cluster_id_kafka_python(servers)
-            mock_thread.assert_not_called()
-
-        _kafka_cluster_id_cache.pop(cache_key, None)
-
-    def test_sentinel_removed_on_failure(self):
-        """If KafkaAdminClient raises, the sentinel is removed so future instances can retry."""
-        servers = ["broker-fail:9092"]
-        cache_key = self._cache_key(servers)
-        _kafka_cluster_id_cache.pop(cache_key, None)
-
-        # Raise at construction time — this hits the outer except in _run() which
-        # removes the sentinel. Raising only on connect() wouldn't work because
-        # MagicMock.describe_cluster() auto-creates a truthy return value, causing
-        # the cache to be populated with a MagicMock instead of being cleared.
-        with patch("kafka.admin.KafkaAdminClient", side_effect=Exception("connection refused")):
-            _fetch_cluster_id_kafka_python(servers)
-            time.sleep(0.3)
-
-        assert _kafka_cluster_id_cache.get(cache_key) is None
+    def test_returns_none_when_no_metadata_or_client_attribute(self, monkeypatch):
+        _enable_cluster_metrics(monkeypatch)
+        instance = MagicMock(spec=[])
+        assert _read_cluster_id(instance) is None

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import pytest
 from conftest import cache_kafka_consumer_headers
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
@@ -199,7 +201,7 @@ def seeded_cluster_id(broker):
 
     cache_key = ",".join(sorted(broker))
     test_cluster_id = "test-cluster-consumer-xyz"
-    _kafka_cluster_id_cache[cache_key] = test_cluster_id
+    _kafka_cluster_id_cache[cache_key] = (test_cluster_id, time.monotonic())
     yield test_cluster_id
     _kafka_cluster_id_cache.pop(cache_key, None)
 

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -186,3 +186,38 @@ def expected_broker_metrics(broker, topic):
 @pytest.fixture
 def expected_missing_broker_metrics(broker, topic):
     return [(f"MessageBroker/Kafka/Nodes/{server}/Consume/{topic}", None) for server in broker]
+
+
+# ---------------------------------------------------------------------------
+# Cluster-ID metric and attribute tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def seeded_cluster_id(broker):
+    """Pre-seed the cluster-ID cache so metric tests are deterministic."""
+    from newrelic.hooks.messagebroker_kafkapython import _kafka_cluster_id_cache
+
+    cache_key = ",".join(sorted(broker))
+    test_cluster_id = "test-cluster-consumer-xyz"
+    _kafka_cluster_id_cache[cache_key] = test_cluster_id
+    yield test_cluster_id
+    _kafka_cluster_id_cache.pop(cache_key, None)
+
+
+def test_cluster_consume_metric(get_consumer_record, topic, broker, seeded_cluster_id):
+    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Consume appears after a poll."""
+    cluster_id = seeded_cluster_id
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Consume"
+
+    @validate_transaction_metrics(
+        f"Named/{topic}",
+        group="Message/Kafka/Topic",
+        custom_metrics=[(cluster_metric, 1)],
+        background_task=True,
+    )
+    def _test():
+        get_consumer_record()
+
+    _test()
+
+

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -195,13 +195,16 @@ def expected_missing_broker_metrics(broker, topic):
 
 @pytest.fixture
 def seeded_cluster_id(consumer, monkeypatch):
-    """Directly set the cluster id on kafka-python's own ClusterMetadata object
-    — the same passive attribute _read_cluster_id reads — so tests are
-    deterministic without depending on a real broker round trip."""
+    """Directly set _nr_cluster_id on kafka-python's own ClusterMetadata object
+    — the attribute wrap_ClusterMetadata_update_metadata populates from a real
+    metadata refresh, and the same one _read_cluster_id reads — so tests are
+    deterministic without depending on a real broker round trip. (The native
+    ClusterMetadata.cluster_id is never populated by the real library — see
+    TestUpdateMetadataCapture in test_cluster_metrics_unit.py.)"""
     settings = global_settings()
     monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
     test_cluster_id = "test-cluster-consumer-xyz"
-    consumer._client.cluster.cluster_id = test_cluster_id
+    consumer._client.cluster._nr_cluster_id = test_cluster_id
     return test_cluster_id
 
 

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -209,9 +209,9 @@ def seeded_cluster_id(consumer, monkeypatch):
 
 
 def test_cluster_consume_metric(get_consumer_record, topic, broker, seeded_cluster_id):
-    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Consume appears after a poll."""
+    """MessageBroker/Kafka/Cluster/{id}/Consume/{topic} appears after a poll."""
     cluster_id = seeded_cluster_id
-    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Consume"
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Consume/{topic}"
 
     @validate_transaction_metrics(
         f"Named/{topic}",

--- a/tests/messagebroker_kafkapython/test_consumer.py
+++ b/tests/messagebroker_kafkapython/test_consumer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 import pytest
 from conftest import cache_kafka_consumer_headers
 from testing_support.fixtures import reset_core_stats_engine, validate_attributes
@@ -28,6 +26,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 from newrelic.api.background_task import background_task
 from newrelic.api.transaction import end_of_transaction
 from newrelic.common.object_names import callable_name
+from newrelic.core.config import global_settings
 
 
 def test_custom_metrics(get_consumer_record, topic, expected_broker_metrics):
@@ -195,15 +194,15 @@ def expected_missing_broker_metrics(broker, topic):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def seeded_cluster_id(broker):
-    """Pre-seed the cluster-ID cache so metric tests are deterministic."""
-    from newrelic.hooks.messagebroker_kafkapython import _kafka_cluster_id_cache
-
-    cache_key = ",".join(sorted(broker))
+def seeded_cluster_id(consumer, monkeypatch):
+    """Directly set the cluster id on kafka-python's own ClusterMetadata object
+    — the same passive attribute _read_cluster_id reads — so tests are
+    deterministic without depending on a real broker round trip."""
+    settings = global_settings()
+    monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
     test_cluster_id = "test-cluster-consumer-xyz"
-    _kafka_cluster_id_cache[cache_key] = (test_cluster_id, time.monotonic())
-    yield test_cluster_id
-    _kafka_cluster_id_cache.pop(cache_key, None)
+    consumer._client.cluster.cluster_id = test_cluster_id
+    return test_cluster_id
 
 
 def test_cluster_consume_metric(get_consumer_record, topic, broker, seeded_cluster_id):

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -101,3 +101,42 @@ def test_producer_errors(topic, producer, monkeypatch):
 @pytest.fixture
 def expected_broker_metrics(broker, topic):
     return [(f"MessageBroker/Kafka/Nodes/{server}/Produce/{topic}", 1) for server in broker]
+
+
+# ---------------------------------------------------------------------------
+# Cluster-ID metric tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def seeded_cluster_id(broker):
+    """Pre-seed the cluster-ID cache with a known value so tests are deterministic.
+
+    The real cluster-ID fetch is async; seeding avoids flaky timing issues
+    in the test suite while still exercising the metric-recording code path.
+    """
+    from newrelic.hooks.messagebroker_kafkapython import _kafka_cluster_id_cache
+
+    cache_key = ",".join(sorted(broker))
+    test_cluster_id = "test-cluster-abc123"
+    _kafka_cluster_id_cache[cache_key] = test_cluster_id
+    yield test_cluster_id
+    _kafka_cluster_id_cache.pop(cache_key, None)
+
+
+def test_cluster_produce_metric(topic, send_producer_message, broker, seeded_cluster_id):
+    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Produce appears after a send."""
+    cluster_id = seeded_cluster_id
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce"
+
+    @validate_transaction_metrics(
+        "test_producer:test_cluster_produce_metric.<locals>.test",
+        custom_metrics=[(cluster_metric, 1)],
+        background_task=True,
+    )
+    @background_task()
+    def test():
+        send_producer_message()
+
+    test()
+
+

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 import pytest
 from conftest import cache_kafka_producer_headers
 from testing_support.validators.validate_messagebroker_headers import validate_messagebroker_headers
@@ -118,7 +120,7 @@ def seeded_cluster_id(broker):
 
     cache_key = ",".join(sorted(broker))
     test_cluster_id = "test-cluster-abc123"
-    _kafka_cluster_id_cache[cache_key] = test_cluster_id
+    _kafka_cluster_id_cache[cache_key] = (test_cluster_id, time.monotonic())
     yield test_cluster_id
     _kafka_cluster_id_cache.pop(cache_key, None)
 

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-
 import pytest
 from conftest import cache_kafka_producer_headers
 from testing_support.validators.validate_messagebroker_headers import validate_messagebroker_headers
@@ -23,6 +21,7 @@ from testing_support.validators.validate_transaction_metrics import validate_tra
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.common.object_names import callable_name
+from newrelic.core.config import global_settings
 
 
 def test_trace_metrics(topic, send_producer_message, expected_broker_metrics):
@@ -110,19 +109,15 @@ def expected_broker_metrics(broker, topic):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def seeded_cluster_id(broker):
-    """Pre-seed the cluster-ID cache with a known value so tests are deterministic.
-
-    The real cluster-ID fetch is async; seeding avoids flaky timing issues
-    in the test suite while still exercising the metric-recording code path.
-    """
-    from newrelic.hooks.messagebroker_kafkapython import _kafka_cluster_id_cache
-
-    cache_key = ",".join(sorted(broker))
+def seeded_cluster_id(producer, monkeypatch):
+    """Directly set the cluster id on kafka-python's own ClusterMetadata object
+    — the same passive attribute _read_cluster_id reads — so tests are
+    deterministic without depending on a real broker round trip."""
+    settings = global_settings()
+    monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
     test_cluster_id = "test-cluster-abc123"
-    _kafka_cluster_id_cache[cache_key] = (test_cluster_id, time.monotonic())
-    yield test_cluster_id
-    _kafka_cluster_id_cache.pop(cache_key, None)
+    producer._metadata.cluster_id = test_cluster_id
+    return test_cluster_id
 
 
 def test_cluster_produce_metric(topic, send_producer_message, broker, seeded_cluster_id):

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -124,9 +124,9 @@ def seeded_cluster_id(producer, monkeypatch):
 
 
 def test_cluster_produce_metric(topic, send_producer_message, broker, seeded_cluster_id):
-    """MessageBroker/Kafka/Cluster/{id}/Topic/{topic}/Produce appears after a send."""
+    """MessageBroker/Kafka/Cluster/{id}/Produce/{topic} appears after a send."""
     cluster_id = seeded_cluster_id
-    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Topic/{topic}/Produce"
+    cluster_metric = f"MessageBroker/Kafka/Cluster/{cluster_id}/Produce/{topic}"
 
     @validate_transaction_metrics(
         "test_producer:test_cluster_produce_metric.<locals>.test",

--- a/tests/messagebroker_kafkapython/test_producer.py
+++ b/tests/messagebroker_kafkapython/test_producer.py
@@ -110,13 +110,16 @@ def expected_broker_metrics(broker, topic):
 
 @pytest.fixture
 def seeded_cluster_id(producer, monkeypatch):
-    """Directly set the cluster id on kafka-python's own ClusterMetadata object
-    — the same passive attribute _read_cluster_id reads — so tests are
-    deterministic without depending on a real broker round trip."""
+    """Directly set _nr_cluster_id on kafka-python's own ClusterMetadata object
+    — the attribute wrap_ClusterMetadata_update_metadata populates from a real
+    metadata refresh, and the same one _read_cluster_id reads — so tests are
+    deterministic without depending on a real broker round trip. (The native
+    ClusterMetadata.cluster_id is never populated by the real library — see
+    TestUpdateMetadataCapture in test_cluster_metrics_unit.py.)"""
     settings = global_settings()
     monkeypatch.setattr(settings.kafka, "cluster_metrics_enabled", True)
     test_cluster_id = "test-cluster-abc123"
-    producer._metadata.cluster_id = test_cluster_id
+    producer._metadata._nr_cluster_id = test_cluster_id
     return test_cluster_id
 
 


### PR DESCRIPTION
## What
Adds per-cluster, per-topic throughput metrics using the Kafka cluster UUID.

New metrics:
```
  MessageBroker/Kafka/Cluster/{cluster_id}/Produce/{topic}
  MessageBroker/Kafka/Cluster/{cluster_id}/Consume/{topic}
```

## How it works (optimized cluster ID resolution)

**confluent-kafka** — Producers resolve the cluster id at most once per instance via `list_topics(timeout=1)`, run on a background daemon thread rather than the calling `produce()` thread (with an in-flight guard so concurrent `produce()` calls don't each spawn one) — no separate AdminClient connection either way, and once resolved it's cached on the instance itself with no repeated fetches. Consumers never call `list_topics()` themselves — they read a shared `bootstrap_servers -> cluster_id` map that producers populate, since issuing that call from a Consumer risks a real use-after-free in librdkafka during partition rebalance (upstream issue #4214).

**kafka-python** — The real `ClusterMetadata` never stores a cluster id anywhere on itself (`update_metadata()` discards that field from the wire response), so reading it back later requires capturing it at the one point it's actually available: a new hook on `ClusterMetadata.update_metadata()` captures the id off the raw `MetadataResponse` argument as a passive side effect of the client's own normal metadata refresh, and `KafkaProducer`/`KafkaConsumer` read it back off that same object — no separate `KafkaAdminClient` connection needed.

Both drivers are gated behind the existing opt-in `kafka.cluster_metrics_enabled` setting.

## Metric name format + why no aggregation rework was needed

Per [agent-specs #817](https://source.datanerd.us/agents/agent-specs/pull/817)
review, the metric name now matches the `Nodes` shape (verb before topic, not
after): `Cluster/{id}/Produce/{topic}`, not `Cluster/{id}/Topic/{topic}/Produce`.

Separately, the spec no longer requires per-message emission — these metrics
exist to power entity relationships, not to report exact throughput, so counts
just need to be aggregated over the same interval as `Nodes`. No code rework
was needed for that: `record_custom_metric` already merges same-named metrics
into the transaction's `CustomMetrics` table (`TimeStats.merge_stats`) and that
table only rolls up into the harvest-period `StatsEngine` once per harvest —
the exact same mechanism the existing `Nodes` metric already uses. Calling it
once per message only costs an in-memory dict merge on the hot path; the data
New Relic receives was already one aggregated count per harvest interval, not
one per message.

## Bug fixes

- **confluent-kafka**: the cluster-id resolution call previously ran synchronously on the `produce()` hot path and only cached on success, so a sustained resolution failure (broker outage, ACL issue) meant every subsequent `produce()` call re-blocked on the same bounded call — worst exactly when fast failure matters most. Moved to the background thread described above. Also normalized whitespace in the bootstrap-servers cache key so equivalently-formatted broker lists share one cache entry.
- **kafka-python**: the existing attribute read (`instance._metadata.cluster_id` / `instance._client.cluster.cluster_id`) always returned `None` against the real library — `ClusterMetadata` never populates that attribute, so the feature did nothing for real usage despite passing tests (which had hand-seeded the attribute the real client never sets). Fixed by capturing the id from `update_metadata()`'s actual response argument, per above.

## NRQL
SELECT sum(newrelic.timeslice.value) FROM Metric
WHERE metricTimesliceName LIKE 'MessageBroker/Kafka/Cluster%'
FACET appName, metricTimesliceName SINCE 30 minutes ago
