### PR TITLE
Simplify SciKitLearn Tests

### DIFF
--- a/tests/mlmodel_sklearn/conftest.py
+++ b/tests/mlmodel_sklearn/conftest.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from sklearn import __version__
+import pytest
 from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
 _default_settings = {
@@ -32,3 +31,10 @@ collector_agent_registration = collector_agent_registration_fixture(
     default_settings=_default_settings,
     linked_applications=["Python Agent Test (mlmodel_sklearn)"],
 )
+
+
+@pytest.fixture(scope="session")
+def sklearn_version():
+    from sklearn import __version__
+
+    return tuple(map(int, __version__.split(".")[:2]))

--- a/tests/mlmodel_sklearn/test_multioutput_models.py
+++ b/tests/mlmodel_sklearn/test_multioutput_models.py
@@ -48,7 +48,7 @@ def test_model_methods_wrapped_in_function_trace(multioutput_model_name, run_mul
 
 
 @pytest.fixture
-def run_multioutput_model():
+def run_multioutput_model(sklearn_version):
     def _run(multioutput_model_name):
         import sklearn.multioutput
         from sklearn.datasets import make_multilabel_classification
@@ -56,7 +56,7 @@ def run_multioutput_model():
         X, y = make_multilabel_classification(n_classes=3, random_state=0)
 
         kwargs = {"estimator": AdaBoostClassifier()}
-        if multioutput_model_name in ["RegressorChain", "ClassifierChain"]:
+        if multioutput_model_name in ["RegressorChain", "ClassifierChain"] and sklearn_version < (1, 9):
             kwargs = {"base_estimator": AdaBoostClassifier()}
 
         clf = getattr(sklearn.multioutput, multioutput_model_name)(**kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -258,7 +258,6 @@ deps =
     mlmodel_sklearn: pandas
     mlmodel_sklearn: protobuf
     mlmodel_sklearn: numpy
-    ; Temporarily pin scikit-learn to below v1.8.0
     mlmodel_sklearn-scikitlearnlatest: scikit-learn
     mlmodel_sklearn-scikitlearnlatest: scipy
     component_djangorestframework-djangorestframeworklatest: Django


### PR DESCRIPTION
# Overview

* SciKitLearn recently dropped the `base_estimator` argument in favor or `estimator`. Change over to the new name to keep the tests working as intended.