### PR TITLE
Modify garbage collection data sampler logic

### DIFF
--- a/newrelic/samplers/gc_data.py
+++ b/newrelic/samplers/gc_data.py
@@ -105,12 +105,11 @@ class _GCDataSource:
                 yield (f"GC/objects/{self.pid}/generation/{gen}", {"count": count})
 
         # Record object count for top five types with highest count
-        if hasattr(gc, "get_objects"):
+        if hasattr(gc, "get_objects") and self.top_object_count_limit > 0:
             object_types = map(type, gc.get_objects())
-            if self.top_object_count_limit > 0:
-                highest_types = Counter(object_types).most_common(self.top_object_count_limit)
-                for obj_type, count in highest_types:
-                    yield (f"GC/objects/{self.pid}/type/{callable_name(obj_type)}", {"count": count})
+            highest_types = Counter(object_types).most_common(self.top_object_count_limit)
+            for obj_type, count in highest_types:
+                yield (f"GC/objects/{self.pid}/type/{callable_name(obj_type)}", {"count": count})
 
         if hasattr(gc, "get_stats"):
             stats_by_gen = gc.get_stats()


### PR DESCRIPTION
This PR gates calls to `gc.get_objects()` based on whether the configured value of  `top_object_count_limit` is greater than 0. This is done to avoid calls to `gc.get_objects()` if the user does not intend to track object types collected by the GC to reduce the chances of race conditions occurring by dumping the heap.