### PR TITLE
Agent Framework Bedrock Context Propagation

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -2314,6 +2314,12 @@ def _process_module_builtin_defaults():
     )
 
     _process_module_definition(
+        "agent_framework_bedrock",
+        "newrelic.hooks.mlmodel_agentframework",
+        "instrument_agent_framwork_bedrock__chat_client",
+    )
+
+    _process_module_definition(
         "asyncio.base_events", "newrelic.hooks.coroutines_asyncio", "instrument_asyncio_base_events"
     )
 

--- a/newrelic/hooks/mlmodel_agentframework.py
+++ b/newrelic/hooks/mlmodel_agentframework.py
@@ -48,9 +48,13 @@ def wrap_BedrockChatClient__invoke_converse(wrapped, instance, args, kwargs):
 def wrap_BedrockChatClient__prepare_options(wrapped, instance, args, kwargs):
     request = wrapped(*args, **kwargs)
 
+    trace = current_trace()
+    if not trace:
+        return request
+
     # Attach the current trace to the request so we can resume it inside the asyncio.to_thread call
     try:
-        request["_nr_trace"] = current_trace()
+        request["_nr_trace"] = trace
     except Exception:
         _logger.debug(BEDROCK_CONTEXT_FAILURE_MESSAGE)
 

--- a/newrelic/hooks/mlmodel_agentframework.py
+++ b/newrelic/hooks/mlmodel_agentframework.py
@@ -1,0 +1,66 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+
+from newrelic.api.time_trace import current_trace
+from newrelic.common.object_wrapper import wrap_function_wrapper
+from newrelic.common.package_version_utils import get_package_version
+from newrelic.common.signature import bind_args
+from newrelic.core.context import ContextOf
+
+_logger = logging.getLogger(__name__)
+AGENT_FRAMEWORK_VERSION = get_package_version("agent-framework")
+BEDROCK_CONTEXT_FAILURE_MESSAGE = (
+    "Failed to grab existing trace and attach to request object in agent_framework_bedrock."
+)
+
+
+def wrap_BedrockChatClient__invoke_converse(wrapped, instance, args, kwargs):
+    bound_args = bind_args(wrapped, args, kwargs)
+
+    # Pop the current trace out of the request object and resume it on this thread
+    try:
+        request = bound_args["request"]
+        trace = request.pop("_nr_trace", None)
+    except Exception:
+        trace = None
+
+    if trace:
+        with ContextOf(trace=trace, strict=False):
+            return wrapped(*args, **kwargs)
+    else:
+        return wrapped(*args, **kwargs)
+
+
+def wrap_BedrockChatClient__prepare_options(wrapped, instance, args, kwargs):
+    request = wrapped(*args, **kwargs)
+
+    # Attach the current trace to the request so we can resume it inside the asyncio.to_thread call
+    try:
+        request["_nr_trace"] = current_trace()
+    except Exception:
+        _logger.debug(BEDROCK_CONTEXT_FAILURE_MESSAGE)
+
+    return request
+
+
+def instrument_agent_framwork_bedrock__chat_client(module):
+    if hasattr(module, "BedrockChatClient"):
+        if hasattr(module.BedrockChatClient, "_invoke_converse"):
+            wrap_function_wrapper(module, "BedrockChatClient._invoke_converse", wrap_BedrockChatClient__invoke_converse)
+
+        if hasattr(module.BedrockChatClient, "_prepare_options"):
+            wrap_function_wrapper(module, "BedrockChatClient._prepare_options", wrap_BedrockChatClient__prepare_options)

--- a/tests/mlmodel_agentframework/__init__.py
+++ b/tests/mlmodel_agentframework/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/mlmodel_agentframework/bedrock/__init__.py
+++ b/tests/mlmodel_agentframework/bedrock/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/mlmodel_agentframework/bedrock/_test_agent.py
+++ b/tests/mlmodel_agentframework/bedrock/_test_agent.py
@@ -1,0 +1,58 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from agent_framework import Agent
+
+MODEL = "anthropic.claude-3-sonnet-20240229-v1:0"
+AGENT_NAME = "my_agent"
+AGENT_INSTRUCTION = "Answer the user's question in one word."
+PROMPT = "What is the capital of France?"
+
+
+def build_agent(client, tools=None):
+    return Agent(client=client, name=AGENT_NAME, instructions=AGENT_INSTRUCTION, tools=tools)
+
+
+# TODO: This will house the expected events once Agent Framework instrumentation is written.
+
+# agent_recorded_event = [
+#     (
+#         {"type": "LlmAgent"},
+#         {
+#             "id": None,
+#             "name": AGENT_NAME,
+#             "span_id": None,
+#             "trace_id": "trace-id",
+#             "vendor": "agentframework",
+#             "ingest_source": "Python",
+#             "duration": None,
+#         },
+#     )
+# ]
+
+# agent_recorded_event_error = [
+#     (
+#         {"type": "LlmAgent"},
+#         {
+#             "id": None,
+#             "name": AGENT_NAME,
+#             "span_id": None,
+#             "trace_id": "trace-id",
+#             "vendor": "agentframework",
+#             "ingest_source": "Python",
+#             "duration": None,
+#             "error": True,
+#         },
+#     )
+# ]

--- a/tests/mlmodel_agentframework/bedrock/cassette.yaml
+++ b/tests/mlmodel_agentframework/bedrock/cassette.yaml
@@ -1,0 +1,46 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "What is the capital
+      of France?"}]}], "inferenceConfig": {"maxTokens": 1024}, "system": [{"text":
+      "Answer the user''s question in one word."}]}'
+    headers:
+      Content-Type:
+      - !!binary |
+        YXBwbGljYXRpb24vanNvbg==
+      authorization:
+      - XXXXXX
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-sonnet-20240229-v1%3A0/converse
+  response:
+    body:
+      string: '{"metrics": {"latencyMs": 1219}, "output": {"message": {"content":
+        [{"text": "Paris"}], "role": "assistant"}}, "stopReason": "end_turn", "usage":
+        {"inputTokens": 23, "outputTokens": 4, "serverToolUsage": {}, "totalTokens":
+        27}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Jul 2026 17:38:15 GMT
+      x-amzn-RequestId:
+      - 10e29e28-5f4b-4d0d-a7f0-eecc55c35038
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/mlmodel_agentframework/bedrock/conftest.py
+++ b/tests/mlmodel_agentframework/bedrock/conftest.py
@@ -1,0 +1,36 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+from testing_support.fixture.event_loop import event_loop as loop
+
+from ._test_agent import MODEL
+
+
+@pytest.fixture
+def bedrock_client(vcr_recording):
+    from agent_framework.amazon import BedrockChatClient
+
+    if vcr_recording:
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        if not (access_key and secret_key):
+            raise RuntimeError("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables required.")
+    else:
+        access_key = "NOT-A-REAL-SECRET"
+        secret_key = "NOT-A-REAL-SECRET"
+
+    return BedrockChatClient(model=MODEL, region="us-east-1", access_key=access_key, secret_key=secret_key)

--- a/tests/mlmodel_agentframework/bedrock/test_agent.py
+++ b/tests/mlmodel_agentframework/bedrock/test_agent.py
@@ -1,0 +1,84 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from testing_support.fixtures import dt_enabled, reset_core_stats_engine
+from testing_support.ml_testing_utils import (
+    disabled_ai_monitoring_record_content_settings,
+    disabled_ai_monitoring_settings,
+)
+from testing_support.validators.validate_custom_event import validate_custom_event_count
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
+from newrelic.api.llm_custom_attributes import WithLlmCustomAttributes
+
+from ._test_agent import PROMPT, build_agent
+
+# 4 events from the Bedrock Converse round-trip:
+#  * 1 LlmChatCompletionSummary
+#  * 3 LlmChatCompletionMessage (system / user / assistant)
+# No other events yet as MAF instrumentation is not written.
+EXPECTED_EVENT_COUNT = 4
+
+
+@dt_enabled
+@reset_core_stats_engine()
+@validate_custom_event_count(EXPECTED_EVENT_COUNT)
+@validate_transaction_metrics("mlmodel_agentframework.bedrock.test_agent:test_agent", background_task=True)
+@background_task()
+def test_agent(exercise_agent, bedrock_client, set_trace_info):
+    set_trace_info()
+    agent = build_agent(bedrock_client)
+    with WithLlmCustomAttributes({"context": "attr"}):
+        response = exercise_agent(agent, PROMPT)
+
+    assert "Paris" in response.text
+
+
+@dt_enabled
+@reset_core_stats_engine()
+@disabled_ai_monitoring_record_content_settings
+@validate_custom_event_count(EXPECTED_EVENT_COUNT)
+@validate_transaction_metrics("mlmodel_agentframework.bedrock.test_agent:test_agent_no_content", background_task=True)
+@background_task()
+def test_agent_no_content(exercise_agent, bedrock_client, set_trace_info):
+    set_trace_info()
+    agent = build_agent(bedrock_client)
+    response = exercise_agent(agent, PROMPT)
+
+    assert "Paris" in response.text
+
+
+@dt_enabled
+@reset_core_stats_engine()
+@disabled_ai_monitoring_settings
+@validate_custom_event_count(0)
+@validate_transaction_metrics("mlmodel_agentframework.bedrock.test_agent:test_agent_disabled_ai_monitoring", background_task=True)
+@background_task()
+def test_agent_disabled_ai_monitoring(exercise_agent, bedrock_client, set_trace_info):
+    set_trace_info()
+    agent = build_agent(bedrock_client)
+    response = exercise_agent(agent, PROMPT)
+
+    assert "Paris" in response.text
+
+
+@reset_core_stats_engine()
+@validate_custom_event_count(0)
+def test_agent_outside_transaction(exercise_agent, bedrock_client, set_trace_info):
+    set_trace_info()
+    agent = build_agent(bedrock_client)
+    response = exercise_agent(agent, PROMPT)
+
+    assert "Paris" in response.text

--- a/tests/mlmodel_agentframework/bedrock/test_agent.py
+++ b/tests/mlmodel_agentframework/bedrock/test_agent.py
@@ -64,7 +64,9 @@ def test_agent_no_content(exercise_agent, bedrock_client, set_trace_info):
 @reset_core_stats_engine()
 @disabled_ai_monitoring_settings
 @validate_custom_event_count(0)
-@validate_transaction_metrics("mlmodel_agentframework.bedrock.test_agent:test_agent_disabled_ai_monitoring", background_task=True)
+@validate_transaction_metrics(
+    "mlmodel_agentframework.bedrock.test_agent:test_agent_disabled_ai_monitoring", background_task=True
+)
 @background_task()
 def test_agent_disabled_ai_monitoring(exercise_agent, bedrock_client, set_trace_info):
     set_trace_info()

--- a/tests/mlmodel_agentframework/conftest.py
+++ b/tests/mlmodel_agentframework/conftest.py
@@ -57,4 +57,5 @@ def exercise_agent(loop, request):
                 return await agent.run(prompt)
 
         return loop.run_until_complete(_exercise())
+
     return _exercise_agent

--- a/tests/mlmodel_agentframework/conftest.py
+++ b/tests/mlmodel_agentframework/conftest.py
@@ -1,0 +1,50 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixture.vcr import *  # noqa: F403
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
+from testing_support.ml_testing_utils import set_trace_info
+
+from newrelic.common.package_version_utils import get_package_version, get_package_version_tuple
+
+_default_settings = {
+    "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slowdowns.
+    "transaction_tracer.explain_threshold": 0.0,
+    "transaction_tracer.transaction_threshold": 0.0,
+    "transaction_tracer.stack_trace_threshold": 0.0,
+    "debug.log_data_collector_payloads": True,
+    "debug.record_transaction_failure": True,
+    "ai_monitoring.enabled": True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+    app_name="Python Agent Test (mlmodel_agentframework)",
+    default_settings=_default_settings,
+    linked_applications=["Python Agent Test (mlmodel_agentframework)"],
+)
+
+
+AGENT_FRAMEWORK_VERSION_TUPLE = get_package_version_tuple("agent-framework")
+AGENT_FRAMEWORK_VERSION = get_package_version("agent-framework")
+assert AGENT_FRAMEWORK_VERSION, "Failed to pull agent-framework version for supportability metric"
+
+
+@pytest.fixture
+def exercise_agent(loop):
+    def _exercise_agent(agent, prompt):
+        return loop.run_until_complete(agent.run(prompt))
+
+    return _exercise_agent

--- a/tests/mlmodel_agentframework/conftest.py
+++ b/tests/mlmodel_agentframework/conftest.py
@@ -42,9 +42,19 @@ AGENT_FRAMEWORK_VERSION = get_package_version("agent-framework")
 assert AGENT_FRAMEWORK_VERSION, "Failed to pull agent-framework version for supportability metric"
 
 
-@pytest.fixture
-def exercise_agent(loop):
-    def _exercise_agent(agent, prompt):
-        return loop.run_until_complete(agent.run(prompt))
+@pytest.fixture(params=[False, True], ids=["ResponseStandard", "ResponseStreaming"])
+def exercise_agent(loop, request):
+    is_streaming = request.param
 
+    def _exercise_agent(agent, prompt):
+        async def _exercise():
+            if is_streaming:
+                response_stream = agent.run(prompt, stream=True)
+                async for _ in response_stream:
+                    pass
+                return await response_stream.get_final_response()
+            else:
+                return await agent.run(prompt)
+
+        return loop.run_until_complete(_exercise())
     return _exercise_agent

--- a/tests/testing_support/fixture/vcr.py
+++ b/tests/testing_support/fixture/vcr.py
@@ -96,6 +96,10 @@ VCR_IGNORED_HEADERS = [
     "user-agent",
     "strict-transport-security",
     "x-content-type-options",
+    # AWS Bedrock
+    "amz-sdk-invocation-id",
+    "amz-sdk-request",
+    "x-amz-date",
     # Google Gemini
     "x-goog-api-client",
     # OpenAI Headers

--- a/tox.ini
+++ b/tox.ini
@@ -182,7 +182,7 @@ envlist =
     python-logger_logging-{py39,py310,py311,py312,py313,py314,py314t,pypy311},
     python-logger_loguru-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-logurulatest,
     python-logger_structlog-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-structloglatest,
-    python-mlmodel_agentframework-{py310,py311,py312,py313,py314,pypy311}-agentframeworklatest,
+    python-mlmodel_agentframework-{py310,py311,py312,py313,py314}-agentframeworklatest,
     python-mlmodel_anthropic-{py39,py310,py311,py312,py313,py314,py314t},
     python-mlmodel_autogen-{py310,py311,py312,py313,py314,py314t}-autogen061,
     python-mlmodel_autogen-{py310,py311,py312,py313,py314,py314t}-autogenlatest,

--- a/tox.ini
+++ b/tox.ini
@@ -182,14 +182,15 @@ envlist =
     python-logger_logging-{py39,py310,py311,py312,py313,py314,py314t,pypy311},
     python-logger_loguru-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-logurulatest,
     python-logger_structlog-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-structloglatest,
+    python-mlmodel_agentframework-{py310,py311,py312,py313,py314,pypy311}-agentframeworklatest,
+    python-mlmodel_anthropic-{py39,py310,py311,py312,py313,py314,py314t},
     python-mlmodel_autogen-{py310,py311,py312,py313,py314,py314t}-autogen061,
     python-mlmodel_autogen-{py310,py311,py312,py313,py314,py314t}-autogenlatest,
+    python-mlmodel_gemini-{py39,py310,py311,py312,py313,py314,py314t},
     python-mlmodel_googleadk-{py310,py311,py312,py313}-googleadk01,
     python-mlmodel_googleadk-{py310,py311,py312,py313,py314}-googleadklatest,
-    python-mlmodel_strands-{py310,py311,py312,py313}-strandslatest,
-    python-mlmodel_anthropic-{py39,py310,py311,py312,py313,py314,py314t},
-    python-mlmodel_gemini-{py39,py310,py311,py312,py313,py314,py314t},
     python-mlmodel_langchain-{py310,py311,py312,py313},
+    python-mlmodel_strands-{py310,py311,py312,py313}-strandslatest,
     ;; Package not ready for Python 3.14 (type annotations not updated)
     ; python-mlmodel_langchain-{py314,py314t},
     python-mlmodel_openai-openai0-{py39,py310,py311,py312},
@@ -457,6 +458,10 @@ deps =
     hybridagent_strawberry: opentelemetry-api
     hybridagent_strawberry: starlette
     hybridagent_strawberry: strawberry-graphql[asgi]
+    mlmodel_agentframework: agent-framework
+    mlmodel_agentframework: agent-framework-bedrock
+    mlmodel_agentframework: pytest-recording
+    mlmodel_anthropic: anthropic
     mlmodel_autogen-autogen061: autogen-agentchat<0.6.2
     mlmodel_autogen-autogen061: autogen-core<0.6.2
     mlmodel_autogen-autogen061: autogen-ext<0.6.2
@@ -464,7 +469,6 @@ deps =
     mlmodel_autogen-autogenlatest: autogen-ext
     mlmodel_autogen-autogenlatest: autogen-agentchat
     mlmodel_autogen: mcp
-    mlmodel_anthropic: anthropic
     mlmodel_gemini: pytest-recording
     mlmodel_gemini: google-genai
     mlmodel_googleadk-googleadk01: google-adk<2
@@ -635,8 +639,9 @@ changedir =
     messagebroker_kafkapython: tests/messagebroker_kafkapython
     messagebroker_kombu: tests/messagebroker_kombu
     messagebroker_pika: tests/messagebroker_pika
-    mlmodel_autogen: tests/mlmodel_autogen
+    mlmodel_agentframework: tests/mlmodel_agentframework
     mlmodel_anthropic: tests/mlmodel_anthropic
+    mlmodel_autogen: tests/mlmodel_autogen
     mlmodel_gemini: tests/mlmodel_gemini
     mlmodel_googleadk: tests/mlmodel_googleadk
     mlmodel_langchain: tests/mlmodel_langchain


### PR DESCRIPTION
# Overview

* Adds context propagation to thread boundaries in `agent_framework_bedrock` invocations to allow LLM data to be captured.
* Add test coverage that validates `agent_framework_bedrock` is now transparent to instrumentation and `botocore` produces LLM events.
* Does NOT include a full instrumentation of `agent_framework`.