### PR TITLE
Remove byte encoding for DT headers in Kombu instrumentation.

### DIFF
--- a/newrelic/hooks/messagebroker_kombu.py
+++ b/newrelic/hooks/messagebroker_kombu.py
@@ -115,7 +115,7 @@ def wrap_Producer_publish(wrapped, instance, args, kwargs):
         source=wrapped,
         terminal=False,
     ):
-        dt_headers = {k: v.encode("utf-8") for k, v in MessageTrace.generate_request_headers(transaction)}
+        dt_headers = dict(MessageTrace.generate_request_headers(transaction))
         if headers:
             dt_headers.update(headers)
 

--- a/tests/messagebroker_kombu/test_producer.py
+++ b/tests/messagebroker_kombu/test_producer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 import pytest
 from conftest import cache_kombu_producer_headers
 from kombu.exceptions import EncodeError
@@ -67,6 +69,31 @@ def test_distributed_tracing_headers(exchange, send_producer_message):
         send_producer_message()
 
     test()
+
+
+def test_distributed_tracing_headers_are_json_serializable(exchange, send_producer_message):
+    # Regression test for dropping DT header byte encoding
+    # (done to support kombu's sqlalchemy transport, which serializes the
+    # message envelope with the stdlib json module and can't encode bytes).
+
+    captured_headers = {}
+
+    @transient_function_wrapper("kombu.messaging", "Producer.publish.__wrapped__")
+    def capture_headers_before_publish(wrapped, instance, args, kwargs):
+        captured_headers.update(kwargs.get("headers") or {})
+        return wrapped(*args, **kwargs)
+
+    @background_task()
+    @capture_headers_before_publish
+    @cache_kombu_producer_headers
+    def test():
+        send_producer_message()
+
+    test()
+
+    assert all(isinstance(v, str) for v in captured_headers.values()), captured_headers
+    # Shouldn't raise an exception when converting the headers to JSON
+    json.dumps(captured_headers)
 
 
 def test_distributed_tracing_headers_under_terminal(exchange, send_producer_message):


### PR DESCRIPTION
This PR removes byte encoding for DT headers in Kombu instrumentation in order to support transports that serialize  payloads with the stdlib json module (ex: sqlalchemy).
