### PR TITLE
Fix Google Adk Tox Requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -468,6 +468,7 @@ deps =
     mlmodel_gemini: pytest-recording
     mlmodel_gemini: google-genai
     mlmodel_googleadk-googleadk01: google-adk<2
+    mlmodel_googleadk-googleadk01: opentelemetry-resourcedetector-gcp>=1.12.0a0  # Fixes only non-prerelease version being yanked
     mlmodel_googleadk-googleadklatest: google-adk
     mlmodel_googleadk: pytest-recording
     mlmodel_openai-openai0: openai[datalib]<1.0


### PR DESCRIPTION
# Overview

* Due to a yanked release, google-adk is failing to find any version of `opentelemetry-resourcedetector-gcp` that's installable. The only other versions were in pre-release, so explicitly include the last pre-release as an acceptable version.