### PR TITLE
Swap to Trace Cache ID in LangChain and AgentFramework

### DIFF
--- a/newrelic/hooks/mlmodel_agentframework.py
+++ b/newrelic/hooks/mlmodel_agentframework.py
@@ -34,12 +34,12 @@ def wrap_BedrockChatClient__invoke_converse(wrapped, instance, args, kwargs):
     # Pop the current trace out of the request object and resume it on this thread
     try:
         request = bound_args["request"]
-        trace = request.pop("_nr_trace", None)
+        trace_cache_id = request.pop("_nr_trace_id", None)
     except Exception:
-        trace = None
+        trace_cache_id = None
 
-    if trace:
-        with ContextOf(trace=trace, strict=False):
+    if trace_cache_id:
+        with ContextOf(trace_cache_id=trace_cache_id, strict=False):
             return wrapped(*args, **kwargs)
     else:
         return wrapped(*args, **kwargs)
@@ -54,7 +54,7 @@ def wrap_BedrockChatClient__prepare_options(wrapped, instance, args, kwargs):
 
     # Attach the current trace to the request so we can resume it inside the asyncio.to_thread call
     try:
-        request["_nr_trace"] = trace
+        request["_nr_trace_id"] = trace.thread_id
     except Exception:
         _logger.debug(BEDROCK_CONTEXT_FAILURE_MESSAGE)
 

--- a/newrelic/hooks/mlmodel_langchain.py
+++ b/newrelic/hooks/mlmodel_langchain.py
@@ -1375,11 +1375,11 @@ def wrap_StructuredTool_invoke(wrapped, instance, args, kwargs):
 
     metadata = bind_args(wrapped, args, kwargs).get("config", {}).get("metadata", {})
     # Delete the reference after grabbing it to avoid it ending up in LangChain attributes
-    trace = metadata.pop("_nr_trace", None)
-    if not trace:
+    trace_cache_id = metadata.pop("_nr_trace_id", None)
+    if not trace_cache_id:
         return wrapped(*args, **kwargs)
 
-    with ContextOf(trace=trace):
+    with ContextOf(trace_cache_id=trace_cache_id):
         return wrapped(*args, **kwargs)
 
 
@@ -1391,12 +1391,12 @@ async def wrap_StructuredTool_ainvoke(wrapped, instance, args, kwargs):
         return await wrapped(*args, **kwargs)
 
     metadata = bind_args(wrapped, args, kwargs).get("config", {}).get("metadata", {})
-    metadata["_nr_trace"] = trace
+    metadata["_nr_trace_id"] = trace.thread_id
 
     try:
         return await wrapped(*args, **kwargs)
     finally:
-        metadata.pop("_nr_trace", None)
+        metadata.pop("_nr_trace_id", None)
 
 
 def instrument_langchain_runnables_chains_base(module):

--- a/tox.ini
+++ b/tox.ini
@@ -437,7 +437,7 @@ deps =
     hybridagent_kafkapython: kafka-python<2.1
     hybridagent_mysql: opentelemetry-api
     hybridagent_mysql: opentelemetry-instrumentation-mysql
-    hybridagent_mysql: mysql-connector-python
+    hybridagent_mysql: mysql-connector-python<26
     hybridagent_mysql: protobuf<4
     hybridagent_opentelemetry: opentelemetry-api
     hybridagent_pika: opentelemetry-api


### PR DESCRIPTION
# Overview

* For context propagation purposes, swap the langchain and agent-framework instrumentation to only store the trace cache ID rather than the full trace in a ref.
  * This is to prevent these objects from getting serialized unexpectedly in the case of leaks. The ID is a much smaller object while the trace could contain MBs of data.