### PR TITLE
Instrument New Redis Commands

### DIFF
--- a/.github/containers/rediscluster/Dockerfile
+++ b/.github/containers/rediscluster/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM redis:7.0.12
+FROM redis:latest
 
 COPY <<"EOF" /etc/redis.conf
 bind 0.0.0.0

--- a/newrelic/hooks/datastore_redis.py
+++ b/newrelic/hooks/datastore_redis.py
@@ -25,6 +25,7 @@ _redis_client_sync_methods = {
     "auth",
     "bgrewriteaof",
     "bitfield",
+    "blmovem",
     "blmpop",
     "bzmpop",
     "client",
@@ -41,6 +42,9 @@ _redis_client_sync_methods = {
     "hexpiretime",
     "hgetdel",
     "hgetex",
+    "himport_discard_all_internal",
+    "himport_discard_internal",
+    "himport_prepare_internal",
     "hotkeys_get",
     "hotkeys_reset",
     "hotkeys_start",
@@ -56,18 +60,24 @@ _redis_client_sync_methods = {
     "latency_graph",
     "latency_histogram",
     "lcs",
+    "lmovem",
     "lpop",
     "lpos",
     "memory_doctor",
     "memory_help",
     "monitor",
+    "nrange",
+    "nrevrange",
     "pexpiretime",
     "psetex",
     "psync",
     "pubsub",
+    "querylabels",
+    "read",
     "renamenx",
     "rpop",
     "script_debug",
+    "sdiffcard",
     "sentinel_ckquorum",
     "sentinel_failover",
     "sentinel_flushconfig",
@@ -85,6 +95,7 @@ _redis_client_sync_methods = {
     "sort",
     "spop",
     "srandmember",
+    "sunioncard",
     "unwatch",
     "vadd",
     "vcard",
@@ -126,6 +137,7 @@ _redis_client_async_methods = {
     "aggregate",
     "aliasadd",
     "aliasdel",
+    "aliaslist",
     "aliasupdate",
     "alter_schema_add",
     "alter",
@@ -553,17 +565,22 @@ def _instance_info(kwargs):
     return (host, port_path_or_id, db)
 
 
-def _wrap_Redis_method_wrapper_(module, instance_class_name, operation):
-    name = f"{instance_class_name}.{operation}"
-    if operation in _redis_client_gen_methods:
+def _wrap_Redis_method_wrapper_(module, instance_class_name, method_name):
+    name = f"{instance_class_name}.{method_name}"
+    if method_name in _redis_client_gen_methods:
         async_wrapper = generator_wrapper
     else:
         async_wrapper = None
 
+    # For methods with a internal helper, the internal method is wrapped but
+    # we need to remove that suffix before reporting it to match the API the
+    # user actually called.
+    operation = method_name.removesuffix("_internal")
+
     wrap_datastore_trace(module, name, product="Redis", target=None, operation=operation, async_wrapper=async_wrapper)
 
 
-def _wrap_asyncio_Redis_method_wrapper(module, instance_class_name, operation):
+def _wrap_asyncio_Redis_method_wrapper(module, instance_class_name, method_name):
     def _nr_wrapper_asyncio_Redis_method_(wrapped, instance, args, kwargs):
         from redis.asyncio.client import Pipeline
 
@@ -575,11 +592,16 @@ def _wrap_asyncio_Redis_method_wrapper(module, instance_class_name, operation):
             wrapped, product="Redis", target=None, operation=operation, async_wrapper=async_wrapper
         )(*args, **kwargs)
 
-    name = f"{instance_class_name}.{operation}"
-    if operation in _redis_client_gen_methods:
+    name = f"{instance_class_name}.{method_name}"
+    if method_name in _redis_client_gen_methods:
         async_wrapper = async_generator_wrapper
     else:
         async_wrapper = coroutine_wrapper
+
+    # For methods with a internal helper, the internal method is wrapped but
+    # we need to remove that suffix before reporting it to match the API the
+    # user actually called.
+    operation = method_name.removesuffix("_internal")
 
     wrap_function_wrapper(module, name, _nr_wrapper_asyncio_Redis_method_)
 

--- a/tests/datastore_redis/conftest.py
+++ b/tests/datastore_redis/conftest.py
@@ -17,6 +17,8 @@ from testing_support.db_settings import redis_settings
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
+from newrelic.common.package_version_utils import get_package_version_tuple
+
 _default_settings = {
     "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.
     "transaction_tracer.explain_threshold": 0.0,
@@ -34,17 +36,17 @@ collector_agent_registration = collector_agent_registration_fixture(
 
 DB_SETTINGS = redis_settings()[0]
 
+REDIS_PY_VERSION = get_package_version_tuple("redis")
+
 
 @pytest.fixture(scope="session")
 def connection_kwargs():
     kwargs = {"host": DB_SETTINGS["host"], "port": DB_SETTINGS["port"], "db": 0}
 
-    try:
+    if REDIS_PY_VERSION >= (8, 1, 0):
         from redis.maint_notifications import MaintNotificationsConfig
 
         kwargs["maint_notifications_config"] = MaintNotificationsConfig(enabled=False)
-    except ImportError:
-        pass
 
     return kwargs
 

--- a/tests/datastore_redis/conftest.py
+++ b/tests/datastore_redis/conftest.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import pytest
+from testing_support.db_settings import redis_settings
 from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
 
@@ -30,3 +31,53 @@ collector_agent_registration = collector_agent_registration_fixture(
     default_settings=_default_settings,
     linked_applications=["Python Agent Test (datastore)"],
 )
+
+DB_SETTINGS = redis_settings()[0]
+
+
+@pytest.fixture(scope="session")
+def connection_kwargs():
+    kwargs = {"host": DB_SETTINGS["host"], "port": DB_SETTINGS["port"], "db": 0}
+
+    try:
+        from redis.maint_notifications import MaintNotificationsConfig
+
+        kwargs["maint_notifications_config"] = MaintNotificationsConfig(enabled=False)
+    except ImportError:
+        pass
+
+    return kwargs
+
+
+@pytest.fixture(scope="session", params=("Redis", "StrictRedis"))
+def client(request, connection_kwargs):
+    def _client():
+        import redis
+
+        if request.param == "Redis":
+            return redis.Redis(**connection_kwargs)
+        else:
+            return redis.StrictRedis(**connection_kwargs)
+
+    return _client
+
+
+@pytest.fixture(scope="session")
+def async_client(loop, connection_kwargs):
+    def _client():
+        import redis
+
+        return loop.run_until_complete(redis.asyncio.Redis(**connection_kwargs))
+
+    return _client
+
+
+@pytest.fixture
+def async_client_pool(loop, connection_kwargs):
+    def _client_pool():
+        import redis.asyncio
+
+        connection_pool = redis.asyncio.ConnectionPool(**connection_kwargs)
+        return loop.run_until_complete(redis.asyncio.Redis(connection_pool=connection_pool))
+
+    return _client_pool

--- a/tests/datastore_redis/test_asyncio.py
+++ b/tests/datastore_redis/test_asyncio.py
@@ -15,7 +15,8 @@
 import asyncio
 from uuid import uuid4
 
-import pytest
+from conftest import async_client as client
+from conftest import async_client_pool as client_pool
 from testing_support.db_settings import redis_settings
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
@@ -64,21 +65,6 @@ _base_pool_rollup_metrics = [
 # Tests
 
 
-@pytest.fixture
-def client(loop):
-    import redis.asyncio
-
-    return loop.run_until_complete(redis.asyncio.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0))
-
-
-@pytest.fixture
-def client_pool(loop):
-    import redis.asyncio
-
-    connection_pool = redis.asyncio.ConnectionPool(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    return loop.run_until_complete(redis.asyncio.Redis(connection_pool=connection_pool))
-
-
 @validate_transaction_metrics(
     "test_asyncio:test_async_connection_pool",
     scoped_metrics=_base_pool_scoped_metrics,
@@ -87,6 +73,8 @@ def client_pool(loop):
 )
 @background_task()
 def test_async_connection_pool(client_pool, loop):
+    client_pool = client_pool()
+
     async def _test_async_pool(client_pool):
         await client_pool.set("key1", "value1")
         await client_pool.get("key1")
@@ -98,6 +86,8 @@ def test_async_connection_pool(client_pool, loop):
 @validate_transaction_metrics("test_asyncio:test_async_pipeline", background_task=True)
 @background_task()
 def test_async_pipeline(client, loop):
+    client = client()
+
     async def _test_pipeline(client):
         async with client.pipeline(transaction=True) as pipe:
             await pipe.set("key1", "value1")
@@ -114,6 +104,8 @@ def test_async_pipeline(client, loop):
 )
 @background_task()
 def test_async_pubsub(client, loop):
+    client = client()
+
     messages_received = []
     message_received = asyncio.Event()
 

--- a/tests/datastore_redis/test_asyncio.py
+++ b/tests/datastore_redis/test_asyncio.py
@@ -17,40 +17,28 @@ from uuid import uuid4
 
 import pytest
 from testing_support.db_settings import redis_settings
-from testing_support.fixture.event_loop import event_loop as loop
 from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version_tuple
 
 # Settings
 
 DB_SETTINGS = redis_settings()[0]
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 # Metrics for publish test
 
-datastore_all_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
-
-_base_scoped_metrics = [("Datastore/operation/Redis/publish", 3)]
-
-if REDIS_PY_VERSION >= (5, 0):
-    _base_scoped_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
+_base_scoped_metrics = [("Datastore/operation/Redis/publish", 3), ("Datastore/operation/Redis/client_setinfo", 2)]
 
 _base_rollup_metrics = [
-    ("Datastore/all", datastore_all_metric_count),
-    ("Datastore/allOther", datastore_all_metric_count),
-    ("Datastore/Redis/all", datastore_all_metric_count),
-    ("Datastore/Redis/allOther", datastore_all_metric_count),
+    ("Datastore/all", 5),
+    ("Datastore/allOther", 5),
+    ("Datastore/Redis/all", 5),
+    ("Datastore/Redis/allOther", 5),
     ("Datastore/operation/Redis/publish", 3),
-    (
-        f"Datastore/instance/Redis/{instance_hostname(DB_SETTINGS['host'])}/{DB_SETTINGS['port']}",
-        datastore_all_metric_count,
-    ),
+    (f"Datastore/instance/Redis/{instance_hostname(DB_SETTINGS['host'])}/{DB_SETTINGS['port']}", 5),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-if REDIS_PY_VERSION >= (5, 0):
-    _base_rollup_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
 
 # Metrics for connection pool test
@@ -91,7 +79,6 @@ def client_pool(loop):
     return loop.run_until_complete(redis.asyncio.Redis(connection_pool=connection_pool))
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")
 @validate_transaction_metrics(
     "test_asyncio:test_async_connection_pool",
     scoped_metrics=_base_pool_scoped_metrics,
@@ -108,7 +95,6 @@ def test_async_connection_pool(client_pool, loop):
     loop.run_until_complete(_test_async_pool(client_pool))
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")
 @validate_transaction_metrics("test_asyncio:test_async_pipeline", background_task=True)
 @background_task()
 def test_async_pipeline(client, loop):
@@ -120,7 +106,6 @@ def test_async_pipeline(client, loop):
     loop.run_until_complete(_test_pipeline(client))
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="This functionality exists in Redis 4.2+")
 @validate_transaction_metrics(
     "test_asyncio:test_async_pubsub",
     scoped_metrics=_base_scoped_metrics,

--- a/tests/datastore_redis/test_custom_conn_pool.py
+++ b/tests/datastore_redis/test_custom_conn_pool.py
@@ -65,37 +65,31 @@ _disable_instance_settings = {"datastore_tracer.instance_reporting.enabled": Fal
 
 # We don't record instance metrics when using redis blaster,
 # so we just check for base metrics.
-datastore_all_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
 
 _base_scoped_metrics = [
     ("Datastore/operation/Redis/get", 1),
     ("Datastore/operation/Redis/set", 1),
     ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-# client_setinfo was introduced in v5.0.0 and assigns info displayed in client_list output
-if REDIS_PY_VERSION >= (5, 0):
-    _base_scoped_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
 _base_rollup_metrics = [
-    ("Datastore/all", datastore_all_metric_count),
-    ("Datastore/allOther", datastore_all_metric_count),
-    ("Datastore/Redis/all", datastore_all_metric_count),
-    ("Datastore/Redis/allOther", datastore_all_metric_count),
+    ("Datastore/all", 5),
+    ("Datastore/allOther", 5),
+    ("Datastore/Redis/all", 5),
+    ("Datastore/Redis/allOther", 5),
     ("Datastore/operation/Redis/get", 1),
     ("Datastore/operation/Redis/set", 1),
     ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-if REDIS_PY_VERSION >= (5, 0):
-    _base_rollup_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
 _host = instance_hostname(DB_SETTINGS["host"])
 _port = DB_SETTINGS["port"]
 
 _instance_metric_name = f"Datastore/instance/Redis/{_host}/{_port}"
 
-instance_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
-
-_enable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, instance_metric_count))
+_enable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, 5))
 
 _disable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, None))
 

--- a/tests/datastore_redis/test_custom_conn_pool.py
+++ b/tests/datastore_redis/test_custom_conn_pool.py
@@ -114,8 +114,8 @@ def exercise_redis(client):
     background_task=True,
 )
 @background_task()
-def test_fake_conn_pool_enable_instance(command_name):
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
+def test_fake_conn_pool_enable_instance(client, command_name):
+    client = client()
 
     # Get a real connection
 
@@ -140,8 +140,8 @@ def test_fake_conn_pool_enable_instance(command_name):
     background_task=True,
 )
 @background_task()
-def test_fake_conn_pool_disable_instance(command_name):
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
+def test_fake_conn_pool_disable_instance(client, command_name):
+    client = client()
 
     # Get a real connection
 

--- a/tests/datastore_redis/test_custom_conn_pool.py
+++ b/tests/datastore_redis/test_custom_conn_pool.py
@@ -18,7 +18,7 @@ will not result in an error.
 """
 
 import pytest
-import redis
+from conftest import REDIS_PY_VERSION
 from testing_support.db_settings import redis_settings
 from testing_support.fixtures import override_application_settings
 from testing_support.util import instance_hostname
@@ -28,7 +28,6 @@ from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_SETTINGS = redis_settings()[0]
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 
 class FakeConnectionPool:

--- a/tests/datastore_redis/test_execute_command.py
+++ b/tests/datastore_redis/test_execute_command.py
@@ -20,7 +20,6 @@ from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_SETTINGS = redis_settings()[0]
 
@@ -63,41 +62,14 @@ def exercise_redis_single_arg(client):
 
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
-    "test_execute_command:test_strict_redis_execute_command_two_args_enable",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_enable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_execute_command_two_args_enable():
-    r = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_multi_args(r)
-
-
-@override_application_settings(_disable_instance_settings)
-@validate_transaction_metrics(
-    "test_execute_command:test_strict_redis_execute_command_two_args_disabled",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_disable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_execute_command_two_args_disabled():
-    r = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_multi_args(r)
-
-
-@override_application_settings(_enable_instance_settings)
-@validate_transaction_metrics(
     "test_execute_command:test_redis_execute_command_two_args_enable",
     scoped_metrics=_base_scoped_metrics,
     rollup_metrics=_enable_rollup_metrics,
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_two_args_enable():
-    r = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_multi_args(r)
+def test_redis_execute_command_two_args_enable(client):
+    exercise_redis_multi_args(client())
 
 
 @override_application_settings(_disable_instance_settings)
@@ -108,35 +80,8 @@ def test_redis_execute_command_two_args_enable():
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_two_args_disabled():
-    r = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_multi_args(r)
-
-
-@override_application_settings(_enable_instance_settings)
-@validate_transaction_metrics(
-    "test_execute_command:test_strict_redis_execute_command_as_one_arg_enable",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_enable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_execute_command_as_one_arg_enable():
-    r = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_single_arg(r)
-
-
-@override_application_settings(_disable_instance_settings)
-@validate_transaction_metrics(
-    "test_execute_command:test_strict_redis_execute_command_as_one_arg_disabled",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_disable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_execute_command_as_one_arg_disabled():
-    r = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_single_arg(r)
+def test_redis_execute_command_two_args_disabled(client):
+    exercise_redis_multi_args(client())
 
 
 @override_application_settings(_enable_instance_settings)
@@ -147,9 +92,8 @@ def test_strict_redis_execute_command_as_one_arg_disabled():
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_one_arg_enable():
-    r = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_single_arg(r)
+def test_redis_execute_command_as_one_arg_enable(client):
+    exercise_redis_single_arg(client())
 
 
 @override_application_settings(_disable_instance_settings)
@@ -160,6 +104,5 @@ def test_redis_execute_command_as_one_arg_enable():
     background_task=True,
 )
 @background_task()
-def test_redis_execute_command_as_one_arg_disabled():
-    r = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis_single_arg(r)
+def test_redis_execute_command_as_one_arg_disabled(client):
+    exercise_redis_single_arg(client())

--- a/tests/datastore_redis/test_execute_command.py
+++ b/tests/datastore_redis/test_execute_command.py
@@ -23,7 +23,6 @@ from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_SETTINGS = redis_settings()[0]
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 
 # Settings
@@ -33,9 +32,7 @@ _disable_instance_settings = {"datastore_tracer.instance_reporting.enabled": Fal
 
 # Metrics
 
-_base_scoped_metrics = [("Datastore/operation/Redis/client_list", 1)]
-if REDIS_PY_VERSION >= (5, 0):
-    _base_scoped_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
+_base_scoped_metrics = [("Datastore/operation/Redis/client_list", 1), ("Datastore/operation/Redis/client_setinfo", 2)]
 
 _base_rollup_metrics = [
     ("Datastore/all", 3),
@@ -43,18 +40,15 @@ _base_rollup_metrics = [
     ("Datastore/Redis/all", 3),
     ("Datastore/Redis/allOther", 3),
     ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-if REDIS_PY_VERSION >= (5, 0):
-    _base_rollup_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
 _host = instance_hostname(DB_SETTINGS["host"])
 _port = DB_SETTINGS["port"]
 
 _instance_metric_name = f"Datastore/instance/Redis/{_host}/{_port}"
 
-instance_metric_count = 3 if REDIS_PY_VERSION >= (5, 0) else 1
-
-_enable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, instance_metric_count))
+_enable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, 3))
 
 _disable_rollup_metrics = _base_rollup_metrics.append((_instance_metric_name, None))
 
@@ -119,7 +113,6 @@ def test_redis_execute_command_two_args_disabled():
     exercise_redis_multi_args(r)
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (2, 10), reason="This command is not implemented yet")
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
     "test_execute_command:test_strict_redis_execute_command_as_one_arg_enable",
@@ -133,7 +126,6 @@ def test_strict_redis_execute_command_as_one_arg_enable():
     exercise_redis_single_arg(r)
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (2, 10), reason="This command is not implemented yet")
 @override_application_settings(_disable_instance_settings)
 @validate_transaction_metrics(
     "test_execute_command:test_strict_redis_execute_command_as_one_arg_disabled",
@@ -147,7 +139,6 @@ def test_strict_redis_execute_command_as_one_arg_disabled():
     exercise_redis_single_arg(r)
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (2, 10), reason="This command is not implemented yet")
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
     "test_execute_command:test_redis_execute_command_as_one_arg_enable",
@@ -161,7 +152,6 @@ def test_redis_execute_command_as_one_arg_enable():
     exercise_redis_single_arg(r)
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (2, 10), reason="This command is not implemented yet")
 @override_application_settings(_disable_instance_settings)
 @validate_transaction_metrics(
     "test_execute_command:test_redis_execute_command_as_one_arg_disabled",

--- a/tests/datastore_redis/test_generators.py
+++ b/tests/datastore_redis/test_generators.py
@@ -173,41 +173,14 @@ async def exercise_redis_async(client):
 
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
-    "test_generators:test_strict_redis_generator_enable_instance",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_enable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_generator_enable_instance():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
-
-
-@override_application_settings(_disable_instance_settings)
-@validate_transaction_metrics(
-    "test_generators:test_strict_redis_generator_disable_instance",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_disable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_generator_disable_instance():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
-
-
-@override_application_settings(_enable_instance_settings)
-@validate_transaction_metrics(
     "test_generators:test_redis_generator_enable_instance",
     scoped_metrics=_base_scoped_metrics,
     rollup_metrics=_enable_rollup_metrics,
     background_task=True,
 )
 @background_task()
-def test_redis_generator_enable_instance():
-    client = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
+def test_redis_generator_enable_instance(client):
+    exercise_redis(client())
 
 
 @override_application_settings(_disable_instance_settings)
@@ -218,9 +191,8 @@ def test_redis_generator_enable_instance():
     background_task=True,
 )
 @background_task()
-def test_redis_generator_disable_instance():
-    client = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
+def test_redis_generator_disable_instance(client):
+    exercise_redis(client())
 
 
 @override_application_settings(_enable_instance_settings)
@@ -231,9 +203,8 @@ def test_redis_generator_disable_instance():
     background_task=True,
 )
 @background_task()
-def test_redis_async_generator_enable_instance(loop):
-    client = redis.asyncio.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    loop.run_until_complete(exercise_redis_async(client))
+def test_redis_async_generator_enable_instance(loop, async_client):
+    loop.run_until_complete(exercise_redis_async(async_client()))
 
 
 @override_application_settings(_disable_instance_settings)
@@ -244,6 +215,5 @@ def test_redis_async_generator_enable_instance(loop):
     background_task=True,
 )
 @background_task()
-def test_redis_async_generator_disable_instance(loop):
-    client = redis.asyncio.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    loop.run_until_complete(exercise_redis_async(client))
+def test_redis_async_generator_disable_instance(loop, async_client):
+    loop.run_until_complete(exercise_redis_async(async_client()))

--- a/tests/datastore_redis/test_generators.py
+++ b/tests/datastore_redis/test_generators.py
@@ -25,7 +25,6 @@ from newrelic.api.time_trace import current_trace
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_SETTINGS = redis_settings()[0]
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 # Settings
 
@@ -224,7 +223,6 @@ def test_redis_generator_disable_instance():
     exercise_redis(client)
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="Redis.asyncio was not added until v4.2")
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
     "test_generators:test_redis_async_generator_enable_instance",
@@ -238,7 +236,6 @@ def test_redis_async_generator_enable_instance(loop):
     loop.run_until_complete(exercise_redis_async(client))
 
 
-@pytest.mark.skipif(REDIS_PY_VERSION < (4, 2), reason="Redis.asyncio was not added until v4.2")
 @override_application_settings(_disable_instance_settings)
 @validate_transaction_metrics(
     "test_generators:test_redis_async_generator_disable_instance",

--- a/tests/datastore_redis/test_get_and_set.py
+++ b/tests/datastore_redis/test_get_and_set.py
@@ -65,41 +65,14 @@ def exercise_redis(client):
 
 @override_application_settings(_enable_instance_settings)
 @validate_transaction_metrics(
-    "test_get_and_set:test_strict_redis_operation_enable_instance",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_enable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_operation_enable_instance():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
-
-
-@override_application_settings(_disable_instance_settings)
-@validate_transaction_metrics(
-    "test_get_and_set:test_strict_redis_operation_disable_instance",
-    scoped_metrics=_base_scoped_metrics,
-    rollup_metrics=_disable_rollup_metrics,
-    background_task=True,
-)
-@background_task()
-def test_strict_redis_operation_disable_instance():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
-
-
-@override_application_settings(_enable_instance_settings)
-@validate_transaction_metrics(
     "test_get_and_set:test_redis_operation_enable_instance",
     scoped_metrics=_base_scoped_metrics,
     rollup_metrics=_enable_rollup_metrics,
     background_task=True,
 )
 @background_task()
-def test_redis_operation_enable_instance():
-    client = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
+def test_redis_operation_enable_instance(client):
+    exercise_redis(client())
 
 
 @override_application_settings(_disable_instance_settings)
@@ -110,6 +83,5 @@ def test_redis_operation_enable_instance():
     background_task=True,
 )
 @background_task()
-def test_redis_operation_disable_instance():
-    client = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-    exercise_redis(client)
+def test_redis_operation_disable_instance(client):
+    exercise_redis(client())

--- a/tests/datastore_redis/test_instance_info.py
+++ b/tests/datastore_redis/test_instance_info.py
@@ -14,11 +14,10 @@
 
 import pytest
 import redis
+from conftest import REDIS_PY_VERSION
 
 from newrelic.common.package_version_utils import get_package_version_tuple
 from newrelic.hooks.datastore_redis import _conn_attrs_to_dict, _instance_info
-
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 # Call to `get_connection` function with the usage of the command
 # name as an input argument has been deprecated since v5.3.0.

--- a/tests/datastore_redis/test_multiple_dbs.py
+++ b/tests/datastore_redis/test_multiple_dbs.py
@@ -20,7 +20,6 @@ from testing_support.util import instance_hostname
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
-from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_MULTIPLE_SETTINGS = redis_settings()
 

--- a/tests/datastore_redis/test_multiple_dbs.py
+++ b/tests/datastore_redis/test_multiple_dbs.py
@@ -23,7 +23,6 @@ from newrelic.api.background_task import background_task
 from newrelic.common.package_version_utils import get_package_version_tuple
 
 DB_MULTIPLE_SETTINGS = redis_settings()
-REDIS_PY_VERSION = get_package_version_tuple("redis")
 
 
 # Settings
@@ -37,26 +36,20 @@ _base_scoped_metrics = [
     ("Datastore/operation/Redis/get", 1),
     ("Datastore/operation/Redis/set", 1),
     ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-# client_setinfo was introduced in v5.0.0 and assigns info displayed in client_list output
-if REDIS_PY_VERSION >= (5, 0):
-    _base_scoped_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
-datastore_all_metric_count = 5 if REDIS_PY_VERSION >= (5, 0) else 3
 
 _base_rollup_metrics = [
-    ("Datastore/all", datastore_all_metric_count),
-    ("Datastore/allOther", datastore_all_metric_count),
-    ("Datastore/Redis/all", datastore_all_metric_count),
-    ("Datastore/Redis/allOther", datastore_all_metric_count),
+    ("Datastore/all", 5),
+    ("Datastore/allOther", 5),
+    ("Datastore/Redis/all", 5),
+    ("Datastore/Redis/allOther", 5),
     ("Datastore/operation/Redis/get", 1),
     ("Datastore/operation/Redis/set", 1),
     ("Datastore/operation/Redis/client_list", 1),
+    ("Datastore/operation/Redis/client_setinfo", 2),
 ]
-
-# client_setinfo was introduced in v5.0.0 and assigns info displayed in client_list output
-if REDIS_PY_VERSION >= (5, 0):
-    _base_rollup_metrics.append(("Datastore/operation/Redis/client_setinfo", 2))
 
 
 if len(DB_MULTIPLE_SETTINGS) > 1:
@@ -73,7 +66,7 @@ if len(DB_MULTIPLE_SETTINGS) > 1:
     instance_metric_name_2 = f"Datastore/instance/Redis/{host_2}/{port_2}"
 
     instance_metric_name_1_count = 2
-    instance_metric_name_2_count = 3 if REDIS_PY_VERSION >= (5, 0) else 1
+    instance_metric_name_2_count = 3
 
     _enable_rollup_metrics = _base_rollup_metrics.extend(
         [(instance_metric_name_1, instance_metric_name_1_count), (instance_metric_name_2, instance_metric_name_2_count)]

--- a/tests/datastore_redis/test_span_event.py
+++ b/tests/datastore_redis/test_span_event.py
@@ -42,9 +42,7 @@ _disable_instance_settings = {
 }
 
 
-def _exercise_db():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=DATABASE_NUMBER)
-
+def _exercise_db(client):
     client.set("key", "value")
     client.get("key")
 
@@ -56,7 +54,7 @@ def _exercise_db():
 
 @pytest.mark.parametrize("db_instance_enabled", (True, False))
 @pytest.mark.parametrize("instance_enabled", (True, False))
-def test_span_events(instance_enabled, db_instance_enabled):
+def test_span_events(instance_enabled, db_instance_enabled, client):
     guid = "dbb533c53b749e0b"
     priority = 0.5
 
@@ -123,6 +121,6 @@ def test_span_events(instance_enabled, db_instance_enabled):
         txn.guid = guid
         txn._priority = priority
         txn._sampled = True
-        _exercise_db()
+        _exercise_db(client())
 
     _test()

--- a/tests/datastore_redis/test_trace_node.py
+++ b/tests/datastore_redis/test_trace_node.py
@@ -64,9 +64,7 @@ _database_only_forgone = {"host": "VALUE NOT USED", "port_path_or_id": "VALUE NO
 # Query
 
 
-def _exercise_db():
-    client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=DATABASE_NUMBER)
-
+def _exercise_db(client):
     client.set("key", "value")
     client.get("key")
 
@@ -79,26 +77,26 @@ def _exercise_db():
 @override_application_settings(_enable_instance_settings)
 @validate_tt_collector_json(datastore_params=_enabled_required, datastore_forgone_params=_enabled_forgone)
 @background_task()
-def test_trace_node_datastore_params_enable_instance():
-    _exercise_db()
+def test_trace_node_datastore_params_enable_instance(client):
+    _exercise_db(client())
 
 
 @override_application_settings(_disable_instance_settings)
 @validate_tt_collector_json(datastore_params=_disabled_required, datastore_forgone_params=_disabled_forgone)
 @background_task()
-def test_trace_node_datastore_params_disable_instance():
-    _exercise_db()
+def test_trace_node_datastore_params_disable_instance(client):
+    _exercise_db(client())
 
 
 @override_application_settings(_instance_only_settings)
 @validate_tt_collector_json(datastore_params=_instance_only_required, datastore_forgone_params=_instance_only_forgone)
 @background_task()
-def test_trace_node_datastore_params_instance_only():
-    _exercise_db()
+def test_trace_node_datastore_params_instance_only(client):
+    _exercise_db(client())
 
 
 @override_application_settings(_database_only_settings)
 @validate_tt_collector_json(datastore_params=_database_only_required, datastore_forgone_params=_database_only_forgone)
 @background_task()
-def test_trace_node_datastore_params_database_only():
-    _exercise_db()
+def test_trace_node_datastore_params_database_only(client):
+    _exercise_db(client())

--- a/tests/datastore_redis/test_uninstrumented_methods.py
+++ b/tests/datastore_redis/test_uninstrumented_methods.py
@@ -67,6 +67,7 @@ IGNORED_METHODS = {
     "get_property",
     "get_relation",
     "get_retry",
+    "himport_registry",
     "index_name",
     "keyspace_notifications",
     "labels",

--- a/tests/datastore_redis/test_uninstrumented_methods.py
+++ b/tests/datastore_redis/test_uninstrumented_methods.py
@@ -18,9 +18,6 @@ from testing_support.db_settings import redis_settings
 
 DB_SETTINGS = redis_settings()[0]
 
-redis_client = redis.Redis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-strict_redis_client = redis.StrictRedis(host=DB_SETTINGS["host"], port=DB_SETTINGS["port"], db=0)
-
 
 IGNORED_METHODS = {
     "MODULE_CALLBACKS",
@@ -99,7 +96,6 @@ REDIS_MODULES = {"bf", "cf", "cms", "ft", "graph", "json", "tdigest", "topk", "t
 IGNORED_METHODS |= REDIS_MODULES
 
 
-@pytest.mark.parametrize("client", (redis_client, strict_redis_client))
 def test_uninstrumented_methods(client):
     methods = {m for m in dir(client) if not m[0] == "_"}
     is_wrapped = lambda m: hasattr(getattr(client, m), "__wrapped__")

--- a/tests/datastore_rediscluster/test_uninstrumented_rediscluster_methods.py
+++ b/tests/datastore_rediscluster/test_uninstrumented_rediscluster_methods.py
@@ -102,6 +102,7 @@ IGNORED_METHODS = {
     "get_replicas",
     "get_retry",
     "get_special_nodes",
+    "himport_registry",
     "hscan_iter",
     "index_name",
     "keyslot",

--- a/tox.ini
+++ b/tox.ini
@@ -203,9 +203,8 @@ envlist =
     rabbitmq-hybridagent_pika-{py39,py310,py311,py312,py313,py314,py314t,pypy311},
     rabbitmq-messagebroker_kombu-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-kombulatest,
     rabbitmq-messagebroker_kombu-{py39,py310,pypy311}-kombu050204,
-    redis-datastore_redis-{py39,py310,py311,pypy311}-redis04,
-    redis-datastore_redis-{py39,py310,py311,py312,pypy311}-redis05,
-    redis-datastore_redis-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-redislatest,
+    redis-datastore_redis-{py312,pypy311}-redis{05,06,07},
+    redis-datastore_redis-{py310,py311,py312,py313,py314,py314t,pypy311}-redislatest,
     redis-hybridagent_redis-{py39,py310,py311,py312,py313,py314,py314t,pypy311},
     rediscluster-datastore_rediscluster-{py312,py313,py314,py314t,pypy311}-redislatest,
     valkey-datastore_valkey-{py39,py310,py311,py312,py313,py314,py314t,pypy311}-valkeylatest,
@@ -321,8 +320,9 @@ deps =
     datastore_pymysql: PyMySQL
     datastore_pymysql: cryptography
     datastore_pysolr: pysolr<4.0
-    datastore_redis-redis04: redis<5
     datastore_redis-redis05: redis<6
+    datastore_redis-redis06: redis<7
+    datastore_redis-redis07: redis<8
     datastore_redis-redislatest: redis
     datastore_rediscluster-redislatest: redis
     datastore_valkey-valkeylatest: valkey


### PR DESCRIPTION
# Overview

* Add instrumentation for new Redis commands introduced in Redis `v8.10.0` and redis-py `8.1.0`. 
* Rewire Redis tests to disable MaintenanceNotifications globally, to prevent random pollution of captured metrics in tests.
* Change out `tox` matrixes for Redis to latest set of supported major versions.