### PR TITLE
Ignore Dependabot Coverage Runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,8 @@ jobs:
   # Combine and upload coverage data
   coverage:
     runs-on: ubuntu-24.04
-    if: success() || failure() # Does not run on cancelled workflows
+    # Don't run this job if triggered by Dependabot, but otherwise run it regardless of success or failure
+    if: ${{ (github.actor != 'dependabot[bot]') && (success() || failure()) }} # Does not run on cancelled workflows
     needs:
       - tests
 


### PR DESCRIPTION
# Overview

Dependabot cannot upload results to CodeCov, and causes the coverage action to be marked as a failure.

* Ignore the `coverage` step on Dependabot triggered runs of the CI and don't mark it as a failure.