### PR TITLE
Pin Django version in Django Rest Framework

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -267,7 +267,7 @@ deps =
     mlmodel_sklearn: numpy
     mlmodel_sklearn-scikitlearnlatest: scikit-learn
     mlmodel_sklearn-scikitlearnlatest: scipy
-    component_djangorestframework-djangorestframeworklatest: Django
+    component_djangorestframework-djangorestframeworklatest: Django<6.0.8
     component_djangorestframework-djangorestframeworklatest: djangorestframework
     component_flask_rest: flask-restful
     component_flask_rest: jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -172,7 +172,7 @@ envlist =
     python-framework_tornado-{py39,py310,py311,py312,py313,py314,py314t}-tornadolatest,
     ; Remove `python-framework_tornado-{py314,py314t}-tornadomaster` temporarily
     python-framework_wagtail-{py39,py310,py311,py312,py313,py314,py314t}-wagtaillatest,
-    python-framework_tornado-{py310,py311,py312,py313}-tornadomaster,
+    python-framework_tornado-{py311,py312,py313}-tornadomaster,
     python-hybridagent_ariadne-{py39,py310,py311,py312,py313,py314,py314t},
     python-hybridagent_dynamodb-{py39,py310,py311,py312,py313,py314,py314t},
     python-hybridagent_fastapi-{py39,py310,py311,py312,py313,py314,py314t,pypy311},


### PR DESCRIPTION
In Django Rest Framework, `rest_framework/views.py`, `from django.utils.cache import cc_delim_re` fails to import in Django v6.0.8+

This has been pinned until this bug is fixed on their end.

This PR also drops Python 3.10 from Tornado master tests since [3.10 support has been dropped](https://github.com/tornadoweb/tornado/pull/3707).