### PR TITLE
fix: pass application through get_linking_metadata

### DIFF
--- a/newrelic/api/time_trace.py
+++ b/newrelic/api/time_trace.py
@@ -744,7 +744,7 @@ def get_service_linking_metadata(application=None, settings=None):
 
 
 def get_linking_metadata(application=None):
-    metadata = get_service_linking_metadata()
+    metadata = get_service_linking_metadata(application)
     trace = current_trace()
     if trace:
         metadata.update(trace._get_trace_linking_metadata())

--- a/tests/agent_features/test_logs_in_context.py
+++ b/tests/agent_features/test_logs_in_context.py
@@ -21,6 +21,7 @@ from traceback import format_exception
 import pytest
 
 from newrelic.agent import get_linking_metadata
+from newrelic.api import time_trace
 from newrelic.api.background_task import background_task
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.log import NewRelicContextFormatter
@@ -375,3 +376,24 @@ def test_get_linking_metadata_api_inside_transaction():
 def test_get_linking_metadata_api_outside_transaction():
     metadata = get_linking_metadata()
     validate_metadata(metadata, EXPECTED_KEYS_NO_TXN)
+
+
+def test_get_linking_metadata_api_honors_application(monkeypatch):
+    """The application argument must reach the entity attributes.
+
+    It was accepted and dropped, so a process reporting to more than one
+    application always got the default entity.
+    """
+
+    class FakeSettings:
+        app_name = "OTHER-APP"
+        entity_guid = "other-guid"
+
+    class FakeApplication:
+        settings = FakeSettings()
+
+    monkeypatch.setattr(time_trace, "current_trace", lambda: None)
+
+    metadata = get_linking_metadata(application=FakeApplication())
+    assert metadata["entity.name"] == "OTHER-APP"
+    assert metadata["entity.guid"] == "other-guid"


### PR DESCRIPTION
`newrelic.agent.get_linking_metadata(application=...)` accepts the argument and drops it. `time_trace.py:746` calls `get_service_linking_metadata()` with nothing, so a caller passing an application still gets the default one's `entity.name` and `entity.guid`.

Three things in the same file say that was not deliberate. The helper it calls takes `application` and uses it to resolve settings. The identically named method on `TimeTrace` at line 694 passes it through to `_get_service_linking_metadata`. And `application=None` is the convention across a good number of public APIs here, including `notice_error` and `record_custom_event`, which this one member quietly breaks.

Nobody chose it. `git log -L` on the function puts it in `2c4f46bc`, "Record log event (#555)", the same commit that added `application` to the helper, and the line has not been touched since. No test pins the current behaviour: every test and benchmark calls it with no arguments.

The fix is one word.

Verified offline, no collector and no network. With a fake application whose settings name a different entity, the public function returns `None` for `entity.name` on main and `OTHER-APP` here, while the helper returns `OTHER-APP` both times. The added test fails without the source change and `tests/agent_features/test_logs_in_context.py` is 9 passed with it.

Severity is low. It only bites a process reporting to more than one application, since everyone else was getting the default they wanted anyway. Nothing leaks and nothing crashes, the metadata is just attributed to the wrong entity.

I did not run this against a collector or a real multi-application process, so the argument that it matters rests on reading, and I did not run the wider suite beyond that one file.
