### PR TITLE
Port HTTPX Instrumentation to HTTPX2

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -3023,6 +3023,8 @@ def _process_module_builtin_defaults():
 
     _process_module_definition("httpx._client", "newrelic.hooks.external_httpx", "instrument_httpx_client")
 
+    _process_module_definition("httpx2._client", "newrelic.hooks.external_httpx2", "instrument_httpx2_client")
+
     _process_module_definition("gluon.contrib.feedparser", "newrelic.hooks.external_feedparser")
     _process_module_definition("gluon.contrib.memcache.memcache", "newrelic.hooks.memcache_memcache")
 

--- a/newrelic/hooks/external_httpx2.py
+++ b/newrelic/hooks/external_httpx2.py
@@ -1,0 +1,125 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from newrelic.api.external_trace import ExternalTrace
+from newrelic.common.object_wrapper import wrap_function_wrapper
+
+
+def newrelic_event_hook(response):
+    tracer = getattr(response.request, "_nr_trace", None)
+    if tracer is not None:
+        headers = dict(getattr(response, "headers", ())).items()
+        tracer.process_response(getattr(response, "status_code", None), headers)
+
+
+async def newrelic_event_hook_async(response):
+    tracer = getattr(response.request, "_nr_trace", None)
+    if tracer is not None:
+        headers = dict(getattr(response, "headers", ())).items()
+        tracer.process_response(getattr(response, "status_code", None), headers)
+
+
+def newrelic_first_gen(wrapped, is_async=False):
+    if is_async:
+        yield newrelic_event_hook_async
+    else:
+        yield newrelic_event_hook
+    while True:
+        try:
+            yield next(wrapped)
+        except StopIteration:
+            break
+
+
+class NewRelicFirstList(list):
+    def __init__(self, *args, is_async=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_async = is_async
+
+    def __iter__(self):
+        wrapped_iter = super().__iter__()
+        return iter(newrelic_first_gen(wrapped_iter, self.is_async))
+
+
+class NewRelicFirstDict(dict):
+    def __init__(self, *args, is_async=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_async = is_async
+        self.__setitem__("response", self["response"])
+
+    def __setitem__(self, key, value):
+        if key == "response":
+            value = NewRelicFirstList(value, is_async=self.is_async)
+
+        super().__setitem__(key, value)
+
+
+def bind_request(request, *args, **kwargs):
+    return request
+
+
+def sync_send_wrapper(wrapped, instance, args, kwargs):
+    request = bind_request(*args, **kwargs)
+
+    with ExternalTrace("httpx2", str(request.url), request.method, source=wrapped) as tracer:
+        if hasattr(tracer, "generate_request_headers"):
+            request._nr_trace = tracer
+            outgoing_headers = tracer.generate_request_headers(tracer.transaction)
+            for header_name, header_value in outgoing_headers:
+                # User headers should override our DT headers
+                if header_name not in request.headers:
+                    request.headers[header_name] = header_value
+
+        return wrapped(*args, **kwargs)
+
+
+async def async_send_wrapper(wrapped, instance, args, kwargs):
+    request = bind_request(*args, **kwargs)
+
+    with ExternalTrace("httpx2", str(request.url), request.method, source=wrapped) as tracer:
+        if hasattr(tracer, "generate_request_headers"):
+            request._nr_trace = tracer
+            outgoing_headers = tracer.generate_request_headers(tracer.transaction)
+            for header_name, header_value in outgoing_headers:
+                # User headers should override our DT headers
+                if header_name not in request.headers:
+                    request.headers[header_name] = header_value
+
+        return await wrapped(*args, **kwargs)
+
+
+def create_nr_first_event_hooks(is_async=False):
+    @property
+    def nr_first_event_hooks(self):
+        if not hasattr(self, "_nr_event_hooks"):
+            # This branch should only be hit if agent initialize is called after
+            # the initialization of the http client
+            self._event_hooks = vars(self)["_event_hooks"]
+            del vars(self)["_event_hooks"]
+        return self._nr_event_hooks
+
+    @nr_first_event_hooks.setter
+    def nr_first_event_hooks(self, value):
+        value = NewRelicFirstDict(value, is_async=is_async)
+        self._nr_event_hooks = value
+
+    return nr_first_event_hooks
+
+
+def instrument_httpx2_client(module):
+    module.Client._event_hooks = create_nr_first_event_hooks(is_async=False)
+    module.AsyncClient._event_hooks = create_nr_first_event_hooks(is_async=True)
+
+    wrap_function_wrapper(module, "Client.send", sync_send_wrapper)
+    wrap_function_wrapper(module, "AsyncClient.send", async_send_wrapper)

--- a/tests/external_httpx2/conftest.py
+++ b/tests/external_httpx2/conftest.py
@@ -1,0 +1,59 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from testing_support.db_settings import nginx_settings
+from testing_support.fixture.event_loop import event_loop as loop
+from testing_support.fixtures import collector_agent_registration_fixture, collector_available_fixture
+
+_default_settings = {
+    "package_reporting.enabled": False,  # Turn off package reporting for testing as it causes slow downs.
+    "transaction_tracer.explain_threshold": 0.0,
+    "transaction_tracer.transaction_threshold": 0.0,
+    "transaction_tracer.stack_trace_threshold": 0.0,
+    "debug.log_data_collector_payloads": True,
+    "debug.record_transaction_failure": True,
+}
+
+collector_agent_registration = collector_agent_registration_fixture(
+    app_name="Python Agent Test (external_httpx2)", default_settings=_default_settings
+)
+
+
+@pytest.fixture(scope="session")
+def httpx2():
+    import httpx2
+
+    return httpx2
+
+
+@pytest.fixture(scope="session")
+def real_server():
+    settings = nginx_settings()[0]
+
+    class RealHTTP2Server:
+        host = settings["host"]
+        port = settings["port"]
+
+    return RealHTTP2Server
+
+
+@pytest.fixture
+def sync_client(httpx2):
+    return httpx2.Client()
+
+
+@pytest.fixture
+def async_client(httpx2):
+    return httpx2.AsyncClient()

--- a/tests/external_httpx2/test_client.py
+++ b/tests/external_httpx2/test_client.py
@@ -1,0 +1,374 @@
+# Copyright 2010 New Relic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+from testing_support.fixtures import dt_enabled, override_application_settings, override_generic_settings
+from testing_support.mock_external_http_server import MockExternalHTTPHResponseHeadersServer
+from testing_support.validators.validate_distributed_tracing_headers import validate_distributed_tracing_headers
+from testing_support.validators.validate_span_events import validate_span_events
+from testing_support.validators.validate_transaction_errors import validate_transaction_errors
+from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
+
+from newrelic.api.background_task import background_task
+from newrelic.api.time_trace import current_trace
+from newrelic.api.transaction import current_transaction
+from newrelic.core.config import global_settings
+
+SCOPED_METRICS = []
+ROLLUP_METRICS = [("External/all", 2), ("External/allOther", 2)]
+
+RESPONSE_CODE = None
+
+
+def dt_response_handler(self):
+    if not RESPONSE_CODE:
+        raise ValueError("RESPONSE_CODE must be a valid status_code.")
+
+    response = str(self.headers).encode("utf-8")  # Might need to put headers here
+    self.send_response(RESPONSE_CODE)
+    self.end_headers()
+    self.wfile.write(response)
+
+
+@pytest.fixture(scope="session")
+def mock_server():
+    external = MockExternalHTTPHResponseHeadersServer(handler=dt_response_handler)
+    with external:
+        yield external
+
+
+@pytest.fixture
+def populate_metrics(mock_server, request):
+    SCOPED_METRICS[:] = []
+    method = request.getfixturevalue("method").upper()
+    SCOPED_METRICS.append((f"External/localhost:{mock_server.port}/httpx2/{method}", 2))
+
+
+def exercise_sync_client(server, client, method, protocol="http"):
+    with client as client:
+        resolved_method = getattr(client, method)
+        resolved_method(f"{protocol}://{server.host}:{server.port}")
+        response = resolved_method(f"{protocol}://{server.host}:{server.port}")
+
+    return response
+
+
+@pytest.mark.parametrize("method", ("get", "options", "head", "post", "put", "patch", "delete"))
+@validate_transaction_metrics(
+    "test_sync_client", scoped_metrics=SCOPED_METRICS, rollup_metrics=ROLLUP_METRICS, background_task=True
+)
+@background_task(name="test_sync_client")
+def test_sync_client(httpx2, sync_client, mock_server, method):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    assert exercise_sync_client(mock_server, sync_client, method).status_code == 200
+
+
+async def exercise_async_client(server, client, method, protocol="http"):
+    async with client as client:
+        resolved_method = getattr(client, method)
+        responses = await asyncio.gather(
+            resolved_method(f"{protocol}://{server.host}:{server.port}"),
+            resolved_method(f"{protocol}://{server.host}:{server.port}"),
+        )
+
+    return responses
+
+
+@pytest.mark.parametrize("method", ("get", "options", "head", "post", "put", "patch", "delete"))
+@validate_transaction_metrics(
+    "test_async_client", scoped_metrics=SCOPED_METRICS, rollup_metrics=ROLLUP_METRICS, background_task=True
+)
+@background_task(name="test_async_client")
+def test_async_client(httpx2, async_client, mock_server, loop, method):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    responses = loop.run_until_complete(exercise_async_client(mock_server, async_client, method))
+    assert all(response.status_code == 200 for response in responses)
+
+
+@pytest.mark.parametrize("distributed_tracing,span_events", ((True, True), (True, False), (False, False)))
+def test_sync_distributed_tracing_request(httpx2, sync_client, mock_server, distributed_tracing, span_events):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    @override_application_settings(
+        {"distributed_tracing.enabled": distributed_tracing, "span_events.enabled": span_events}
+    )
+    @validate_transaction_errors(errors=[])
+    @background_task(name="test_sync_distributed_tracing_request")
+    @validate_distributed_tracing_headers
+    def _test():
+        transaction = current_transaction()
+
+        with sync_client:
+            response = sync_client.get(f"http://localhost:{mock_server.port}")
+
+        transaction._test_request_headers = response.request.headers
+
+        assert response.status_code == 200
+
+    _test()
+
+
+@pytest.mark.parametrize("distributed_tracing,span_events", ((True, True), (True, False), (False, False)))
+@validate_transaction_errors(errors=[])
+@background_task(name="test_async_distributed_tracing_request")
+@validate_distributed_tracing_headers
+def test_async_distributed_tracing_request(httpx2, async_client, mock_server, loop, distributed_tracing, span_events):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    @override_application_settings(
+        {"distributed_tracing.enabled": distributed_tracing, "span_events.enabled": span_events}
+    )
+    async def _test():
+        async with async_client:
+            response = await async_client.get(f"http://localhost:{mock_server.port}")
+
+        return response
+
+    transaction = current_transaction()
+    response = loop.run_until_complete(_test())
+    transaction._test_request_headers = response.request.headers
+
+    assert response.status_code == 200
+
+
+@override_application_settings(
+    {"distributed_tracing.enabled": True, "span_events.enabled": True}  # , "cross_application_tracer.enabled": True}
+)
+@validate_transaction_errors(errors=[])
+@background_task(name="test_sync_distributed_tracing_override_headers")
+def test_sync_distributed_tracing_override_headers(httpx2, sync_client, mock_server, loop):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    transaction = current_transaction()
+
+    with sync_client:
+        response = sync_client.get(f"http://localhost:{mock_server.port}", headers={"newrelic": "1234"})
+
+    transaction._test_request_headers = response.request.headers
+
+    assert response.status_code == 200
+    assert response.request.headers["newrelic"] == "1234"
+
+
+@override_application_settings({"distributed_tracing.enabled": True, "span_events.enabled": True})
+@validate_transaction_errors(errors=[])
+@background_task(name="test_async_distributed_tracing_override_headers")
+def test_async_distributed_tracing_override_headers(httpx2, async_client, mock_server, loop):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    async def _test():
+        async with async_client:
+            response = await async_client.get(f"http://localhost:{mock_server.port}", headers={"newrelic": "1234"})
+
+        return response
+
+    response = loop.run_until_complete(_test())
+
+    assert response.status_code == 200
+    assert response.request.headers["newrelic"] == "1234"
+
+
+@dt_enabled
+def test_sync_client_event_hook_exception(httpx2, mock_server):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 500
+
+    def exception_event_hook(response):
+        if response.status_code >= 400:
+            raise RuntimeError
+
+    def empty_hook(response):
+        pass
+
+    @validate_span_events(
+        count=1,
+        exact_intrinsics={"name": f"External/localhost:{mock_server.port}/httpx2/GET"},
+        exact_agents={"http.statusCode": RESPONSE_CODE},
+    )
+    @background_task(name="test_sync_client_event_hook_exception")
+    def make_request(client, exc_expected=True):
+        if exc_expected:
+            with pytest.raises(RuntimeError):
+                client.get(f"http://localhost:{mock_server.port}")
+        else:
+            client.get(f"http://localhost:{mock_server.port}")
+
+    with httpx2.Client(event_hooks={"response": [exception_event_hook]}) as client:
+        # Test client init
+        make_request(client)
+
+        # Test client setter
+        client.event_hooks = {"response": [exception_event_hook]}
+        make_request(client)
+
+        # Test dict setitem
+        client.event_hooks["response"] = [exception_event_hook]
+        make_request(client)
+
+        # Test list insert
+        client.event_hooks["response"].insert(0, exception_event_hook)
+        make_request(client)
+
+        # Don't crash if response isn't specified
+        client.event_hooks = {"request": [empty_hook]}
+        make_request(client, exc_expected=False)
+
+
+@override_application_settings({"distributed_tracing.enabled": True, "span_events.enabled": True})
+def test_async_client_event_hook_exception(httpx2, mock_server, loop):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 500
+
+    def exception_event_hook(response):
+        if response.status_code >= 400:
+            raise RuntimeError
+
+    def empty_hook(response):
+        pass
+
+    @validate_span_events(
+        count=1,
+        exact_intrinsics={"name": f"External/localhost:{mock_server.port}/httpx2/GET"},
+        exact_agents={"http.statusCode": RESPONSE_CODE},
+    )
+    @background_task(name="test_sync_client_event_hook_exception")
+    def make_request(client, exc_expected=True):
+        async def coro():
+            if exc_expected:
+                with pytest.raises(RuntimeError):
+                    await client.get(f"http://localhost:{mock_server.port}")
+            else:
+                await client.get(f"http://localhost:{mock_server.port}")
+
+        loop.run_until_complete(coro())
+
+    def _test():
+        with httpx2.AsyncClient(event_hooks={"response": [exception_event_hook]}) as client:
+            # Test client init
+            make_request(client)
+
+            # Test client setter
+            client.event_hooks = {"response": [exception_event_hook]}
+            make_request(client)
+
+            # Test dict setitem
+            client.event_hooks["response"] = [exception_event_hook]
+            make_request(client)
+
+            # Test list insert
+            client.event_hooks["response"].insert(0, exception_event_hook)
+            make_request(client)
+
+            # Don't crash if response isn't specified
+            client.event_hooks = {"request": [empty_hook]}
+            make_request(client, exc_expected=False)
+
+
+@override_generic_settings(global_settings(), {"enabled": False})
+def test_sync_nr_disabled(httpx2, mock_server):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    with httpx2.Client() as client:
+        trace = current_trace()
+        response = client.get(f"http://localhost:{mock_server.port}")
+
+        assert response.status_code == 200
+        assert trace is None
+
+
+@override_generic_settings(global_settings(), {"enabled": False})
+def test_async_nr_disabled(httpx2, mock_server, loop):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    async def _test():
+        async with httpx2.AsyncClient() as client:
+            response = await client.get(f"http://localhost:{mock_server.port}")
+
+        return response
+
+    trace = current_trace()
+    response = loop.run_until_complete(_test())
+    assert response.status_code == 200
+    assert trace is None
+
+
+@pytest.mark.parametrize("client", ("Client", "AsyncClient"))
+def test_invalid_import_order_client(monkeypatch, httpx2, mock_server, loop, client):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    if "Async" in client:
+        is_async = True
+    else:
+        is_async = False
+
+    client = getattr(httpx2, client)
+
+    # Force the client class into the state as if instrumentation had not run
+    monkeypatch.setattr(client, "_event_hooks", None)
+
+    # Instantiate a client
+    client = client()
+
+    # Remove monkeypatching of _event_hooks to restore instrumentation
+    monkeypatch.undo()
+
+    if is_async:
+        responses = loop.run_until_complete(exercise_async_client(mock_server, client, "get"))
+        assert all(response.status_code == 200 for response in responses)
+    else:
+        response = exercise_sync_client(mock_server, client, "get")
+        assert response.status_code == 200
+
+
+@validate_transaction_metrics(
+    "test_sync_client_http2", scoped_metrics=SCOPED_METRICS, rollup_metrics=ROLLUP_METRICS, background_task=True
+)
+@background_task(name="test_sync_client_http2")
+def test_sync_client_http2(httpx2, real_server):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    client = httpx2.Client(http1=False, http2=True, verify=False)
+    response = exercise_sync_client(real_server, client, "get", protocol="https")
+
+    assert response.status_code == 200
+    assert response.http_version in {"HTTP/2", "HTTP/2.0"}
+
+
+@validate_transaction_metrics(
+    "test_async_client_http2", scoped_metrics=SCOPED_METRICS, rollup_metrics=ROLLUP_METRICS, background_task=True
+)
+@background_task(name="test_async_client_http2")
+def test_async_client_http2(httpx2, real_server, loop):
+    global RESPONSE_CODE
+    RESPONSE_CODE = 200
+
+    client = httpx2.AsyncClient(http1=False, http2=True, verify=False)
+
+    responses = loop.run_until_complete(exercise_async_client(real_server, client, "get", protocol="https"))
+    assert all(response.status_code == 200 for response in responses)
+    assert all(response.http_version in {"HTTP/2", "HTTP/2.0"} for response in responses)

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ envlist =
     oracledb-datastore_oracledb-{py39,py313,py314}-oracledb02,
     oracledb-datastore_oracledb-{py39,py312}-oracledb01,
     nginx-external_httpx-{py39,py310,py311,py312,py313,py314,py314t},
+    nginx-external_httpx2-{py39,py310,py311,py312,py313,py314,py314t},
     postgres16-datastore_asyncpg-{py39,py310,py311,py312,py313,py314,py314t},
     postgres16-datastore_psycopg-{py39,py310,py311,py312,py313,py314,pypy311}-psycopglatest,
     postgres16-datastore_psycopg-py312-psycopg_{purepython,binary,compiled}0301,
@@ -348,6 +349,7 @@ deps =
     external_feedparser-feedparser06: feedparser<7
     external_httplib2: httplib2<1.0
     external_httpx: httpx[http2]
+    external_httpx2: httpx2[http2]
     external_requests: urllib3
     external_requests: requests
     external_pyzeebe: pyzeebe
@@ -612,6 +614,7 @@ changedir =
     external_httplib: tests/external_httplib
     external_httplib2: tests/external_httplib2
     external_httpx: tests/external_httpx
+    external_httpx2: tests/external_httpx2
     external_pyzeebe: tests/external_pyzeebe
     external_requests: tests/external_requests
     external_urllib3: tests/external_urllib3


### PR DESCRIPTION
# Overview

The successor package [HTTPX2](https://pypi.org/project/httpx2) maintained by the pydantic team is seeing usage in some newer dependency trees. The original package [HTTPX](https://pypi.org/project/httpx) hasn't seen much recent activity and may be unmaintained. 

* Add instrumentation for HTTPX2 by simply porting existing instrumentation and tests for HTTPX.