### PR TITLE
Add WebTest to Deployment Requirements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
           CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=/opt/rh/devtoolset-8/root/usr/lib64:/opt/rh/devtoolset-8/root/usr/lib:/opt/rh/devtoolset-8/root/usr/lib64/dyninst:/opt/rh/devtoolset-8/root/usr/lib/dyninst:/usr/local/lib64:/usr/local/lib"
           CIBW_ENABLE: cpython-freethreading
-          CIBW_TEST_REQUIRES: pytest certifi
+          CIBW_TEST_REQUIRES: pytest certifi WebTest
           CIBW_TEST_COMMAND_LINUX: "export PYTHONPATH={project}/tests; pytest {project}/tests/agent_unittests -vx"
           CIBW_TEST_COMMAND_MACOS: "export PYTHONPATH={project}/tests; pytest {project}/tests/agent_unittests -vx"
           CIBW_TEST_COMMAND_WINDOWS: "set PYTHONPATH={project}/tests; pytest {project}/tests/agent_unittests -vx"


### PR DESCRIPTION
# Overview

* Add Webtest to deployment requirements for unittests to run.