### PR TITLE
Add Timeout to Deploy Job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
 
     name: Build wheels for ${{ matrix.wheel }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1


### PR DESCRIPTION
# Overview

* Add timeout to deploy job to prevent runners from getting stuck in the future.