### PR TITLE
Revert testing for Django Rest Framework to latest Django version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -269,7 +269,7 @@ deps =
     mlmodel_sklearn: numpy
     mlmodel_sklearn-scikitlearnlatest: scikit-learn
     mlmodel_sklearn-scikitlearnlatest: scipy
-    component_djangorestframework-djangorestframeworklatest: Django<6.0.8
+    component_djangorestframework-djangorestframeworklatest: Django
     component_djangorestframework-djangorestframeworklatest: djangorestframework
     component_flask_rest: flask-restful
     component_flask_rest: jinja2


### PR DESCRIPTION
The issue that [necessitated this temporary fix](https://github.com/newrelic/newrelic-python-agent/pull/1814) has been fixed [here](https://github.com/encode/django-rest-framework/pull/9978).