### PR TITLE
Add utilization for Azure App Service

### DIFF
--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -238,8 +238,11 @@ class AzureFunctionUtilization(CommonUtilization):
         cloud_region = os.environ.get("REGION_NAME")
         website_owner_name = os.environ.get("WEBSITE_OWNER_NAME")
         azure_function_app_name = os.environ.get("WEBSITE_SITE_NAME")
+        # Use this environment variable to distinguish between
+        # Azure Functions and Azure App Services
+        functions_worker_runtime = os.environ.get("FUNCTIONS_WORKER_RUNTIME")
 
-        if all((cloud_region, website_owner_name, azure_function_app_name)):
+        if all((cloud_region, website_owner_name, azure_function_app_name, functions_worker_runtime)):
             try:
                 if website_owner_name.endswith("-Linux"):
                     resource_group_name = AZURE_RESOURCE_GROUP_NAME_RE.search(website_owner_name).group(1)
@@ -276,7 +279,7 @@ class AzureAppServiceUtilization(CommonUtilization):
     METADATA_HOST = "169.254.169.254"
     METADATA_PATH = "/metadata/instance/compute"
     METADATA_QUERY = {"api-version": "2017-03-01"}  # noqa: RUF012
-    EXPECTED_KEYS = "cloud.resource_id"
+    EXPECTED_KEYS = ("cloud.resource_id",)
     HEADERS = {"Metadata": "true"}  # noqa: RUF012
     VENDOR_NAME = "azureappservice"
 
@@ -302,6 +305,19 @@ class AzureAppServiceUtilization(CommonUtilization):
                 )
 
         return None
+
+    @classmethod
+    def get_values(cls, response):
+        if response is None:
+            return
+
+        values = {}
+        key = cls.EXPECTED_KEYS[0]
+        if hasattr(response, "decode"):
+            response = response.decode("utf-8")
+        values[key] = response
+
+        return values
 
 
 class GCPUtilization(CommonUtilization):

--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -245,7 +245,7 @@ class AzureFunctionUtilization(CommonUtilization):
                     resource_group_name = AZURE_RESOURCE_GROUP_NAME_RE.search(website_owner_name).group(1)
                 else:
                     resource_group_name = AZURE_RESOURCE_GROUP_NAME_PARTIAL_RE.search(website_owner_name).group(1)
-                subscription_id = re.search(r"(?:(?!\+).)*", website_owner_name).group(0)
+                subscription_id = re.search(r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name).group(0)
                 faas_app_name = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}/providers/Microsoft.Web/sites/{azure_function_app_name}"
                 # Only send if all values are present
                 return (faas_app_name, cloud_region)
@@ -268,6 +268,36 @@ class AzureFunctionUtilization(CommonUtilization):
                 v = v.decode("utf-8")
             values[k] = v
         return values
+
+
+class AzureAppServiceUtilization(CommonUtilization):
+    METADATA_HOST = "169.254.169.254"
+    METADATA_PATH = "/metadata/instance/compute"
+    METADATA_QUERY = {"api-version": "2017-03-01"}  # noqa: RUF012
+    EXPECTED_KEYS = ("cloud.resource_id")
+    HEADERS = {"Metadata": "true"}  # noqa: RUF012
+    VENDOR_NAME = "azureappservice"
+
+    @classmethod
+    def fetch(cls):
+        website_resource_group_name = os.environ.get("WEBSITE_RESOURCE_GROUP")
+        website_owner_name = os.environ.get("WEBSITE_OWNER_NAME")
+        azure_service_app_name = os.environ.get("WEBSITE_SITE_NAME")
+
+        if all((website_resource_group_name, website_owner_name, azure_service_app_name)):
+            try:
+                subscription_id = re.search(r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name).group(0)
+                if subscription_id: 
+                    cloud_resource_id = f"/subscriptions/{subscription_id}/resourceGroups/{website_resource_group_name}/providers/Microsoft.Web/sites/{azure_service_app_name}"
+                    return cloud_resource_id
+                raise Exception
+            except Exception:
+                _logger.debug(
+                    "Unable to determine Azure App Services subscription id from WEBSITE_OWNER_NAME. %r",
+                    website_owner_name,
+                )
+
+        return None
 
 
 class GCPUtilization(CommonUtilization):

--- a/newrelic/common/utilization.py
+++ b/newrelic/common/utilization.py
@@ -245,7 +245,9 @@ class AzureFunctionUtilization(CommonUtilization):
                     resource_group_name = AZURE_RESOURCE_GROUP_NAME_RE.search(website_owner_name).group(1)
                 else:
                     resource_group_name = AZURE_RESOURCE_GROUP_NAME_PARTIAL_RE.search(website_owner_name).group(1)
-                subscription_id = re.search(r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name).group(0)
+                subscription_id = re.search(
+                    r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name
+                ).group(0)
                 faas_app_name = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group_name}/providers/Microsoft.Web/sites/{azure_function_app_name}"
                 # Only send if all values are present
                 return (faas_app_name, cloud_region)
@@ -274,7 +276,7 @@ class AzureAppServiceUtilization(CommonUtilization):
     METADATA_HOST = "169.254.169.254"
     METADATA_PATH = "/metadata/instance/compute"
     METADATA_QUERY = {"api-version": "2017-03-01"}  # noqa: RUF012
-    EXPECTED_KEYS = ("cloud.resource_id")
+    EXPECTED_KEYS = "cloud.resource_id"
     HEADERS = {"Metadata": "true"}  # noqa: RUF012
     VENDOR_NAME = "azureappservice"
 
@@ -286,8 +288,10 @@ class AzureAppServiceUtilization(CommonUtilization):
 
         if all((website_resource_group_name, website_owner_name, azure_service_app_name)):
             try:
-                subscription_id = re.search(r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name).group(0)
-                if subscription_id: 
+                subscription_id = re.search(
+                    r"([0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})", website_owner_name
+                ).group(0)
+                if subscription_id:
                     cloud_resource_id = f"/subscriptions/{subscription_id}/resourceGroups/{website_resource_group_name}/providers/Microsoft.Web/sites/{azure_service_app_name}"
                     return cloud_resource_id
                 raise Exception

--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -749,6 +749,7 @@ def _process_configuration(section):
     _process_setting(section, "utilization.detect_aws", "getboolean", None)
     _process_setting(section, "utilization.detect_azure", "getboolean", None)
     _process_setting(section, "utilization.detect_azurefunction", "getboolean", None)
+    _process_setting(section, "utilization.detect_azureappservice", "getboolean", None)
     _process_setting(section, "utilization.detect_docker", "getboolean", None)
     _process_setting(section, "utilization.detect_kubernetes", "getboolean", None)
     _process_setting(section, "utilization.detect_gcp", "getboolean", None)

--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -351,10 +351,10 @@ class AgentProtocol:
             vendors.append(GCPUtilization)
         if settings["utilization.detect_azure"]:
             vendors.append(AzureUtilization)
-        if settings["utilization.detect_azurefunction"]:
-            vendors.append(AzureFunctionUtilization)
         if settings["utilization.detect_azureappservice"]:
             vendors.append(AzureAppServiceUtilization)
+        if settings["utilization.detect_azurefunction"]:
+            vendors.append(AzureFunctionUtilization)
 
         for vendor in vendors:
             metadata = vendor.detect()

--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -24,6 +24,7 @@ from newrelic.common.encoding_utils import json_decode, json_encode, serverless_
 from newrelic.common.utilization import (
     AWSUtilization,
     AzureFunctionUtilization,
+    AzureAppServiceUtilization,
     AzureUtilization,
     DockerUtilization,
     ECSUtilization,
@@ -352,6 +353,8 @@ class AgentProtocol:
             vendors.append(AzureUtilization)
         if settings["utilization.detect_azurefunction"]:
             vendors.append(AzureFunctionUtilization)
+        if settings["utilization.detect_azureappservice"]:
+            vendors.append(AzureAppServiceUtilization)
 
         for vendor in vendors:
             metadata = vendor.detect()

--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -23,8 +23,8 @@ from newrelic.common.agent_http import ApplicationModeClient, ServerlessModeClie
 from newrelic.common.encoding_utils import json_decode, json_encode, serverless_payload_encode
 from newrelic.common.utilization import (
     AWSUtilization,
-    AzureFunctionUtilization,
     AzureAppServiceUtilization,
+    AzureFunctionUtilization,
     AzureUtilization,
     DockerUtilization,
     ECSUtilization,

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -1344,6 +1344,7 @@ _settings.message_tracer.segment_parameters_enabled = True
 _settings.utilization.detect_aws = True
 _settings.utilization.detect_azure = True
 _settings.utilization.detect_azurefunction = True
+_settings.utilization.detect_azureappservice = True
 _settings.utilization.detect_docker = sys.platform != "win32"  # Docker detection is not supported on Windows
 _settings.utilization.detect_kubernetes = True
 _settings.utilization.detect_gcp = True

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -40,7 +40,7 @@ from newrelic.network.exceptions import (
 
 # Global constants used in tests
 APP_NAME = "test_app"
-IP_ADDRESS = AWS = AZURE = ECS = GCP = PCF = BOOT_ID = DOCKER = KUBERNETES = AZUREFUNCTION = None
+IP_ADDRESS = AWS = AZURE = ECS = GCP = PCF = BOOT_ID = DOCKER = KUBERNETES = AZUREFUNCTION = AZUREAPPSERVICE = None
 BROWSER_MONITORING_DEBUG = "debug"
 BROWSER_MONITORING_LOADER = "loader"
 CAPTURE_PARAMS = "capture_params"
@@ -80,7 +80,7 @@ def clear_sent_values():
 
 @pytest.fixture(autouse=True)
 def override_utilization(monkeypatch):
-    global AWS, AZURE, ECS, GCP, PCF, BOOT_ID, DOCKER, KUBERNETES, AZUREFUNCTION
+    global AWS, AZURE, ECS, GCP, PCF, BOOT_ID, DOCKER, KUBERNETES, AZUREFUNCTION, AZUREAPPSERVICE
     AWS = {"id": "foo", "type": "bar", "zone": "baz"}
     AZURE = {"location": "foo", "name": "bar", "vmId": "baz", "vmSize": "boo"}
     ECS = {"ecsDockerId": "foobar"}
@@ -92,6 +92,9 @@ def override_utilization(monkeypatch):
     AZUREFUNCTION = {
         "faas_app_name": "/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-azure-function-app",
         "cloud_region": "Central US",
+    }
+    AZUREAPPSERVICE = {
+        "cloud_resource_id": "/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-azure-service-app",
     }
 
     @classmethod
@@ -106,6 +109,8 @@ def override_utilization(monkeypatch):
             output = ECS
         elif name.startswith("AzureFunction"):
             output = AZUREFUNCTION
+        elif name.startswith("AzureApp"):
+            output = AZUREAPPSERVICE
         elif name.startswith("Azure"):
             output = AZURE
         elif name.startswith("ECS"):
@@ -261,6 +266,7 @@ def connect_payload_asserts(
     with_docker=True,
     with_kubernetes=True,
     with_azurefunction=True,
+    with_azureappservice=True,
 ):
     payload_data = payload[0]
 
@@ -295,7 +301,7 @@ def connect_payload_asserts(
         assert "ip_address" not in payload_data["utilization"]
 
     utilization_len = utilization_len + any(
-        [with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_docker, with_kubernetes, with_azurefunction]
+        [with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_docker, with_kubernetes, with_azurefunction, with_azureappservice]
     )
     assert len(payload_data["utilization"]) == utilization_len
     assert payload_data["utilization"]["hostname"] == HOST
@@ -313,7 +319,7 @@ def connect_payload_asserts(
     assert harvest_limits["error_event_data"] == ERROR_EVENT_DATA
 
     vendors_len = 0
-    if any([with_aws, with_pcf, with_gcp, with_azure, with_azurefunction]):
+    if any([with_aws, with_pcf, with_gcp, with_azure, with_azurefunction, with_azureappservice]):
         vendors_len += 1
 
     if with_ecs:
@@ -339,6 +345,8 @@ def connect_payload_asserts(
             assert payload_data["utilization"]["vendors"]["azure"] == AZURE
         elif with_azurefunction:
             assert payload_data["utilization"]["vendors"]["azurefunction"] == AZUREFUNCTION
+        elif with_azureappservice:
+            assert payload_data["utilization"]["vendors"]["azureappservice"] == AZUREAPPSERVICE
 
         if with_ecs:
             assert payload_data["utilization"]["vendors"]["ecs"] == ECS
@@ -353,30 +361,32 @@ def connect_payload_asserts(
 
 
 @pytest.mark.parametrize(
-    "with_aws,with_ecs,with_pcf,with_gcp,with_azure,with_azurefunction,with_docker,with_kubernetes,with_ip",
+    "with_aws,with_ecs,with_pcf,with_gcp,with_azure,with_azurefunction,with_azureappservice,with_docker,with_kubernetes,with_ip",
     [
-        (False, False, False, False, False, False, False, False, False),
-        (False, False, False, False, False, False, False, False, True),
-        (True, True, False, False, False, False, True, False, True),
-        (True, True, False, False, False, False, True, True, True),
-        (False, False, True, False, False, False, True, True, True),
-        (False, False, False, True, False, False, True, True, True),
-        (False, False, False, False, True, False, True, True, True),
-        (False, False, False, False, False, True, True, True, True),
-        (True, True, False, False, False, False, False, False, True),
-        (False, False, True, False, False, False, False, False, True),
-        (False, False, False, True, False, False, False, False, True),
-        (False, False, False, False, True, False, False, False, True),
-        (False, False, False, False, False, True, False, False, True),
-        (True, True, True, True, True, True, True, True, True),
-        (True, True, True, True, True, True, True, False, True),
-        (True, True, True, True, True, True, False, True, True),
+        (False, False, False, False, False, False, False, False, False, False),
+        (False, False, False, False, False, False, False, False, False, True),
+        (True, True, False, False, False, False, False, True, False, True),
+        (True, True, False, False, False, False, False, True, True, True),
+        (False, False, True, False, False, False, False, True, True, True),
+        (False, False, False, True, False, False, False, True, True, True),
+        (False, False, False, False, True, False, False, True, True, True),
+        (False, False, False, False, False, True, False, True, True, True),
+        (False, False, False, False, False, False, True, True, True, True),
+        (True, True, False, False, False, False, False, False, False, True),
+        (False, False, True, False, False, False, False, False, False, True),
+        (False, False, False, True, False, False, False, False, False, True),
+        (False, False, False, False, True, False, False, False, False, True),
+        (False, False, False, False, False, True, False, False, False, True),
+        (False, False, False, False, False, False, True, False, False, True),
+        (True, True, True, True, True, True, True, True, True, True),
+        (True, True, True, True, True, True, True, True, False, True),
+        (True, True, True, True, True, True, True, False, True, True),
     ],
 )
 def test_connect(
-    with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_azurefunction, with_docker, with_kubernetes, with_ip
+    with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_azurefunction, with_azureappservice, with_docker, with_kubernetes, with_ip
 ):
-    global AWS, AZURE, AZUREFUNCTION, GCP, PCF, DOCKER, KUBERNETES, IP_ADDRESS
+    global AWS, AZURE, AZUREFUNCTION, AZUREAPPSERVICE, GCP, PCF, DOCKER, KUBERNETES, IP_ADDRESS
 
     if sys.platform == "win32":
         # Docker utilization is not supported on Windows.
@@ -399,6 +409,8 @@ def test_connect(
         KUBERNETES = Exception
     if not with_azurefunction:
         AZUREFUNCTION = Exception
+    if not with_azureappservice:
+        AZUREAPPSERVICE = Exception
     if not with_ip:
         IP_ADDRESS = None
     settings = finalize_application_settings(
@@ -417,6 +429,7 @@ def test_connect(
             "utilization.detect_docker": with_docker,
             "utilization.detect_kubernetes": with_kubernetes,
             "utilization.detect_azurefunction": with_azurefunction,
+            "utilization.detect_azureappservice": with_azureappservice,
             "event_harvest_config": {
                 "harvest_limits": {
                     "analytic_event_data": ANALYTIC_EVENT_DATA,
@@ -451,6 +464,7 @@ def test_connect(
         with_docker=with_docker,
         with_kubernetes=with_kubernetes,
         with_azurefunction=with_azurefunction,
+        with_azureappservice=with_azureappservice,
     )
 
     # Verify agent_settings call is done with the finalized settings

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -94,7 +94,7 @@ def override_utilization(monkeypatch):
         "cloud_region": "Central US",
     }
     AZUREAPPSERVICE = {
-        "cloud_resource_id": "/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-azure-service-app",
+        "cloud_resource_id": "/subscriptions/b999997b-cb91-49e0-b922-c9188372bdba/resourceGroups/my-resource-group/providers/Microsoft.Web/sites/my-azure-service-app"
     }
 
     @classmethod
@@ -301,7 +301,17 @@ def connect_payload_asserts(
         assert "ip_address" not in payload_data["utilization"]
 
     utilization_len = utilization_len + any(
-        [with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_docker, with_kubernetes, with_azurefunction, with_azureappservice]
+        [
+            with_aws,
+            with_ecs,
+            with_pcf,
+            with_gcp,
+            with_azure,
+            with_docker,
+            with_kubernetes,
+            with_azurefunction,
+            with_azureappservice,
+        ]
     )
     assert len(payload_data["utilization"]) == utilization_len
     assert payload_data["utilization"]["hostname"] == HOST
@@ -384,7 +394,16 @@ def connect_payload_asserts(
     ],
 )
 def test_connect(
-    with_aws, with_ecs, with_pcf, with_gcp, with_azure, with_azurefunction, with_azureappservice, with_docker, with_kubernetes, with_ip
+    with_aws,
+    with_ecs,
+    with_pcf,
+    with_gcp,
+    with_azure,
+    with_azurefunction,
+    with_azureappservice,
+    with_docker,
+    with_kubernetes,
+    with_ip,
 ):
     global AWS, AZURE, AZUREFUNCTION, AZUREAPPSERVICE, GCP, PCF, DOCKER, KUBERNETES, IP_ADDRESS
 

--- a/tests/framework_azurefunctions/test_utilization.py
+++ b/tests/framework_azurefunctions/test_utilization.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.utilization import AzureFunctionUtilization, AzureAppServiceUtilization
+from newrelic.common.utilization import AzureAppServiceUtilization, AzureFunctionUtilization
 
 
 def test_azure_function_utilization(monkeypatch):
@@ -39,9 +39,11 @@ def test_azure_function_utilization_bad_website_owner_name(monkeypatch):
     result = AzureFunctionUtilization.fetch()
     assert result is None, f"Expected failure but got result instead. {result}"
 
-#-------------------------
+
+# -------------------------
 # The following tests are actually for Azure App Services:
-#-------------------------
+# -------------------------
+
 
 def test_azure_app_service_utilization(monkeypatch):
     monkeypatch.setenv("WEBSITE_RESOURCE_GROUP", "testing-python")

--- a/tests/framework_azurefunctions/test_utilization.py
+++ b/tests/framework_azurefunctions/test_utilization.py
@@ -16,6 +16,7 @@ from newrelic.common.utilization import AzureAppServiceUtilization, AzureFunctio
 
 
 def test_azure_function_utilization(monkeypatch):
+    monkeypatch.setenv("FUNCTIONS_WORKER_RUNTIME", True)
     monkeypatch.setenv("REGION_NAME", "eastus2")
     monkeypatch.setenv(
         "WEBSITE_OWNER_NAME", "0b0d165f-aaaf-4a3b-b929-5f60588d95a3+testing-python-EastUS2webspace-Linux"
@@ -32,6 +33,7 @@ def test_azure_function_utilization(monkeypatch):
 
 
 def test_azure_function_utilization_bad_website_owner_name(monkeypatch):
+    monkeypatch.setenv("FUNCTIONS_WORKER_RUNTIME", True)
     monkeypatch.setenv("REGION_NAME", "eastus2")
     monkeypatch.setenv("WEBSITE_OWNER_NAME", "ERROR")
     monkeypatch.setenv("WEBSITE_SITE_NAME", "test-func-linux")

--- a/tests/framework_azurefunctions/test_utilization.py
+++ b/tests/framework_azurefunctions/test_utilization.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from newrelic.common.utilization import AzureFunctionUtilization
+from newrelic.common.utilization import AzureFunctionUtilization, AzureAppServiceUtilization
 
 
-def test_utilization(monkeypatch):
+def test_azure_function_utilization(monkeypatch):
     monkeypatch.setenv("REGION_NAME", "eastus2")
     monkeypatch.setenv(
         "WEBSITE_OWNER_NAME", "0b0d165f-aaaf-4a3b-b929-5f60588d95a3+testing-python-EastUS2webspace-Linux"
@@ -31,10 +31,36 @@ def test_utilization(monkeypatch):
     assert cloud_region == "eastus2"
 
 
-def test_utilization_bad_website_owner_name(monkeypatch):
+def test_azure_function_utilization_bad_website_owner_name(monkeypatch):
     monkeypatch.setenv("REGION_NAME", "eastus2")
     monkeypatch.setenv("WEBSITE_OWNER_NAME", "ERROR")
     monkeypatch.setenv("WEBSITE_SITE_NAME", "test-func-linux")
 
     result = AzureFunctionUtilization.fetch()
     assert result is None, f"Expected failure but got result instead. {result}"
+
+#-------------------------
+# The following tests are actually for Azure App Services:
+#-------------------------
+
+def test_azure_app_service_utilization(monkeypatch):
+    monkeypatch.setenv("WEBSITE_RESOURCE_GROUP", "testing-python")
+    monkeypatch.setenv(
+        "WEBSITE_OWNER_NAME", "0b0d165f-aaaf-4a3b-b929-5f60588d95a3+testing-python-EastUS2webspace-Linux"
+    )
+    monkeypatch.setenv("WEBSITE_SITE_NAME", "test-func-linux")
+
+    cloud_resource_id = AzureAppServiceUtilization.fetch()
+    assert cloud_resource_id, "Failed to parse utilization for Azure App Service."
+
+    expected_cloud_resource_id = "/subscriptions/0b0d165f-aaaf-4a3b-b929-5f60588d95a3/resourceGroups/testing-python/providers/Microsoft.Web/sites/test-func-linux"
+    assert cloud_resource_id == expected_cloud_resource_id
+
+
+def test_azure_app_service_utilization_bad_website_owner_name(monkeypatch):
+    monkeypatch.setenv("WEBSITE_RESOURCE_GROUP", "testing-python")
+    monkeypatch.setenv("WEBSITE_OWNER_NAME", "ERROR")
+    monkeypatch.setenv("WEBSITE_SITE_NAME", "test-func-linux")
+
+    cloud_resource_id = AzureAppServiceUtilization.fetch()
+    assert cloud_resource_id is None, f"Expected failure but got result instead. {cloud_resource_id}"


### PR DESCRIPTION
Add utilization for Azure App Service to enable entity relationship mapping.

This also adds a new setting, `utilization.detect_azureappservice`