### PR TITLE
Add support for MCP v2

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -3259,7 +3259,11 @@ def _process_module_builtin_defaults():
         "newrelic.hooks.adapter_mcp",
         "instrument_mcp_server_fastmcp_tools_tool_manager",
     )
-
+    _process_module_definition(
+        "mcp.server.mcpserver.tools.tool_manager",
+        "newrelic.hooks.adapter_mcp",
+        "instrument_mcp_server_fastmcp_tools_tool_manager",
+    )
     _process_module_definition("structlog._base", "newrelic.hooks.logger_structlog", "instrument_structlog__base")
     _process_module_definition("structlog._frames", "newrelic.hooks.logger_structlog", "instrument_structlog__frames")
     _process_module_definition("paste.httpserver", "newrelic.hooks.adapter_paste", "instrument_paste_httpserver")

--- a/newrelic/hooks/adapter_mcp.py
+++ b/newrelic/hooks/adapter_mcp.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+from urllib.parse import urlsplit
 
 from newrelic.api.function_trace import FunctionTrace
 from newrelic.api.transaction import current_transaction
@@ -61,9 +62,10 @@ async def wrap_read_resource(wrapped, instance, args, kwargs):
 
     try:
         resource_uri = bound_args.get("uri")
-        resource_scheme = getattr(resource_uri, "scheme", "resource")
+        split_uri = urlsplit(str(resource_uri))
+        resource_scheme = getattr(split_uri, "scheme", "resource") or "resource"
     except Exception:
-        _logger.warning("Unable to parse resource URI scheme for MCP read_resource call")
+        _logger.debug("Unable to parse resource URI scheme for MCP read_resource call.", exc_info=True)
 
     function_trace_name = f"{func_name}/{resource_scheme}"
 

--- a/tests/adapter_mcp/test_mcp.py
+++ b/tests/adapter_mcp/test_mcp.py
@@ -16,13 +16,20 @@ import pytest
 from fastmcp.client import Client
 from fastmcp.client.transports import FastMCPTransport
 from fastmcp.server.server import FastMCP
-from mcp.server.fastmcp.tools import ToolManager
 from testing_support.ml_testing_utils import disabled_ai_monitoring_settings
 from testing_support.validators.validate_function_not_called import validate_function_not_called
 from testing_support.validators.validate_span_events import validate_span_events
 from testing_support.validators.validate_transaction_metrics import validate_transaction_metrics
 
 from newrelic.api.background_task import background_task
+
+# mcp>=2 renamed mcp.server.fastmcp.FastMCP to mcp.server.mcpserver.MCPServer,
+try:
+    from mcp.server.fastmcp import FastMCP as SDKFastMCP
+    TOOL_MANAGER_MODULE = "mcp.server.fastmcp.tools.tool_manager"
+except ImportError:
+    from mcp.server.mcpserver import MCPServer as SDKFastMCP
+    TOOL_MANAGER_MODULE = "mcp.server.mcpserver.tools.tool_manager"
 
 
 @pytest.fixture
@@ -73,8 +80,8 @@ def test_tool_tracing_via_client_session(loop, fastmcp_server):
 
 @validate_transaction_metrics(
     "test_mcp:test_tool_tracing_via_tool_manager",
-    scoped_metrics=[("Llm/tool/MCP/mcp.server.fastmcp.tools.tool_manager:ToolManager.call_tool/add_exclamation", 1)],
-    rollup_metrics=[("Llm/tool/MCP/mcp.server.fastmcp.tools.tool_manager:ToolManager.call_tool/add_exclamation", 1)],
+    scoped_metrics=[(f"Llm/tool/MCP/{TOOL_MANAGER_MODULE}:ToolManager.call_tool/add_exclamation", 1)],
+    rollup_metrics=[(f"Llm/tool/MCP/{TOOL_MANAGER_MODULE}:ToolManager.call_tool/add_exclamation", 1)],
     background_task=True,
 )
 @validate_span_events(count=1, exact_agents={"subcomponent": '{"type": "APM-AI_TOOL", "name": "add_exclamation"}'})
@@ -84,10 +91,11 @@ def test_tool_tracing_via_tool_manager(loop):
         def add_exclamation(phrase):
             return f"{phrase}!"
 
-        manager = ToolManager()
-        manager.add_tool(add_exclamation)
-        result = await manager.call_tool("add_exclamation", {"phrase": "Python is awesome"})
-        assert result == "Python is awesome!"
+        server = SDKFastMCP("Test Tools")
+        server.add_tool(add_exclamation)
+        result = await server.call_tool("add_exclamation", {"phrase": "Python is awesome"})
+        content = result.content if hasattr(result, "content") else result
+        assert "Python is awesome!" in str(content[0])
 
     loop.run_until_complete(_test())
 

--- a/tests/adapter_mcp/test_mcp.py
+++ b/tests/adapter_mcp/test_mcp.py
@@ -26,9 +26,11 @@ from newrelic.api.background_task import background_task
 # mcp>=2 renamed mcp.server.fastmcp.FastMCP to mcp.server.mcpserver.MCPServer,
 try:
     from mcp.server.fastmcp import FastMCP as SDKFastMCP
+
     TOOL_MANAGER_MODULE = "mcp.server.fastmcp.tools.tool_manager"
 except ImportError:
     from mcp.server.mcpserver import MCPServer as SDKFastMCP
+
     TOOL_MANAGER_MODULE = "mcp.server.mcpserver.tools.tool_manager"
 
 


### PR DESCRIPTION
This PR adds support for MCP v2. 
This includes:
- Updating resource scheme parsing logic 
- Adding process module definition for new `ToolManager` location in v2
- Updating import path and metric names in tests for new `ToolManager` module path
