### PR TITLE
Add support for `browser_monitoring.version` config

### DIFF
--- a/newrelic/config.py
+++ b/newrelic/config.py
@@ -612,6 +612,7 @@ def _process_configuration(section):
     _process_setting(section, "browser_monitoring.enabled", "getboolean", None)
     _process_setting(section, "browser_monitoring.auto_instrument", "getboolean", None)
     _process_setting(section, "browser_monitoring.loader", "get", None)
+    _process_setting(section, "browser_monitoring.version", "get", None)
     _process_setting(section, "browser_monitoring.debug", "getboolean", None)
     _process_setting(section, "browser_monitoring.ssl_for_http", "getboolean", None)
     _process_setting(section, "browser_monitoring.content_type", "get", _map_split_strings)

--- a/newrelic/core/agent_protocol.py
+++ b/newrelic/core/agent_protocol.py
@@ -298,6 +298,7 @@ class AgentProtocol:
         connect_settings = {}
         connect_settings["browser_monitoring.loader"] = settings["browser_monitoring.loader"]
         connect_settings["browser_monitoring.debug"] = settings["browser_monitoring.debug"]
+        connect_settings["browser_monitoring.version"] = settings["browser_monitoring.version"]
         connect_settings["ai_monitoring.enabled"] = settings["ai_monitoring.enabled"]
         connect_settings["distributed_tracing.sampler.adaptive_sampling_target"] = settings[
             "distributed_tracing.sampler.adaptive_sampling_target"

--- a/newrelic/core/config.py
+++ b/newrelic/core/config.py
@@ -1249,6 +1249,7 @@ _settings.browser_monitoring.loader_version = None
 _settings.browser_monitoring.debug = False
 _settings.browser_monitoring.ssl_for_http = None
 _settings.browser_monitoring.content_type = ["text/html"]
+_settings.browser_monitoring.version = ""
 _settings.browser_monitoring.attributes.enabled = _environ_as_bool(
     "NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED", default=False
 )
@@ -1727,6 +1728,16 @@ def apply_server_side_settings(server_side_config=None, settings=_settings):
             "Improper configuration. Infinite tracing cannot be enabled at the same time as partial granularity tracing. Setting distributed_tracing.sampler.partial_granularity.enabled=False."
         )
         apply_config_setting(settings_snapshot, "distributed_tracing.sampler.partial_granularity.enabled", False)
+
+    # If browser_monitoring.version is set but no js_agent_loader is returned, we infer
+    # the customer-supplied browser agent version is unsupported, malformed, etc. and
+    # log a warning.
+    if settings_snapshot.browser_monitoring.version and not settings_snapshot.js_agent_loader:
+        _logger.warning(
+            "Requested browser_monitoring.version '%s' did not return a browser agent loader; "
+            "please ensure it is available and supported. No browser monitoring will be injected.",
+            settings_snapshot.browser_monitoring.version,
+        )
 
     # Reapply on top any local setting overrides.
 

--- a/tests/agent_features/test_configuration.py
+++ b/tests/agent_features/test_configuration.py
@@ -396,6 +396,26 @@ def test_delete_setting_parent():
     assert "transaction_tracer" not in settings
 
 
+def test_browser_monitoring_version_without_loader_warns(caplog):
+    caplog.set_level(logging.WARNING, logger="newrelic.core.config")
+
+    settings = global_settings()
+    apply_config_setting(settings, "browser_monitoring.version", "1.317.0")
+
+    app_settings = apply_server_side_settings(settings=settings)
+
+    assert app_settings.browser_monitoring.version == "1.317.0"
+    assert not app_settings.js_agent_loader
+
+    message = (
+        "Requested browser_monitoring.version '1.317.0' did not return a browser agent loader; "
+        "please ensure it is available and supported. No browser monitoring will be injected."
+    )
+    assert message in caplog.text
+
+    apply_config_setting(settings, "browser_monitoring.version", "")
+
+
 translate_deprecated_settings_tests = [
     # Nothing in here right now.
 ]

--- a/tests/agent_unittests/test_agent_protocol.py
+++ b/tests/agent_unittests/test_agent_protocol.py
@@ -43,6 +43,7 @@ APP_NAME = "test_app"
 IP_ADDRESS = AWS = AZURE = ECS = GCP = PCF = BOOT_ID = DOCKER = KUBERNETES = AZUREFUNCTION = None
 BROWSER_MONITORING_DEBUG = "debug"
 BROWSER_MONITORING_LOADER = "loader"
+BROWSER_MONITORING_VERSION = "1.317.0"
 CAPTURE_PARAMS = "capture_params"
 DISPLAY_NAME = "display_name"
 METADATA = {}
@@ -278,9 +279,10 @@ def connect_payload_asserts(
     assert len(payload_data["security_settings"]) == 2
     assert payload_data["security_settings"]["capture_params"] == CAPTURE_PARAMS
     assert payload_data["security_settings"]["transaction_tracer"] == {"record_sql": RECORD_SQL}
-    assert len(payload_data["settings"]) == 4
+    assert len(payload_data["settings"]) == 5
     assert payload_data["settings"]["browser_monitoring.loader"] == (BROWSER_MONITORING_LOADER)
     assert payload_data["settings"]["browser_monitoring.debug"] == (BROWSER_MONITORING_DEBUG)
+    assert payload_data["settings"]["browser_monitoring.version"] == (BROWSER_MONITORING_VERSION)
     assert payload_data["settings"]["ai_monitoring.enabled"] is False
     assert payload_data["settings"]["distributed_tracing.sampler.adaptive_sampling_target"] == 10
 
@@ -405,6 +407,7 @@ def test_connect(
         {
             "browser_monitoring.loader": BROWSER_MONITORING_LOADER,
             "browser_monitoring.debug": BROWSER_MONITORING_DEBUG,
+            "browser_monitoring.version": BROWSER_MONITORING_VERSION,
             "capture_params": CAPTURE_PARAMS,
             "process_host.display_name": DISPLAY_NAME,
             "transaction_tracer.record_sql": RECORD_SQL,


### PR DESCRIPTION
Adds support for new configuration option, `browser_monitoring.version`. 

Customers may specificy which version of the browser agent to use. If the specified version cannot be resolved (out of support, malformed, etc.), browser monitoring will not be installed. See the [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for the latest supported versions. 

If unset, the latest browser monitoring version will be used (default).